### PR TITLE
Fix setup-windows.ps1 for PowerShell 5.1 by adding UTF-8 BOM

### DIFF
--- a/scripts/setup-windows.ps1
+++ b/scripts/setup-windows.ps1
@@ -1,4 +1,4 @@
-#Requires -Version 5.1
+﻿#Requires -Version 5.1
 <#
 .SYNOPSIS
     Installs build prerequisites for CodexBar on Windows.


### PR DESCRIPTION
# Summary
Fixes a parsing error in `setup-windows.ps1` caused by encoding issues on Windows PowerShell 5.1.

---

# Problem
Running `setup-windows.ps1` failed with:

```
The string is missing the terminator: ".
```

**Environment:**
- Windows PowerShell 5.1 (default on Windows 10/11)

**Root Cause:**
PowerShell 5.1 defaults to ANSI (Windows-1252) encoding when no BOM is present.  
The script contains UTF-8 characters (e.g., decorative comment box characters), causing misinterpretation of bytes and breaking parsing.

---

# Fix Applied
- Saved `setup-windows.ps1` as **UTF-8 with BOM** (EF BB BF).
- This ensures PowerShell correctly interprets the file as UTF-8.

---

# Changes
**File:** `setup-windows.ps1`  
**Type:** Encoding-only change (no logic or content modifications)

**Diff Summary:**
- No functional changes to the script
- File appears modified due to the addition of a BOM
- Script behavior remains identical

---

# Why This Fix
- ✅ No behavior changes
- ✅ Maintains full backward compatibility
- ✅ Ensures script works out-of-the-box on Windows PowerShell 5.1
- ✅ Removes a common first-run failure for Windows developers

---

# How to Verify
Run the script:

```
./setup-windows.ps1
```

**Expected Result:**
- Script executes successfully  
- Rust and MinGW install without errors  
- No "missing terminator" parsing issues  


---
BEFORE:
<img width="647" height="421" alt="image" src="https://github.com/user-attachments/assets/1a33d16f-b3d8-4456-a3e6-1d2b33779ebd" />

AFTER:

<img width="792" height="575" alt="image" src="https://github.com/user-attachments/assets/b77e5796-fb34-4700-8bef-c6dd04412fd2" />


