### PR TITLE
feat: Add light mode support with System/Dark/Light theme switching

### DIFF
--- a/rust/src/bin/gen_icons.rs
+++ b/rust/src/bin/gen_icons.rs
@@ -1,6 +1,5 @@
 /// Generate icon files for Tauri
 /// This creates a simple icon.ico file for Windows
-
 use std::fs::File;
 use std::io::Write;
 
@@ -59,16 +58,17 @@ fn create_ico(path: &str) {
 
     // BMP info header (BITMAPINFOHEADER)
     file.write_all(&bmp_header_size.to_le_bytes()).unwrap(); // biSize
-    file.write_all(&(size as i32).to_le_bytes()).unwrap();   // biWidth
+    file.write_all(&(size as i32).to_le_bytes()).unwrap(); // biWidth
     file.write_all(&((size * 2) as i32).to_le_bytes()).unwrap(); // biHeight (doubled for ICO)
-    file.write_all(&1u16.to_le_bytes()).unwrap();            // biPlanes
-    file.write_all(&32u16.to_le_bytes()).unwrap();           // biBitCount
-    file.write_all(&0u32.to_le_bytes()).unwrap();            // biCompression
-    file.write_all(&(pixel_data_size + mask_size).to_le_bytes()).unwrap(); // biSizeImage
-    file.write_all(&0i32.to_le_bytes()).unwrap();            // biXPelsPerMeter
-    file.write_all(&0i32.to_le_bytes()).unwrap();            // biYPelsPerMeter
-    file.write_all(&0u32.to_le_bytes()).unwrap();            // biClrUsed
-    file.write_all(&0u32.to_le_bytes()).unwrap();            // biClrImportant
+    file.write_all(&1u16.to_le_bytes()).unwrap(); // biPlanes
+    file.write_all(&32u16.to_le_bytes()).unwrap(); // biBitCount
+    file.write_all(&0u32.to_le_bytes()).unwrap(); // biCompression
+    file.write_all(&(pixel_data_size + mask_size).to_le_bytes())
+        .unwrap(); // biSizeImage
+    file.write_all(&0i32.to_le_bytes()).unwrap(); // biXPelsPerMeter
+    file.write_all(&0i32.to_le_bytes()).unwrap(); // biYPelsPerMeter
+    file.write_all(&0u32.to_le_bytes()).unwrap(); // biClrUsed
+    file.write_all(&0u32.to_le_bytes()).unwrap(); // biClrImportant
 
     // Pixel data (BGRA, bottom-up)
     for y in (0..size).rev() {

--- a/rust/src/browser/cookie_cache.rs
+++ b/rust/src/browser/cookie_cache.rs
@@ -67,8 +67,8 @@ impl CookieHeaderCache {
         }
 
         let entry = CookieHeaderEntry::new(normalized, source_label);
-        let path = Self::cache_path(provider)
-            .ok_or_else(|| CookieHeaderCacheError::PathNotAvailable)?;
+        let path =
+            Self::cache_path(provider).ok_or_else(|| CookieHeaderCacheError::PathNotAvailable)?;
 
         // Create parent directory
         if let Some(parent) = path.parent() {
@@ -104,8 +104,10 @@ impl CookieHeaderCache {
 
     /// Get the cache file path for a provider
     fn cache_path(provider: ProviderId) -> Option<PathBuf> {
-        dirs::data_local_dir()
-            .map(|d| d.join("CodexBar").join(format!("{}-cookie.json", provider.cli_name())))
+        dirs::data_local_dir().map(|d| {
+            d.join("CodexBar")
+                .join(format!("{}-cookie.json", provider.cli_name()))
+        })
     }
 
     /// Normalize a cookie header string

--- a/rust/src/browser/cookies.rs
+++ b/rust/src/browser/cookies.rs
@@ -120,20 +120,18 @@ impl CookieExtractor {
         // Get the encryption key from Local State
         let local_state_path = profile.local_state_path(&browser.user_data_dir);
         tracing::debug!("Local State path: {:?}", local_state_path);
-        let encryption_key = Self::get_chromium_encryption_key(&local_state_path)
-            .map_err(|e| {
-                tracing::debug!("Failed to get encryption key: {}", e);
-                e
-            })?;
+        let encryption_key = Self::get_chromium_encryption_key(&local_state_path).map_err(|e| {
+            tracing::debug!("Failed to get encryption key: {}", e);
+            e
+        })?;
         tracing::debug!("Got encryption key ({} bytes)", encryption_key.len());
 
         // Copy the database to a temp file (browser may have it locked)
         tracing::debug!("Copying cookies DB to temp...");
-        let temp_db = Self::copy_to_temp(&cookies_db)
-            .map_err(|e| {
-                tracing::debug!("Failed to copy cookies DB: {}", e);
-                e
-            })?;
+        let temp_db = Self::copy_to_temp(&cookies_db).map_err(|e| {
+            tracing::debug!("Failed to copy cookies DB: {}", e);
+            e
+        })?;
         tracing::debug!("Temp DB at: {:?}", temp_db);
 
         // Open and query the database
@@ -148,19 +146,23 @@ impl CookieExtractor {
 
         let domain_pattern = format!("%{}", domain);
         let dot_domain_pattern = format!(".{}", domain);
-        tracing::debug!("Searching for cookies matching: {} or {}", domain_pattern, dot_domain_pattern);
+        tracing::debug!(
+            "Searching for cookies matching: {} or {}",
+            domain_pattern,
+            dot_domain_pattern
+        );
 
         let mut cookies = Vec::new();
 
         let rows = stmt.query_map([&domain_pattern, &dot_domain_pattern], |row| {
             Ok((
-                row.get::<_, String>(0)?,        // name
-                row.get::<_, Vec<u8>>(1)?,       // encrypted_value
-                row.get::<_, String>(2)?,        // host_key
-                row.get::<_, String>(3)?,        // path
-                row.get::<_, i64>(4)?,           // expires_utc
-                row.get::<_, i32>(5)? != 0,      // is_secure
-                row.get::<_, i32>(6)? != 0,      // is_httponly
+                row.get::<_, String>(0)?,   // name
+                row.get::<_, Vec<u8>>(1)?,  // encrypted_value
+                row.get::<_, String>(2)?,   // host_key
+                row.get::<_, String>(3)?,   // path
+                row.get::<_, i64>(4)?,      // expires_utc
+                row.get::<_, i32>(5)? != 0, // is_secure
+                row.get::<_, i32>(6)? != 0, // is_httponly
             ))
         })?;
 
@@ -233,10 +235,8 @@ impl CookieExtractor {
     /// Decrypt data using Windows DPAPI
     #[cfg(windows)]
     fn dpapi_decrypt(encrypted_data: &[u8]) -> Result<Vec<u8>, CookieError> {
-        use windows::Win32::Security::Cryptography::{
-            CryptUnprotectData, CRYPT_INTEGER_BLOB,
-        };
         use windows::Win32::Foundation::{LocalFree, HLOCAL};
+        use windows::Win32::Security::Cryptography::{CryptUnprotectData, CRYPT_INTEGER_BLOB};
 
         unsafe {
             let mut input_blob = CRYPT_INTEGER_BLOB {
@@ -249,15 +249,8 @@ impl CookieExtractor {
                 pbData: std::ptr::null_mut(),
             };
 
-            let result = CryptUnprotectData(
-                &mut input_blob,
-                None,
-                None,
-                None,
-                None,
-                0,
-                &mut output_blob,
-            );
+            let result =
+                CryptUnprotectData(&mut input_blob, None, None, None, None, 0, &mut output_blob);
 
             if result.is_err() {
                 return Err(CookieError::Dpapi(format!(
@@ -289,10 +282,7 @@ impl CookieExtractor {
     }
 
     /// Decrypt a Chromium cookie value
-    fn decrypt_chromium_cookie(
-        encrypted_value: &[u8],
-        key: &[u8],
-    ) -> Result<String, CookieError> {
+    fn decrypt_chromium_cookie(encrypted_value: &[u8], key: &[u8]) -> Result<String, CookieError> {
         if encrypted_value.is_empty() {
             return Ok(String::new());
         }
@@ -319,17 +309,12 @@ impl CookieExtractor {
 
             let nonce_obj = Nonce::from_slice(nonce);
 
-            let plaintext = cipher
-                .decrypt(nonce_obj, ciphertext)
-                .map_err(|e| {
-                    tracing::debug!("AES-GCM decrypt failed: {}", e);
-                    CookieError::Decryption(format!("decrypt: {}", e))
-                })?;
+            let plaintext = cipher.decrypt(nonce_obj, ciphertext).map_err(|e| {
+                tracing::debug!("AES-GCM decrypt failed: {}", e);
+                CookieError::Decryption(format!("decrypt: {}", e))
+            })?;
 
-            tracing::debug!(
-                "Decrypted {} bytes successfully",
-                plaintext.len(),
-            );
+            tracing::debug!("Decrypted {} bytes successfully", plaintext.len(),);
 
             // Modern Chromium (127+) adds a 32-byte prefix to the plaintext
             // (App-Bound Encryption wrapper). Try to find where the actual value starts.
@@ -340,10 +325,13 @@ impl CookieExtractor {
                 let has_garbage_prefix = plaintext[..32].iter().any(|&b| b > 127 || b < 32);
                 if has_garbage_prefix {
                     // Find where ASCII text starts (skip prefix)
-                    let start = plaintext.iter().position(|&b| {
-                        // Look for common cookie value start chars
-                        b.is_ascii_alphanumeric() || b == b'"' || b == b'{'
-                    }).unwrap_or(0);
+                    let start = plaintext
+                        .iter()
+                        .position(|&b| {
+                            // Look for common cookie value start chars
+                            b.is_ascii_alphanumeric() || b == b'"' || b == b'{'
+                        })
+                        .unwrap_or(0);
 
                     // But use a minimum of 32 bytes prefix for App-Bound Encryption
                     let actual_start = if start < 32 && plaintext.len() > 32 {
@@ -352,7 +340,10 @@ impl CookieExtractor {
                         start
                     };
 
-                    tracing::debug!("Skipping {} byte prefix (App-Bound Encryption)", actual_start);
+                    tracing::debug!(
+                        "Skipping {} byte prefix (App-Bound Encryption)",
+                        actual_start
+                    );
                     &plaintext[actual_start..]
                 } else {
                     &plaintext[..]
@@ -551,7 +542,10 @@ pub fn get_cookie_header(domain: &str) -> Result<String, CookieError> {
 }
 
 /// Get a cookie header string for a domain from a specific browser
-pub fn get_cookie_header_from_browser(domain: &str, browser: &super::detection::DetectedBrowser) -> Result<String, CookieError> {
+pub fn get_cookie_header_from_browser(
+    domain: &str,
+    browser: &super::detection::DetectedBrowser,
+) -> Result<String, CookieError> {
     let cookies = CookieExtractor::extract_for_domain(browser, domain)?;
     if cookies.is_empty() {
         return Err(CookieError::NotFound(domain.to_string()));
@@ -570,7 +564,11 @@ mod tests {
             Ok(cookies) => {
                 println!("Found {} cookies for claude.ai", cookies.len());
                 for cookie in &cookies {
-                    println!("  {}={}", cookie.name, &cookie.value[..20.min(cookie.value.len())]);
+                    println!(
+                        "  {}={}",
+                        cookie.name,
+                        &cookie.value[..20.min(cookie.value.len())]
+                    );
                 }
             }
             Err(e) => {

--- a/rust/src/browser/detection.rs
+++ b/rust/src/browser/detection.rs
@@ -119,7 +119,10 @@ impl BrowserDetector {
         let app_data = dirs::data_dir()?;
 
         let path = match browser_type {
-            BrowserType::Chrome => local_app_data.join("Google").join("Chrome").join("User Data"),
+            BrowserType::Chrome => local_app_data
+                .join("Google")
+                .join("Chrome")
+                .join("User Data"),
             BrowserType::Edge => local_app_data
                 .join("Microsoft")
                 .join("Edge")
@@ -128,9 +131,7 @@ impl BrowserDetector {
                 .join("BraveSoftware")
                 .join("Brave-Browser")
                 .join("User Data"),
-            BrowserType::Arc => local_app_data
-                .join("Arc")
-                .join("User Data"),
+            BrowserType::Arc => local_app_data.join("Arc").join("User Data"),
             BrowserType::Chromium => local_app_data.join("Chromium").join("User Data"),
             BrowserType::Firefox => app_data.join("Mozilla").join("Firefox").join("Profiles"),
         };

--- a/rust/src/browser/mod.rs
+++ b/rust/src/browser/mod.rs
@@ -7,4 +7,4 @@ pub mod watchdog;
 
 // Re-exports for future UI integration
 #[allow(unused_imports)]
-pub use watchdog::{WebProbeWatchdog, WatchdogConfig, WatchdogError, global_watchdog};
+pub use watchdog::{global_watchdog, WatchdogConfig, WatchdogError, WebProbeWatchdog};

--- a/rust/src/browser/watchdog.rs
+++ b/rust/src/browser/watchdog.rs
@@ -163,8 +163,13 @@ impl WebProbeWatchdog {
     }
 
     /// Register a process to be watched
-    pub async fn register(&self, name: impl Into<String>, child: Child) -> Result<u32, WatchdogError> {
-        self.register_with_timeout(name, child, self.config.default_timeout).await
+    pub async fn register(
+        &self,
+        name: impl Into<String>,
+        child: Child,
+    ) -> Result<u32, WatchdogError> {
+        self.register_with_timeout(name, child, self.config.default_timeout)
+            .await
     }
 
     /// Register a process with a custom timeout
@@ -216,7 +221,10 @@ impl WebProbeWatchdog {
         let mut procs = self.processes.write().await;
 
         if let Some(mut tracked) = procs.remove(&id) {
-            tracked.child.kill().map_err(|e| WatchdogError::KillFailed(e.to_string()))?;
+            tracked
+                .child
+                .kill()
+                .map_err(|e| WatchdogError::KillFailed(e.to_string()))?;
             Ok(())
         } else {
             Err(WatchdogError::NotFound)

--- a/rust/src/cli/account.rs
+++ b/rust/src/cli/account.rs
@@ -4,7 +4,9 @@
 
 use clap::{Parser, Subcommand};
 
-use crate::core::{ProviderId, ProviderAccountData, TokenAccount, TokenAccountStore, TokenAccountSupport};
+use crate::core::{
+    ProviderAccountData, ProviderId, TokenAccount, TokenAccountStore, TokenAccountSupport,
+};
 
 /// Arguments for the account command
 #[derive(Parser, Debug)]
@@ -51,7 +53,11 @@ pub enum AccountCommand {
 pub async fn run(args: AccountArgs) -> anyhow::Result<()> {
     match args.command {
         AccountCommand::List { provider } => list_accounts(&provider).await,
-        AccountCommand::Add { provider, label, token } => add_account(&provider, &label, &token).await,
+        AccountCommand::Add {
+            provider,
+            label,
+            token,
+        } => add_account(&provider, &label, &token).await,
         AccountCommand::Remove { provider, account } => remove_account(&provider, &account).await,
         AccountCommand::Switch { provider, account } => switch_account(&provider, &account).await,
     }
@@ -62,7 +68,10 @@ async fn list_accounts(provider_name: &str) -> anyhow::Result<()> {
     let provider = parse_provider(provider_name)?;
 
     if !TokenAccountSupport::is_supported(provider) {
-        println!("{} does not support token accounts.", provider.display_name());
+        println!(
+            "{} does not support token accounts.",
+            provider.display_name()
+        );
         return Ok(());
     }
 
@@ -71,17 +80,27 @@ async fn list_accounts(provider_name: &str) -> anyhow::Result<()> {
 
     if data.accounts.is_empty() {
         println!("No accounts configured for {}.", provider.display_name());
-        println!("Use 'codexbar account add {}' to add one.", provider.cli_name());
+        println!(
+            "Use 'codexbar account add {}' to add one.",
+            provider.cli_name()
+        );
         return Ok(());
     }
 
     println!("{} accounts:", provider.display_name());
     for (i, account) in data.accounts.iter().enumerate() {
-        let active = if i == data.clamped_active_index() { " (active)" } else { "" };
+        let active = if i == data.clamped_active_index() {
+            " (active)"
+        } else {
+            ""
+        };
         let masked_token = mask_token(&account.token);
         println!("  {}. {}{}", i + 1, account.label, active);
         println!("     Token: {}", masked_token);
-        println!("     Added: {}", account.added_at_datetime().format("%Y-%m-%d %H:%M"));
+        println!(
+            "     Added: {}",
+            account.added_at_datetime().format("%Y-%m-%d %H:%M")
+        );
         if let Some(last_used) = account.last_used_datetime() {
             println!("     Last used: {}", last_used.format("%Y-%m-%d %H:%M"));
         }
@@ -95,14 +114,21 @@ async fn add_account(provider_name: &str, label: &str, token: &str) -> anyhow::R
     let provider = parse_provider(provider_name)?;
 
     if !TokenAccountSupport::is_supported(provider) {
-        anyhow::bail!("{} does not support token accounts.", provider.display_name());
+        anyhow::bail!(
+            "{} does not support token accounts.",
+            provider.display_name()
+        );
     }
 
     let store = TokenAccountStore::new();
     let mut data = store.load_provider(provider)?;
 
     // Check for duplicate label
-    if data.accounts.iter().any(|a| a.label.eq_ignore_ascii_case(label)) {
+    if data
+        .accounts
+        .iter()
+        .any(|a| a.label.eq_ignore_ascii_case(label))
+    {
         anyhow::bail!("An account with label '{}' already exists.", label);
     }
 
@@ -119,7 +145,10 @@ async fn remove_account(provider_name: &str, account_ref: &str) -> anyhow::Resul
     let provider = parse_provider(provider_name)?;
 
     if !TokenAccountSupport::is_supported(provider) {
-        anyhow::bail!("{} does not support token accounts.", provider.display_name());
+        anyhow::bail!(
+            "{} does not support token accounts.",
+            provider.display_name()
+        );
     }
 
     let store = TokenAccountStore::new();
@@ -132,7 +161,11 @@ async fn remove_account(provider_name: &str, account_ref: &str) -> anyhow::Resul
     data.remove_account(id);
     store.save_provider(provider, &data)?;
 
-    println!("Removed account '{}' from {}.", label, provider.display_name());
+    println!(
+        "Removed account '{}' from {}.",
+        label,
+        provider.display_name()
+    );
     Ok(())
 }
 
@@ -141,7 +174,10 @@ async fn switch_account(provider_name: &str, account_ref: &str) -> anyhow::Resul
     let provider = parse_provider(provider_name)?;
 
     if !TokenAccountSupport::is_supported(provider) {
-        anyhow::bail!("{} does not support token accounts.", provider.display_name());
+        anyhow::bail!(
+            "{} does not support token accounts.",
+            provider.display_name()
+        );
     }
 
     let store = TokenAccountStore::new();
@@ -154,7 +190,11 @@ async fn switch_account(provider_name: &str, account_ref: &str) -> anyhow::Resul
     data.set_active_by_id(id);
     store.save_provider(provider, &data)?;
 
-    println!("Switched to account '{}' for {}.", label, provider.display_name());
+    println!(
+        "Switched to account '{}' for {}.",
+        label,
+        provider.display_name()
+    );
     Ok(())
 }
 
@@ -165,7 +205,10 @@ fn parse_provider(name: &str) -> anyhow::Result<ProviderId> {
 }
 
 /// Find account by label or index
-fn find_account<'a>(data: &'a ProviderAccountData, account_ref: &str) -> anyhow::Result<&'a TokenAccount> {
+fn find_account<'a>(
+    data: &'a ProviderAccountData,
+    account_ref: &str,
+) -> anyhow::Result<&'a TokenAccount> {
     // Try parsing as index first (1-based)
     if let Ok(idx) = account_ref.parse::<usize>() {
         if idx > 0 && idx <= data.accounts.len() {
@@ -174,16 +217,27 @@ fn find_account<'a>(data: &'a ProviderAccountData, account_ref: &str) -> anyhow:
     }
 
     // Try matching by label (case-insensitive)
-    if let Some(account) = data.accounts.iter().find(|a| a.label.eq_ignore_ascii_case(account_ref)) {
+    if let Some(account) = data
+        .accounts
+        .iter()
+        .find(|a| a.label.eq_ignore_ascii_case(account_ref))
+    {
         return Ok(account);
     }
 
     // Try matching by UUID prefix
-    if let Some(account) = data.accounts.iter().find(|a| a.id.to_string().starts_with(account_ref)) {
+    if let Some(account) = data
+        .accounts
+        .iter()
+        .find(|a| a.id.to_string().starts_with(account_ref))
+    {
         return Ok(account);
     }
 
-    anyhow::bail!("Account '{}' not found. Use 'codexbar account list' to see available accounts.", account_ref)
+    anyhow::bail!(
+        "Account '{}' not found. Use 'codexbar account list' to see available accounts.",
+        account_ref
+    )
 }
 
 /// Mask a token for display (show first 4 and last 4 chars)

--- a/rust/src/cli/autostart.rs
+++ b/rust/src/cli/autostart.rs
@@ -57,7 +57,7 @@ fn get_exe_path() -> anyhow::Result<PathBuf> {
 fn enable_autostart() -> anyhow::Result<()> {
     use windows::core::PCWSTR;
     use windows::Win32::System::Registry::{
-        RegSetValueExW, RegOpenKeyExW, RegCloseKey, HKEY_CURRENT_USER, KEY_WRITE, REG_SZ,
+        RegCloseKey, RegOpenKeyExW, RegSetValueExW, HKEY_CURRENT_USER, KEY_WRITE, REG_SZ,
     };
 
     let exe_path = get_exe_path()?;
@@ -105,7 +105,10 @@ fn enable_autostart() -> anyhow::Result<()> {
         let _ = RegCloseKey(hkey);
 
         if result.is_err() {
-            return Err(anyhow::anyhow!("Failed to set registry value: {:?}", result));
+            return Err(anyhow::anyhow!(
+                "Failed to set registry value: {:?}",
+                result
+            ));
         }
     }
 
@@ -117,7 +120,7 @@ fn enable_autostart() -> anyhow::Result<()> {
 fn disable_autostart() -> anyhow::Result<()> {
     use windows::core::PCWSTR;
     use windows::Win32::System::Registry::{
-        RegDeleteValueW, RegOpenKeyExW, RegCloseKey, HKEY_CURRENT_USER, KEY_WRITE,
+        RegCloseKey, RegDeleteValueW, RegOpenKeyExW, HKEY_CURRENT_USER, KEY_WRITE,
     };
 
     let subkey = "Software\\Microsoft\\Windows\\CurrentVersion\\Run";
@@ -159,7 +162,7 @@ fn disable_autostart() -> anyhow::Result<()> {
 fn is_autostart_enabled() -> bool {
     use windows::core::PCWSTR;
     use windows::Win32::System::Registry::{
-        RegQueryValueExW, RegOpenKeyExW, RegCloseKey, HKEY_CURRENT_USER, KEY_READ,
+        RegCloseKey, RegOpenKeyExW, RegQueryValueExW, HKEY_CURRENT_USER, KEY_READ,
     };
 
     let subkey = "Software\\Microsoft\\Windows\\CurrentVersion\\Run";
@@ -188,14 +191,7 @@ fn is_autostart_enabled() -> bool {
             return false;
         }
 
-        let result = RegQueryValueExW(
-            hkey,
-            PCWSTR(name_wide.as_ptr()),
-            None,
-            None,
-            None,
-            None,
-        );
+        let result = RegQueryValueExW(hkey, PCWSTR(name_wide.as_ptr()), None, None, None, None);
 
         let _ = RegCloseKey(hkey);
 

--- a/rust/src/cli/config.rs
+++ b/rust/src/cli/config.rs
@@ -47,15 +47,13 @@ async fn validate_config() -> anyhow::Result<()> {
     if let Some(path) = Settings::settings_path() {
         if path.exists() {
             match std::fs::read_to_string(&path) {
-                Ok(content) => {
-                    match serde_json::from_str::<Settings>(&content) {
-                        Ok(_) => println!("OK"),
-                        Err(e) => {
-                            println!("INVALID");
-                            errors.push(format!("settings.json: {}", e));
-                        }
+                Ok(content) => match serde_json::from_str::<Settings>(&content) {
+                    Ok(_) => println!("OK"),
+                    Err(e) => {
+                        println!("INVALID");
+                        errors.push(format!("settings.json: {}", e));
                     }
-                }
+                },
                 Err(e) => {
                     println!("ERROR");
                     errors.push(format!("settings.json: Could not read file: {}", e));
@@ -75,15 +73,13 @@ async fn validate_config() -> anyhow::Result<()> {
     if let Some(path) = ManualCookies::cookies_path() {
         if path.exists() {
             match std::fs::read_to_string(&path) {
-                Ok(content) => {
-                    match serde_json::from_str::<ManualCookies>(&content) {
-                        Ok(_) => println!("OK"),
-                        Err(e) => {
-                            println!("INVALID");
-                            errors.push(format!("manual_cookies.json: {}", e));
-                        }
+                Ok(content) => match serde_json::from_str::<ManualCookies>(&content) {
+                    Ok(_) => println!("OK"),
+                    Err(e) => {
+                        println!("INVALID");
+                        errors.push(format!("manual_cookies.json: {}", e));
                     }
-                }
+                },
                 Err(e) => {
                     println!("ERROR");
                     errors.push(format!("manual_cookies.json: Could not read file: {}", e));
@@ -128,7 +124,10 @@ async fn validate_config() -> anyhow::Result<()> {
             for e in &errors {
                 println!("  - {}", e);
             }
-            anyhow::bail!("Configuration validation failed with {} error(s).", errors.len());
+            anyhow::bail!(
+                "Configuration validation failed with {} error(s).",
+                errors.len()
+            );
         }
     }
 
@@ -175,7 +174,11 @@ async fn show_paths() -> anyhow::Result<()> {
     }
 
     let token_path = TokenAccountStore::default_path();
-    let exists = if token_path.exists() { "" } else { " (not found)" };
+    let exists = if token_path.exists() {
+        ""
+    } else {
+        " (not found)"
+    };
     println!("  Token accounts: {}{}", token_path.display(), exists);
 
     // Show config directory

--- a/rust/src/cli/cost.rs
+++ b/rust/src/cli/cost.rs
@@ -114,7 +114,10 @@ struct CostResult {
 fn print_text_output(results: &[CostResult], use_color: bool, days: u32) {
     for (i, result) in results.iter().enumerate() {
         if use_color {
-            println!("\x1b[1m{} Cost (last {} days)\x1b[0m", result.display_name, days);
+            println!(
+                "\x1b[1m{} Cost (last {} days)\x1b[0m",
+                result.display_name, days
+            );
         } else {
             println!("{} Cost (last {} days)", result.display_name, days);
         }
@@ -128,7 +131,10 @@ fn print_text_output(results: &[CostResult], use_color: bool, days: u32) {
         } else {
             // Total cost
             if use_color {
-                println!("  Total:    \x1b[32m{}\x1b[0m", result.summary.format_total());
+                println!(
+                    "  Total:    \x1b[32m{}\x1b[0m",
+                    result.summary.format_total()
+                );
             } else {
                 println!("  Total:    {}", result.summary.format_total());
             }

--- a/rust/src/cli/mod.rs
+++ b/rust/src/cli/mod.rs
@@ -35,7 +35,6 @@ pub mod exit_codes {
 #[command(author, version, about, long_about = None)]
 pub struct Cli {
     // === Global flags ===
-
     /// Enable verbose logging
     #[arg(short, long, global = true)]
     pub verbose: bool,
@@ -56,7 +55,6 @@ pub struct Cli {
     pub command: Option<Commands>,
 
     // === Top-level args for the default usage command ===
-
     /// Provider to query (codex, claude, cursor, gemini, copilot, zed, antigravity, factory, all, both)
     #[arg(short, long)]
     pub provider: Option<String>,

--- a/rust/src/cli/tty_runner.rs
+++ b/rust/src/cli/tty_runner.rs
@@ -5,6 +5,7 @@
 
 #![allow(dead_code)]
 
+use regex_lite::Regex;
 use std::collections::HashMap;
 use std::io::{Read, Write};
 use std::path::PathBuf;
@@ -12,7 +13,6 @@ use std::process::{Child, Command, Stdio};
 use std::sync::mpsc;
 use std::time::{Duration, Instant};
 use thiserror::Error;
-use regex_lite::Regex;
 
 /// Result of running a TTY command
 #[derive(Debug, Clone)]
@@ -118,7 +118,11 @@ impl TtyCommandOptions {
         self
     }
 
-    pub fn with_send_on_substring(mut self, trigger: impl Into<String>, keys: impl Into<String>) -> Self {
+    pub fn with_send_on_substring(
+        mut self,
+        trigger: impl Into<String>,
+        keys: impl Into<String>,
+    ) -> Self {
         self.send_on_substrings.insert(trigger.into(), keys.into());
         self
     }
@@ -188,7 +192,12 @@ impl TtyCommandRunner {
         let candidates = [
             // npm global install locations
             dirs::data_local_dir().map(|d| d.join("npm").join("codex.cmd")),
-            dirs::home_dir().map(|h| h.join("AppData").join("Roaming").join("npm").join("codex.cmd")),
+            dirs::home_dir().map(|h| {
+                h.join("AppData")
+                    .join("Roaming")
+                    .join("npm")
+                    .join("codex.cmd")
+            }),
             // Bun install
             dirs::home_dir().map(|h| h.join(".bun").join("bin").join("codex.exe")),
         ];
@@ -217,7 +226,12 @@ impl TtyCommandRunner {
         let candidates = [
             // npm global install locations
             dirs::data_local_dir().map(|d| d.join("npm").join("claude.cmd")),
-            dirs::home_dir().map(|h| h.join("AppData").join("Roaming").join("npm").join("claude.cmd")),
+            dirs::home_dir().map(|h| {
+                h.join("AppData")
+                    .join("Roaming")
+                    .join("npm")
+                    .join("claude.cmd")
+            }),
         ];
 
         for candidate in candidates.into_iter().flatten() {
@@ -291,7 +305,9 @@ impl TtyCommandRunner {
         cmd.stderr(Stdio::piped());
 
         // Launch the process
-        let mut child = cmd.spawn().map_err(|e| TtyCommandError::LaunchFailed(e.to_string()))?;
+        let mut child = cmd
+            .spawn()
+            .map_err(|e| TtyCommandError::LaunchFailed(e.to_string()))?;
 
         // Run the interactive session
         self.run_session(&mut child, script, &options)
@@ -410,7 +426,12 @@ impl TtyCommandRunner {
                     for mat in regex.find_iter(&chunk) {
                         let mut url = mat.as_str().to_string();
                         // Trim trailing punctuation
-                        while url.ends_with(|c| matches!(c, '.' | ',' | ';' | ':' | ')' | ']' | '}' | '>' | '"' | '\'')) {
+                        while url.ends_with(|c| {
+                            matches!(
+                                c,
+                                '.' | ',' | ';' | ':' | ')' | ']' | '}' | '>' | '"' | '\''
+                            )
+                        }) {
                             url.pop();
                         }
                         if !detected_urls.contains(&url) {
@@ -524,12 +545,16 @@ impl TtyCommandRunner {
         let mut env: HashMap<String, String> = std::env::vars().collect();
 
         env.insert("PATH".to_string(), Self::enriched_path());
-        env.entry("TERM".to_string()).or_insert_with(|| "xterm-256color".to_string());
-        env.entry("COLORTERM".to_string()).or_insert_with(|| "truecolor".to_string());
+        env.entry("TERM".to_string())
+            .or_insert_with(|| "xterm-256color".to_string());
+        env.entry("COLORTERM".to_string())
+            .or_insert_with(|| "truecolor".to_string());
 
         if let Some(home) = dirs::home_dir() {
-            env.entry("HOME".to_string()).or_insert_with(|| home.to_string_lossy().to_string());
-            env.entry("USERPROFILE".to_string()).or_insert_with(|| home.to_string_lossy().to_string());
+            env.entry("HOME".to_string())
+                .or_insert_with(|| home.to_string_lossy().to_string());
+            env.entry("USERPROFILE".to_string())
+                .or_insert_with(|| home.to_string_lossy().to_string());
         }
 
         env

--- a/rust/src/cli/usage.rs
+++ b/rust/src/cli/usage.rs
@@ -3,11 +3,11 @@
 use clap::Args;
 use serde::Serialize;
 
-use crate::core::{FetchContext, ProviderId, Provider, ProviderFetchResult, SourceMode};
+use crate::core::{FetchContext, Provider, ProviderFetchResult, ProviderId, SourceMode};
 use crate::providers::{
     AmpProvider, AntigravityProvider, AugmentProvider, ClaudeProvider, CodexProvider,
     CopilotProvider, CursorProvider, FactoryProvider, GeminiProvider, JetBrainsProvider,
-    KiloProvider, KimiProvider, KimiK2Provider, KiroProvider, MiniMaxProvider, OllamaProvider,
+    KiloProvider, KimiK2Provider, KimiProvider, KiroProvider, MiniMaxProvider, OllamaProvider,
     OpenCodeProvider, OpenRouterProvider, SyntheticProvider, VertexAIProvider, WarpProvider,
     ZaiProvider,
 };
@@ -98,7 +98,10 @@ impl ProviderSelection {
                 if let Some(id) = ProviderId::from_cli_name(name) {
                     Ok(ProviderSelection::Single(id))
                 } else {
-                    anyhow::bail!("Unknown provider: '{}'. Use --help to see available providers.", name)
+                    anyhow::bail!(
+                        "Unknown provider: '{}'. Use --help to see available providers.",
+                        name
+                    )
                 }
             }
             None => Ok(ProviderSelection::Single(ProviderId::Claude)), // Default to Claude
@@ -212,7 +215,12 @@ pub async fn run(args: UsageArgs) -> anyhow::Result<()> {
                 };
 
                 if format == OutputFormat::Text {
-                    text_sections.push(render_text_with_status(provider_id, &result, status.as_ref(), use_color));
+                    text_sections.push(render_text_with_status(
+                        provider_id,
+                        &result,
+                        status.as_ref(),
+                        use_color,
+                    ));
                 } else {
                     let mut json_result = serde_json::json!({
                         "provider": provider_id.cli_name(),
@@ -301,9 +309,19 @@ pub fn render_text_with_status(
     };
 
     let header = if use_color {
-        format!("\x1b[1m{}\x1b[0m ({}){}", provider.display_name(), result.source_label, status_indicator)
+        format!(
+            "\x1b[1m{}\x1b[0m ({}){}",
+            provider.display_name(),
+            result.source_label,
+            status_indicator
+        )
     } else {
-        format!("{} ({}){}", provider.display_name(), result.source_label, status_indicator)
+        format!(
+            "{} ({}){}",
+            provider.display_name(),
+            result.source_label,
+            status_indicator
+        )
     };
     lines.push(header);
 
@@ -359,7 +377,12 @@ pub fn render_text_with_status(
     // Cost info
     if let Some(ref cost) = result.cost {
         let cost_line = if let Some(limit) = cost.format_limit() {
-            format!("  Cost:    {} / {} ({})", cost.format_used(), limit, cost.period)
+            format!(
+                "  Cost:    {} / {} ({})",
+                cost.format_used(),
+                limit,
+                cost.period
+            )
         } else {
             format!("  Cost:    {} ({})", cost.format_used(), cost.period)
         };
@@ -370,11 +393,7 @@ pub fn render_text_with_status(
 }
 
 /// Render usage as text (backwards compatible version)
-pub fn render_text(
-    provider: ProviderId,
-    result: &ProviderFetchResult,
-    use_color: bool,
-) -> String {
+pub fn render_text(provider: ProviderId, result: &ProviderFetchResult, use_color: bool) -> String {
     render_text_with_status(provider, result, None, use_color)
 }
 

--- a/rust/src/core/cost_pricing.rs
+++ b/rust/src/core/cost_pricing.rs
@@ -47,31 +47,46 @@ static CODEX_PRICING: LazyLock<HashMap<&'static str, CodexPricing>> = LazyLock::
     let mut m = HashMap::new();
 
     // GPT-5 pricing
-    m.insert("gpt-5", CodexPricing {
-        input_cost_per_token: 1.25e-6,
-        output_cost_per_token: 1e-5,
-        cache_read_input_cost_per_token: 1.25e-7,
-    });
-    m.insert("gpt-5-codex", CodexPricing {
-        input_cost_per_token: 1.25e-6,
-        output_cost_per_token: 1e-5,
-        cache_read_input_cost_per_token: 1.25e-7,
-    });
-    m.insert("gpt-5.1", CodexPricing {
-        input_cost_per_token: 1.25e-6,
-        output_cost_per_token: 1e-5,
-        cache_read_input_cost_per_token: 1.25e-7,
-    });
-    m.insert("gpt-5.2", CodexPricing {
-        input_cost_per_token: 1.75e-6,
-        output_cost_per_token: 1.4e-5,
-        cache_read_input_cost_per_token: 1.75e-7,
-    });
-    m.insert("gpt-5.2-codex", CodexPricing {
-        input_cost_per_token: 1.75e-6,
-        output_cost_per_token: 1.4e-5,
-        cache_read_input_cost_per_token: 1.75e-7,
-    });
+    m.insert(
+        "gpt-5",
+        CodexPricing {
+            input_cost_per_token: 1.25e-6,
+            output_cost_per_token: 1e-5,
+            cache_read_input_cost_per_token: 1.25e-7,
+        },
+    );
+    m.insert(
+        "gpt-5-codex",
+        CodexPricing {
+            input_cost_per_token: 1.25e-6,
+            output_cost_per_token: 1e-5,
+            cache_read_input_cost_per_token: 1.25e-7,
+        },
+    );
+    m.insert(
+        "gpt-5.1",
+        CodexPricing {
+            input_cost_per_token: 1.25e-6,
+            output_cost_per_token: 1e-5,
+            cache_read_input_cost_per_token: 1.25e-7,
+        },
+    );
+    m.insert(
+        "gpt-5.2",
+        CodexPricing {
+            input_cost_per_token: 1.75e-6,
+            output_cost_per_token: 1.4e-5,
+            cache_read_input_cost_per_token: 1.75e-7,
+        },
+    );
+    m.insert(
+        "gpt-5.2-codex",
+        CodexPricing {
+            input_cost_per_token: 1.75e-6,
+            output_cost_per_token: 1.4e-5,
+            cache_read_input_cost_per_token: 1.75e-7,
+        },
+    );
 
     m
 });
@@ -81,137 +96,170 @@ static CLAUDE_PRICING: LazyLock<HashMap<&'static str, ClaudePricing>> = LazyLock
     let mut m = HashMap::new();
 
     // Haiku 4.5
-    m.insert("claude-haiku-4-5", ClaudePricing {
-        input_cost_per_token: 1e-6,
-        output_cost_per_token: 5e-6,
-        cache_creation_input_cost_per_token: 1.25e-6,
-        cache_read_input_cost_per_token: 1e-7,
-        threshold_tokens: None,
-        input_cost_per_token_above_threshold: None,
-        output_cost_per_token_above_threshold: None,
-        cache_creation_input_cost_per_token_above_threshold: None,
-        cache_read_input_cost_per_token_above_threshold: None,
-    });
-    m.insert("claude-haiku-4-5-20251001", ClaudePricing {
-        input_cost_per_token: 1e-6,
-        output_cost_per_token: 5e-6,
-        cache_creation_input_cost_per_token: 1.25e-6,
-        cache_read_input_cost_per_token: 1e-7,
-        threshold_tokens: None,
-        input_cost_per_token_above_threshold: None,
-        output_cost_per_token_above_threshold: None,
-        cache_creation_input_cost_per_token_above_threshold: None,
-        cache_read_input_cost_per_token_above_threshold: None,
-    });
+    m.insert(
+        "claude-haiku-4-5",
+        ClaudePricing {
+            input_cost_per_token: 1e-6,
+            output_cost_per_token: 5e-6,
+            cache_creation_input_cost_per_token: 1.25e-6,
+            cache_read_input_cost_per_token: 1e-7,
+            threshold_tokens: None,
+            input_cost_per_token_above_threshold: None,
+            output_cost_per_token_above_threshold: None,
+            cache_creation_input_cost_per_token_above_threshold: None,
+            cache_read_input_cost_per_token_above_threshold: None,
+        },
+    );
+    m.insert(
+        "claude-haiku-4-5-20251001",
+        ClaudePricing {
+            input_cost_per_token: 1e-6,
+            output_cost_per_token: 5e-6,
+            cache_creation_input_cost_per_token: 1.25e-6,
+            cache_read_input_cost_per_token: 1e-7,
+            threshold_tokens: None,
+            input_cost_per_token_above_threshold: None,
+            output_cost_per_token_above_threshold: None,
+            cache_creation_input_cost_per_token_above_threshold: None,
+            cache_read_input_cost_per_token_above_threshold: None,
+        },
+    );
 
     // Opus 4.6
-    m.insert("claude-opus-4-6", ClaudePricing {
-        input_cost_per_token: 5e-6,
-        output_cost_per_token: 2.5e-5,
-        cache_creation_input_cost_per_token: 6.25e-6,
-        cache_read_input_cost_per_token: 5e-7,
-        threshold_tokens: None,
-        input_cost_per_token_above_threshold: None,
-        output_cost_per_token_above_threshold: None,
-        cache_creation_input_cost_per_token_above_threshold: None,
-        cache_read_input_cost_per_token_above_threshold: None,
-    });
-    m.insert("claude-opus-4-6-20260205", ClaudePricing {
-        input_cost_per_token: 5e-6,
-        output_cost_per_token: 2.5e-5,
-        cache_creation_input_cost_per_token: 6.25e-6,
-        cache_read_input_cost_per_token: 5e-7,
-        threshold_tokens: None,
-        input_cost_per_token_above_threshold: None,
-        output_cost_per_token_above_threshold: None,
-        cache_creation_input_cost_per_token_above_threshold: None,
-        cache_read_input_cost_per_token_above_threshold: None,
-    });
+    m.insert(
+        "claude-opus-4-6",
+        ClaudePricing {
+            input_cost_per_token: 5e-6,
+            output_cost_per_token: 2.5e-5,
+            cache_creation_input_cost_per_token: 6.25e-6,
+            cache_read_input_cost_per_token: 5e-7,
+            threshold_tokens: None,
+            input_cost_per_token_above_threshold: None,
+            output_cost_per_token_above_threshold: None,
+            cache_creation_input_cost_per_token_above_threshold: None,
+            cache_read_input_cost_per_token_above_threshold: None,
+        },
+    );
+    m.insert(
+        "claude-opus-4-6-20260205",
+        ClaudePricing {
+            input_cost_per_token: 5e-6,
+            output_cost_per_token: 2.5e-5,
+            cache_creation_input_cost_per_token: 6.25e-6,
+            cache_read_input_cost_per_token: 5e-7,
+            threshold_tokens: None,
+            input_cost_per_token_above_threshold: None,
+            output_cost_per_token_above_threshold: None,
+            cache_creation_input_cost_per_token_above_threshold: None,
+            cache_read_input_cost_per_token_above_threshold: None,
+        },
+    );
 
     // Opus 4.5
-    m.insert("claude-opus-4-5", ClaudePricing {
-        input_cost_per_token: 5e-6,
-        output_cost_per_token: 2.5e-5,
-        cache_creation_input_cost_per_token: 6.25e-6,
-        cache_read_input_cost_per_token: 5e-7,
-        threshold_tokens: None,
-        input_cost_per_token_above_threshold: None,
-        output_cost_per_token_above_threshold: None,
-        cache_creation_input_cost_per_token_above_threshold: None,
-        cache_read_input_cost_per_token_above_threshold: None,
-    });
-    m.insert("claude-opus-4-5-20251101", ClaudePricing {
-        input_cost_per_token: 5e-6,
-        output_cost_per_token: 2.5e-5,
-        cache_creation_input_cost_per_token: 6.25e-6,
-        cache_read_input_cost_per_token: 5e-7,
-        threshold_tokens: None,
-        input_cost_per_token_above_threshold: None,
-        output_cost_per_token_above_threshold: None,
-        cache_creation_input_cost_per_token_above_threshold: None,
-        cache_read_input_cost_per_token_above_threshold: None,
-    });
+    m.insert(
+        "claude-opus-4-5",
+        ClaudePricing {
+            input_cost_per_token: 5e-6,
+            output_cost_per_token: 2.5e-5,
+            cache_creation_input_cost_per_token: 6.25e-6,
+            cache_read_input_cost_per_token: 5e-7,
+            threshold_tokens: None,
+            input_cost_per_token_above_threshold: None,
+            output_cost_per_token_above_threshold: None,
+            cache_creation_input_cost_per_token_above_threshold: None,
+            cache_read_input_cost_per_token_above_threshold: None,
+        },
+    );
+    m.insert(
+        "claude-opus-4-5-20251101",
+        ClaudePricing {
+            input_cost_per_token: 5e-6,
+            output_cost_per_token: 2.5e-5,
+            cache_creation_input_cost_per_token: 6.25e-6,
+            cache_read_input_cost_per_token: 5e-7,
+            threshold_tokens: None,
+            input_cost_per_token_above_threshold: None,
+            output_cost_per_token_above_threshold: None,
+            cache_creation_input_cost_per_token_above_threshold: None,
+            cache_read_input_cost_per_token_above_threshold: None,
+        },
+    );
 
     // Sonnet 4.5 (with tiered pricing at 200k tokens)
-    m.insert("claude-sonnet-4-5", ClaudePricing {
-        input_cost_per_token: 3e-6,
-        output_cost_per_token: 1.5e-5,
-        cache_creation_input_cost_per_token: 3.75e-6,
-        cache_read_input_cost_per_token: 3e-7,
-        threshold_tokens: Some(200_000),
-        input_cost_per_token_above_threshold: Some(6e-6),
-        output_cost_per_token_above_threshold: Some(2.25e-5),
-        cache_creation_input_cost_per_token_above_threshold: Some(7.5e-6),
-        cache_read_input_cost_per_token_above_threshold: Some(6e-7),
-    });
-    m.insert("claude-sonnet-4-5-20250929", ClaudePricing {
-        input_cost_per_token: 3e-6,
-        output_cost_per_token: 1.5e-5,
-        cache_creation_input_cost_per_token: 3.75e-6,
-        cache_read_input_cost_per_token: 3e-7,
-        threshold_tokens: Some(200_000),
-        input_cost_per_token_above_threshold: Some(6e-6),
-        output_cost_per_token_above_threshold: Some(2.25e-5),
-        cache_creation_input_cost_per_token_above_threshold: Some(7.5e-6),
-        cache_read_input_cost_per_token_above_threshold: Some(6e-7),
-    });
+    m.insert(
+        "claude-sonnet-4-5",
+        ClaudePricing {
+            input_cost_per_token: 3e-6,
+            output_cost_per_token: 1.5e-5,
+            cache_creation_input_cost_per_token: 3.75e-6,
+            cache_read_input_cost_per_token: 3e-7,
+            threshold_tokens: Some(200_000),
+            input_cost_per_token_above_threshold: Some(6e-6),
+            output_cost_per_token_above_threshold: Some(2.25e-5),
+            cache_creation_input_cost_per_token_above_threshold: Some(7.5e-6),
+            cache_read_input_cost_per_token_above_threshold: Some(6e-7),
+        },
+    );
+    m.insert(
+        "claude-sonnet-4-5-20250929",
+        ClaudePricing {
+            input_cost_per_token: 3e-6,
+            output_cost_per_token: 1.5e-5,
+            cache_creation_input_cost_per_token: 3.75e-6,
+            cache_read_input_cost_per_token: 3e-7,
+            threshold_tokens: Some(200_000),
+            input_cost_per_token_above_threshold: Some(6e-6),
+            output_cost_per_token_above_threshold: Some(2.25e-5),
+            cache_creation_input_cost_per_token_above_threshold: Some(7.5e-6),
+            cache_read_input_cost_per_token_above_threshold: Some(6e-7),
+        },
+    );
 
     // Opus 4
-    m.insert("claude-opus-4-20250514", ClaudePricing {
-        input_cost_per_token: 1.5e-5,
-        output_cost_per_token: 7.5e-5,
-        cache_creation_input_cost_per_token: 1.875e-5,
-        cache_read_input_cost_per_token: 1.5e-6,
-        threshold_tokens: None,
-        input_cost_per_token_above_threshold: None,
-        output_cost_per_token_above_threshold: None,
-        cache_creation_input_cost_per_token_above_threshold: None,
-        cache_read_input_cost_per_token_above_threshold: None,
-    });
-    m.insert("claude-opus-4-1", ClaudePricing {
-        input_cost_per_token: 1.5e-5,
-        output_cost_per_token: 7.5e-5,
-        cache_creation_input_cost_per_token: 1.875e-5,
-        cache_read_input_cost_per_token: 1.5e-6,
-        threshold_tokens: None,
-        input_cost_per_token_above_threshold: None,
-        output_cost_per_token_above_threshold: None,
-        cache_creation_input_cost_per_token_above_threshold: None,
-        cache_read_input_cost_per_token_above_threshold: None,
-    });
+    m.insert(
+        "claude-opus-4-20250514",
+        ClaudePricing {
+            input_cost_per_token: 1.5e-5,
+            output_cost_per_token: 7.5e-5,
+            cache_creation_input_cost_per_token: 1.875e-5,
+            cache_read_input_cost_per_token: 1.5e-6,
+            threshold_tokens: None,
+            input_cost_per_token_above_threshold: None,
+            output_cost_per_token_above_threshold: None,
+            cache_creation_input_cost_per_token_above_threshold: None,
+            cache_read_input_cost_per_token_above_threshold: None,
+        },
+    );
+    m.insert(
+        "claude-opus-4-1",
+        ClaudePricing {
+            input_cost_per_token: 1.5e-5,
+            output_cost_per_token: 7.5e-5,
+            cache_creation_input_cost_per_token: 1.875e-5,
+            cache_read_input_cost_per_token: 1.5e-6,
+            threshold_tokens: None,
+            input_cost_per_token_above_threshold: None,
+            output_cost_per_token_above_threshold: None,
+            cache_creation_input_cost_per_token_above_threshold: None,
+            cache_read_input_cost_per_token_above_threshold: None,
+        },
+    );
 
     // Sonnet 4
-    m.insert("claude-sonnet-4-20250514", ClaudePricing {
-        input_cost_per_token: 3e-6,
-        output_cost_per_token: 1.5e-5,
-        cache_creation_input_cost_per_token: 3.75e-6,
-        cache_read_input_cost_per_token: 3e-7,
-        threshold_tokens: Some(200_000),
-        input_cost_per_token_above_threshold: Some(6e-6),
-        output_cost_per_token_above_threshold: Some(2.25e-5),
-        cache_creation_input_cost_per_token_above_threshold: Some(7.5e-6),
-        cache_read_input_cost_per_token_above_threshold: Some(6e-7),
-    });
+    m.insert(
+        "claude-sonnet-4-20250514",
+        ClaudePricing {
+            input_cost_per_token: 3e-6,
+            output_cost_per_token: 1.5e-5,
+            cache_creation_input_cost_per_token: 3.75e-6,
+            cache_read_input_cost_per_token: 3e-7,
+            threshold_tokens: Some(200_000),
+            input_cost_per_token_above_threshold: Some(6e-6),
+            output_cost_per_token_above_threshold: Some(2.25e-5),
+            cache_creation_input_cost_per_token_above_threshold: Some(7.5e-6),
+            cache_read_input_cost_per_token_above_threshold: Some(6e-7),
+        },
+    );
 
     m
 });
@@ -383,8 +431,14 @@ mod tests {
     #[test]
     fn test_normalize_codex_model() {
         assert_eq!(CostUsagePricing::normalize_codex_model("gpt-5"), "gpt-5");
-        assert_eq!(CostUsagePricing::normalize_codex_model("openai/gpt-5"), "gpt-5");
-        assert_eq!(CostUsagePricing::normalize_codex_model("gpt-5-codex"), "gpt-5");
+        assert_eq!(
+            CostUsagePricing::normalize_codex_model("openai/gpt-5"),
+            "gpt-5"
+        );
+        assert_eq!(
+            CostUsagePricing::normalize_codex_model("gpt-5-codex"),
+            "gpt-5"
+        );
     }
 
     #[test]
@@ -410,17 +464,20 @@ mod tests {
 
     #[test]
     fn test_claude_cost() {
-        let cost = CostUsagePricing::claude_cost_usd(
-            "claude-haiku-4-5-20251001",
-            1000, 0, 0, 500,
-        );
+        let cost = CostUsagePricing::claude_cost_usd("claude-haiku-4-5-20251001", 1000, 0, 0, 500);
         assert!(cost.is_some());
     }
 
     #[test]
     fn test_format_model_name() {
-        assert_eq!(CostUsagePricing::format_model_name("claude-3.5-sonnet"), "Sonnet 3.5");
-        assert_eq!(CostUsagePricing::format_model_name("claude-opus-4"), "Opus 4");
+        assert_eq!(
+            CostUsagePricing::format_model_name("claude-3.5-sonnet"),
+            "Sonnet 3.5"
+        );
+        assert_eq!(
+            CostUsagePricing::format_model_name("claude-opus-4"),
+            "Opus 4"
+        );
         assert_eq!(CostUsagePricing::format_model_name("gpt-5"), "GPT-5 5");
     }
 }

--- a/rust/src/core/credential_migration.rs
+++ b/rust/src/core/credential_migration.rs
@@ -165,7 +165,10 @@ impl CredentialMigrator {
             return None;
         }
 
-        tracing::info!("Starting credential migration to version {}", CURRENT_MIGRATION_VERSION);
+        tracing::info!(
+            "Starting credential migration to version {}",
+            CURRENT_MIGRATION_VERSION
+        );
 
         let result = self.run_migration();
 
@@ -194,7 +197,10 @@ impl CredentialMigrator {
                 }
                 Ok(false) => {
                     // Item didn't exist or already migrated
-                    tracing::debug!("Skipped credential (not found or already migrated): {}", item.label());
+                    tracing::debug!(
+                        "Skipped credential (not found or already migrated): {}",
+                        item.label()
+                    );
                 }
                 Err(e) => {
                     result.error_count += 1;
@@ -227,32 +233,48 @@ impl CredentialMigrator {
     }
 
     /// Read a credential from the keyring
-    fn read_credential(&self, service: &str, account: Option<&str>) -> Result<String, MigrationError> {
+    fn read_credential(
+        &self,
+        service: &str,
+        account: Option<&str>,
+    ) -> Result<String, MigrationError> {
         let account = account.unwrap_or("default");
         let entry = keyring::Entry::new(service, account)
             .map_err(|e| MigrationError::ReadFailed(e.to_string()))?;
 
-        entry.get_password()
+        entry
+            .get_password()
             .map_err(|e| MigrationError::ReadFailed(e.to_string()))
     }
 
     /// Write a credential to the keyring
-    fn write_credential(&self, service: &str, account: Option<&str>, value: &str) -> Result<(), MigrationError> {
+    fn write_credential(
+        &self,
+        service: &str,
+        account: Option<&str>,
+        value: &str,
+    ) -> Result<(), MigrationError> {
         let account = account.unwrap_or("default");
         let entry = keyring::Entry::new(service, account)
             .map_err(|e| MigrationError::WriteFailed(e.to_string()))?;
 
-        entry.set_password(value)
+        entry
+            .set_password(value)
             .map_err(|e| MigrationError::WriteFailed(e.to_string()))
     }
 
     /// Delete a credential from the keyring
-    fn delete_credential(&self, service: &str, account: Option<&str>) -> Result<(), MigrationError> {
+    fn delete_credential(
+        &self,
+        service: &str,
+        account: Option<&str>,
+    ) -> Result<(), MigrationError> {
         let account = account.unwrap_or("default");
         let entry = keyring::Entry::new(service, account)
             .map_err(|e| MigrationError::DeleteFailed(e.to_string()))?;
 
-        entry.delete_credential()
+        entry
+            .delete_credential()
             .map_err(|e| MigrationError::DeleteFailed(e.to_string()))
     }
 
@@ -335,8 +357,7 @@ mod tests {
 
     #[test]
     fn test_migration_item_label() {
-        let item = MigrationItem::new("CodexBar")
-            .with_account("claude-cookie");
+        let item = MigrationItem::new("CodexBar").with_account("claude-cookie");
         assert_eq!(item.label(), "CodexBar:claude-cookie");
 
         let item = MigrationItem::new("CodexBar");
@@ -361,8 +382,14 @@ mod tests {
 
     #[test]
     fn test_account_name_for_provider() {
-        assert_eq!(account_name_for_provider(ProviderId::Claude), "claude-cookie");
-        assert_eq!(account_name_for_provider(ProviderId::Copilot), "copilot-api-token");
+        assert_eq!(
+            account_name_for_provider(ProviderId::Claude),
+            "claude-cookie"
+        );
+        assert_eq!(
+            account_name_for_provider(ProviderId::Copilot),
+            "copilot-api-token"
+        );
     }
 
     #[test]

--- a/rust/src/core/credentials.rs
+++ b/rust/src/core/credentials.rs
@@ -51,25 +51,26 @@ impl Default for WindowsCredentialStore {
 #[cfg(windows)]
 impl CredentialStore for WindowsCredentialStore {
     fn get(&self, service: &str, key: &str) -> Result<String, CredentialError> {
-        let entry = keyring::Entry::new(service, key).map_err(|e| CredentialError::Storage(e.to_string()))?;
-        entry
-            .get_password()
-            .map_err(|e| match e {
-                keyring::Error::NoEntry => CredentialError::NotFound,
-                keyring::Error::Ambiguous(_) => CredentialError::Storage("Ambiguous entry".to_string()),
-                _ => CredentialError::Storage(e.to_string()),
-            })
+        let entry = keyring::Entry::new(service, key)
+            .map_err(|e| CredentialError::Storage(e.to_string()))?;
+        entry.get_password().map_err(|e| match e {
+            keyring::Error::NoEntry => CredentialError::NotFound,
+            keyring::Error::Ambiguous(_) => CredentialError::Storage("Ambiguous entry".to_string()),
+            _ => CredentialError::Storage(e.to_string()),
+        })
     }
 
     fn set(&self, service: &str, key: &str, value: &str) -> Result<(), CredentialError> {
-        let entry = keyring::Entry::new(service, key).map_err(|e| CredentialError::Storage(e.to_string()))?;
+        let entry = keyring::Entry::new(service, key)
+            .map_err(|e| CredentialError::Storage(e.to_string()))?;
         entry
             .set_password(value)
             .map_err(|e| CredentialError::Storage(e.to_string()))
     }
 
     fn delete(&self, service: &str, key: &str) -> Result<(), CredentialError> {
-        let entry = keyring::Entry::new(service, key).map_err(|e| CredentialError::Storage(e.to_string()))?;
+        let entry = keyring::Entry::new(service, key)
+            .map_err(|e| CredentialError::Storage(e.to_string()))?;
         entry.delete_credential().map_err(|e| match e {
             keyring::Error::NoEntry => CredentialError::NotFound,
             _ => CredentialError::Storage(e.to_string()),

--- a/rust/src/core/fetch_plan.rs
+++ b/rust/src/core/fetch_plan.rs
@@ -347,7 +347,10 @@ impl ProviderFetchPipeline {
             // Try to fetch
             match strategy.fetch(context).await {
                 Ok(result) => {
-                    attempts.push(ProviderFetchAttempt::success(strategy.id(), strategy.kind()));
+                    attempts.push(ProviderFetchAttempt::success(
+                        strategy.id(),
+                        strategy.kind(),
+                    ));
                     return ProviderFetchOutcome::success(result, attempts);
                 }
                 Err(error) => {

--- a/rust/src/core/jsonl_scanner.rs
+++ b/rust/src/core/jsonl_scanner.rs
@@ -162,7 +162,10 @@ impl JsonlScanner {
             if let Ok(entries) = fs::read_dir(&day_dir) {
                 for entry in entries.flatten() {
                     let path = entry.path();
-                    if path.extension().map_or(false, |e| e.eq_ignore_ascii_case("jsonl")) {
+                    if path
+                        .extension()
+                        .map_or(false, |e| e.eq_ignore_ascii_case("jsonl"))
+                    {
                         files.push(path);
                     }
                 }
@@ -200,7 +203,9 @@ impl JsonlScanner {
             parsed_bytes += line.len() as i64;
 
             // Quick check for relevant lines
-            if !line.contains("\"type\":\"event_msg\"") && !line.contains("\"type\":\"turn_context\"") {
+            if !line.contains("\"type\":\"event_msg\"")
+                && !line.contains("\"type\":\"turn_context\"")
+            {
                 line.clear();
                 continue;
             }
@@ -225,7 +230,11 @@ impl JsonlScanner {
                         continue;
                     };
 
-                    if !CostUsageDayRange::is_in_range(day_key, &range.scan_since_key, &range.scan_until_key) {
+                    if !CostUsageDayRange::is_in_range(
+                        day_key,
+                        &range.scan_since_key,
+                        &range.scan_until_key,
+                    ) {
                         line.clear();
                         continue;
                     }
@@ -264,29 +273,55 @@ impl JsonlScanner {
                             let (delta_input, delta_cached, delta_output) = if let Some(total) =
                                 info.and_then(|i| i.get("total_token_usage"))
                             {
-                                let input = total.get("input_tokens").and_then(|v| v.as_i64()).unwrap_or(0) as i32;
+                                let input = total
+                                    .get("input_tokens")
+                                    .and_then(|v| v.as_i64())
+                                    .unwrap_or(0)
+                                    as i32;
                                 let cached = total
                                     .get("cached_input_tokens")
                                     .or(total.get("cache_read_input_tokens"))
                                     .and_then(|v| v.as_i64())
-                                    .unwrap_or(0) as i32;
-                                let output = total.get("output_tokens").and_then(|v| v.as_i64()).unwrap_or(0) as i32;
+                                    .unwrap_or(0)
+                                    as i32;
+                                let output = total
+                                    .get("output_tokens")
+                                    .and_then(|v| v.as_i64())
+                                    .unwrap_or(0)
+                                    as i32;
 
-                                let delta_input = (input - previous_totals.as_ref().map_or(0, |t| t.input)).max(0);
-                                let delta_cached = (cached - previous_totals.as_ref().map_or(0, |t| t.cached)).max(0);
-                                let delta_output = (output - previous_totals.as_ref().map_or(0, |t| t.output)).max(0);
+                                let delta_input = (input
+                                    - previous_totals.as_ref().map_or(0, |t| t.input))
+                                .max(0);
+                                let delta_cached = (cached
+                                    - previous_totals.as_ref().map_or(0, |t| t.cached))
+                                .max(0);
+                                let delta_output = (output
+                                    - previous_totals.as_ref().map_or(0, |t| t.output))
+                                .max(0);
 
-                                previous_totals = Some(CodexTotals { input, cached, output });
+                                previous_totals = Some(CodexTotals {
+                                    input,
+                                    cached,
+                                    output,
+                                });
 
                                 (delta_input, delta_cached, delta_output)
-                            } else if let Some(last) = info.and_then(|i| i.get("last_token_usage")) {
-                                let input = last.get("input_tokens").and_then(|v| v.as_i64()).unwrap_or(0) as i32;
-                                let cached = last
-                                    .get("cached_input_tokens")
-                                    .or(last.get("cache_read_input_tokens"))
-                                    .and_then(|v| v.as_i64())
-                                    .unwrap_or(0) as i32;
-                                let output = last.get("output_tokens").and_then(|v| v.as_i64()).unwrap_or(0) as i32;
+                            } else if let Some(last) = info.and_then(|i| i.get("last_token_usage"))
+                            {
+                                let input =
+                                    last.get("input_tokens")
+                                        .and_then(|v| v.as_i64())
+                                        .unwrap_or(0) as i32;
+                                let cached =
+                                    last.get("cached_input_tokens")
+                                        .or(last.get("cache_read_input_tokens"))
+                                        .and_then(|v| v.as_i64())
+                                        .unwrap_or(0) as i32;
+                                let output =
+                                    last.get("output_tokens")
+                                        .and_then(|v| v.as_i64())
+                                        .unwrap_or(0) as i32;
 
                                 (input.max(0), cached.max(0), output.max(0))
                             } else {
@@ -304,7 +339,9 @@ impl JsonlScanner {
                             let cached_clamp = delta_cached.min(delta_input);
 
                             let day_models = days.entry(day_key.to_string()).or_default();
-                            let packed = day_models.entry(norm_model).or_insert_with(|| vec![0, 0, 0]);
+                            let packed = day_models
+                                .entry(norm_model)
+                                .or_insert_with(|| vec![0, 0, 0]);
                             packed[0] += delta_input;
                             packed[1] += cached_clamp;
                             packed[2] += delta_output;
@@ -380,9 +417,21 @@ mod tests {
 
     #[test]
     fn test_is_in_range() {
-        assert!(CostUsageDayRange::is_in_range("2026-01-15", "2026-01-10", "2026-01-20"));
-        assert!(!CostUsageDayRange::is_in_range("2026-01-05", "2026-01-10", "2026-01-20"));
-        assert!(!CostUsageDayRange::is_in_range("2026-01-25", "2026-01-10", "2026-01-20"));
+        assert!(CostUsageDayRange::is_in_range(
+            "2026-01-15",
+            "2026-01-10",
+            "2026-01-20"
+        ));
+        assert!(!CostUsageDayRange::is_in_range(
+            "2026-01-05",
+            "2026-01-10",
+            "2026-01-20"
+        ));
+        assert!(!CostUsageDayRange::is_in_range(
+            "2026-01-25",
+            "2026-01-10",
+            "2026-01-20"
+        ));
     }
 
     #[test]

--- a/rust/src/core/openai_dashboard.rs
+++ b/rust/src/core/openai_dashboard.rs
@@ -62,7 +62,10 @@ impl OpenAIDashboardSnapshot {
     }
 
     /// Create daily breakdown from credit events
-    pub fn make_daily_breakdown(events: &[CreditEvent], max_days: usize) -> Vec<OpenAIDashboardDailyBreakdown> {
+    pub fn make_daily_breakdown(
+        events: &[CreditEvent],
+        max_days: usize,
+    ) -> Vec<OpenAIDashboardDailyBreakdown> {
         if events.is_empty() {
             return Vec::new();
         }
@@ -87,7 +90,10 @@ impl OpenAIDashboardSnapshot {
                 let service_totals = totals.get(&day).cloned().unwrap_or_default();
                 let mut services: Vec<_> = service_totals
                     .into_iter()
-                    .map(|(service, credits_used)| OpenAIDashboardServiceUsage { service, credits_used })
+                    .map(|(service, credits_used)| OpenAIDashboardServiceUsage {
+                        service,
+                        credits_used,
+                    })
                     .collect();
 
                 // Sort by credits used descending, then by service name
@@ -289,21 +295,9 @@ mod tests {
     #[test]
     fn test_daily_breakdown() {
         let events = vec![
-            CreditEvent::new(
-                NaiveDate::from_ymd_opt(2026, 1, 15).unwrap(),
-                "CLI",
-                10.5,
-            ),
-            CreditEvent::new(
-                NaiveDate::from_ymd_opt(2026, 1, 15).unwrap(),
-                "API",
-                5.0,
-            ),
-            CreditEvent::new(
-                NaiveDate::from_ymd_opt(2026, 1, 14).unwrap(),
-                "CLI",
-                3.0,
-            ),
+            CreditEvent::new(NaiveDate::from_ymd_opt(2026, 1, 15).unwrap(), "CLI", 10.5),
+            CreditEvent::new(NaiveDate::from_ymd_opt(2026, 1, 15).unwrap(), "API", 5.0),
+            CreditEvent::new(NaiveDate::from_ymd_opt(2026, 1, 14).unwrap(), "CLI", 3.0),
         ];
 
         let breakdown = OpenAIDashboardSnapshot::make_daily_breakdown(&events, 30);

--- a/rust/src/core/provider.rs
+++ b/rust/src/core/provider.rs
@@ -359,7 +359,9 @@ impl ProviderRegistry {
         let providers = self.providers.read().unwrap();
         // We need to clone here, but since Provider is not Clone, we'll return None for now
         // In practice, we'll use Arc<dyn Provider> instead
-        providers.get(&id).map(|_| todo!("Use Arc<dyn Provider> instead"))
+        providers
+            .get(&id)
+            .map(|_| todo!("Use Arc<dyn Provider> instead"))
     }
 
     /// Get all registered provider IDs
@@ -435,12 +437,24 @@ mod tests {
 
     #[test]
     fn test_provider_id_from_cli_name() {
-        assert_eq!(ProviderId::from_cli_name("claude"), Some(ProviderId::Claude));
-        assert_eq!(ProviderId::from_cli_name("anthropic"), Some(ProviderId::Claude));
-        assert_eq!(ProviderId::from_cli_name("CLAUDE"), Some(ProviderId::Claude));
+        assert_eq!(
+            ProviderId::from_cli_name("claude"),
+            Some(ProviderId::Claude)
+        );
+        assert_eq!(
+            ProviderId::from_cli_name("anthropic"),
+            Some(ProviderId::Claude)
+        );
+        assert_eq!(
+            ProviderId::from_cli_name("CLAUDE"),
+            Some(ProviderId::Claude)
+        );
         assert_eq!(ProviderId::from_cli_name("codex"), Some(ProviderId::Codex));
         assert_eq!(ProviderId::from_cli_name("openai"), Some(ProviderId::Codex));
-        assert_eq!(ProviderId::from_cli_name("factory"), Some(ProviderId::Factory));
+        assert_eq!(
+            ProviderId::from_cli_name("factory"),
+            Some(ProviderId::Factory)
+        );
         assert_eq!(ProviderId::from_cli_name("zed"), Some(ProviderId::Zai));
         assert_eq!(ProviderId::from_cli_name("unknown"), None);
     }
@@ -488,7 +502,10 @@ mod tests {
         assert_eq!(ProviderId::Cursor.cookie_domain(), Some("cursor.com"));
         assert_eq!(ProviderId::Factory.cookie_domain(), Some("app.factory.ai"));
         assert_eq!(ProviderId::Codex.cookie_domain(), Some("chatgpt.com"));
-        assert_eq!(ProviderId::Gemini.cookie_domain(), Some("aistudio.google.com"));
+        assert_eq!(
+            ProviderId::Gemini.cookie_domain(),
+            Some("aistudio.google.com")
+        );
         assert_eq!(ProviderId::Kiro.cookie_domain(), Some("kiro.dev"));
         assert_eq!(ProviderId::Kimi.cookie_domain(), Some("kimi.moonshot.cn"));
         assert_eq!(ProviderId::OpenCode.cookie_domain(), Some("opencode.ai"));

--- a/rust/src/core/token_accounts.rs
+++ b/rust/src/core/token_accounts.rs
@@ -241,7 +241,8 @@ impl TokenAccount {
 
     /// Get last_used as DateTime
     pub fn last_used_datetime(&self) -> Option<DateTime<Utc>> {
-        self.last_used.and_then(|ts| DateTime::from_timestamp(ts, 0))
+        self.last_used
+            .and_then(|ts| DateTime::from_timestamp(ts, 0))
     }
 }
 
@@ -519,7 +520,9 @@ mod tests {
         assert!(!TokenAccountSupport::is_claude_oauth_token(
             "sessionKey=abc123"
         ));
-        assert!(!TokenAccountSupport::is_claude_oauth_token("Cookie: foo=bar"));
+        assert!(!TokenAccountSupport::is_claude_oauth_token(
+            "Cookie: foo=bar"
+        ));
     }
 
     #[test]

--- a/rust/src/core/usage_pace.rs
+++ b/rust/src/core/usage_pace.rs
@@ -90,7 +90,11 @@ impl UsagePace {
     /// * `window` - The rate window to analyze
     /// * `now` - Current time (defaults to Utc::now())
     /// * `default_window_minutes` - Default window duration if not specified (10080 = 7 days)
-    pub fn weekly(window: &RateWindow, now: Option<DateTime<Utc>>, default_window_minutes: u32) -> Option<Self> {
+    pub fn weekly(
+        window: &RateWindow,
+        now: Option<DateTime<Utc>>,
+        default_window_minutes: u32,
+    ) -> Option<Self> {
         let now = now.unwrap_or_else(Utc::now);
         let resets_at = window.resets_at?;
         let minutes = window.window_minutes.unwrap_or(default_window_minutes);

--- a/rust/src/core/usage_snapshot.rs
+++ b/rust/src/core/usage_snapshot.rs
@@ -102,7 +102,10 @@ impl UsageSnapshot {
     pub fn any_exhausted(&self) -> bool {
         self.primary.is_exhausted()
             || self.secondary.as_ref().is_some_and(|w| w.is_exhausted())
-            || self.model_specific.as_ref().is_some_and(|w| w.is_exhausted())
+            || self
+                .model_specific
+                .as_ref()
+                .is_some_and(|w| w.is_exhausted())
     }
 }
 

--- a/rust/src/core/widget_snapshot.rs
+++ b/rust/src/core/widget_snapshot.rs
@@ -349,8 +349,8 @@ mod tests {
 
     #[test]
     fn test_widget_provider_entry() {
-        let entry = WidgetProviderEntry::new(ProviderId::Claude, Utc::now())
-            .with_credits_remaining(100.0);
+        let entry =
+            WidgetProviderEntry::new(ProviderId::Claude, Utc::now()).with_credits_remaining(100.0);
 
         assert_eq!(entry.provider, ProviderId::Claude);
         assert_eq!(entry.credits_remaining, Some(100.0));

--- a/rust/src/cost_scanner.rs
+++ b/rust/src/cost_scanner.rs
@@ -65,12 +65,13 @@ struct ClaudePricing;
 
 impl ClaudePricing {
     fn cost_usd(model: &str, input: u64, cache_create: u64, cache_read: u64, output: u64) -> f64 {
-        let (input_price, cache_create_price, cache_read_price, output_price) = match model.to_lowercase().as_str() {
-            m if m.contains("opus") => (15.00, 18.75, 1.50, 75.00),
-            m if m.contains("sonnet") => (3.00, 3.75, 0.30, 15.00),
-            m if m.contains("haiku") => (0.25, 0.30, 0.03, 1.25),
-            _ => (3.00, 3.75, 0.30, 15.00), // Default to Sonnet
-        };
+        let (input_price, cache_create_price, cache_read_price, output_price) =
+            match model.to_lowercase().as_str() {
+                m if m.contains("opus") => (15.00, 18.75, 1.50, 75.00),
+                m if m.contains("sonnet") => (3.00, 3.75, 0.30, 15.00),
+                m if m.contains("haiku") => (0.25, 0.30, 0.03, 1.25),
+                _ => (3.00, 3.75, 0.30, 15.00), // Default to Sonnet
+            };
 
         let input_cost = (input as f64 / 1_000_000.0) * input_price;
         let cache_create_cost = (cache_create as f64 / 1_000_000.0) * cache_create_price;
@@ -250,9 +251,18 @@ impl CostScanner {
                 // Check for token_count events
                 if let Some(event_msg) = event.get("event_msg") {
                     if event_msg.get("type").and_then(|t| t.as_str()) == Some("token_count") {
-                        let input = event_msg.get("input_tokens").and_then(|t| t.as_u64()).unwrap_or(0);
-                        let cached = event_msg.get("cached_input_tokens").and_then(|t| t.as_u64()).unwrap_or(0);
-                        let output = event_msg.get("output_tokens").and_then(|t| t.as_u64()).unwrap_or(0);
+                        let input = event_msg
+                            .get("input_tokens")
+                            .and_then(|t| t.as_u64())
+                            .unwrap_or(0);
+                        let cached = event_msg
+                            .get("cached_input_tokens")
+                            .and_then(|t| t.as_u64())
+                            .unwrap_or(0);
+                        let output = event_msg
+                            .get("output_tokens")
+                            .and_then(|t| t.as_u64())
+                            .unwrap_or(0);
 
                         summary.input_tokens += input;
                         summary.cached_tokens += cached;
@@ -313,21 +323,40 @@ impl CostScanner {
                 // Look for assistant messages with usage
                 if event.get("type").and_then(|t| t.as_str()) == Some("assistant") {
                     if let Some(message) = event.get("message") {
-                        let model = message.get("model")
+                        let model = message
+                            .get("model")
                             .and_then(|m| m.as_str())
                             .unwrap_or("claude-3-5-sonnet");
 
                         if let Some(usage) = message.get("usage") {
-                            let input = usage.get("input_tokens").and_then(|t| t.as_u64()).unwrap_or(0);
-                            let output = usage.get("output_tokens").and_then(|t| t.as_u64()).unwrap_or(0);
-                            let cache_create = usage.get("cache_creation_input_tokens").and_then(|t| t.as_u64()).unwrap_or(0);
-                            let cache_read = usage.get("cache_read_input_tokens").and_then(|t| t.as_u64()).unwrap_or(0);
+                            let input = usage
+                                .get("input_tokens")
+                                .and_then(|t| t.as_u64())
+                                .unwrap_or(0);
+                            let output = usage
+                                .get("output_tokens")
+                                .and_then(|t| t.as_u64())
+                                .unwrap_or(0);
+                            let cache_create = usage
+                                .get("cache_creation_input_tokens")
+                                .and_then(|t| t.as_u64())
+                                .unwrap_or(0);
+                            let cache_read = usage
+                                .get("cache_read_input_tokens")
+                                .and_then(|t| t.as_u64())
+                                .unwrap_or(0);
 
                             summary.input_tokens += input;
                             summary.output_tokens += output;
                             summary.cached_tokens += cache_create + cache_read;
 
-                            let cost = ClaudePricing::cost_usd(model, input, cache_create, cache_read, output);
+                            let cost = ClaudePricing::cost_usd(
+                                model,
+                                input,
+                                cache_create,
+                                cache_read,
+                                output,
+                            );
                             session_cost += cost;
                             has_tokens = true;
 
@@ -434,9 +463,18 @@ fn scan_codex_file_cost(path: &PathBuf) -> f64 {
 
             if let Some(event_msg) = event.get("event_msg") {
                 if event_msg.get("type").and_then(|t| t.as_str()) == Some("token_count") {
-                    let input = event_msg.get("input_tokens").and_then(|t| t.as_u64()).unwrap_or(0);
-                    let cached = event_msg.get("cached_input_tokens").and_then(|t| t.as_u64()).unwrap_or(0);
-                    let output = event_msg.get("output_tokens").and_then(|t| t.as_u64()).unwrap_or(0);
+                    let input = event_msg
+                        .get("input_tokens")
+                        .and_then(|t| t.as_u64())
+                        .unwrap_or(0);
+                    let cached = event_msg
+                        .get("cached_input_tokens")
+                        .and_then(|t| t.as_u64())
+                        .unwrap_or(0);
+                    let output = event_msg
+                        .get("output_tokens")
+                        .and_then(|t| t.as_u64())
+                        .unwrap_or(0);
 
                     total_cost += CodexPricing::cost_usd(&current_model, input, cached, output);
                 }

--- a/rust/src/host/command_runner.rs
+++ b/rust/src/host/command_runner.rs
@@ -253,7 +253,9 @@ impl CommandRunner {
                     last_output_time = Instant::now();
 
                     // Check stop conditions
-                    if options.stop_on_url && (line.contains("https://") || line.contains("http://")) {
+                    if options.stop_on_url
+                        && (line.contains("https://") || line.contains("http://"))
+                    {
                         std::thread::sleep(options.settle_after_stop);
                         break;
                     }
@@ -293,9 +295,7 @@ impl CommandRunner {
         let env = self.env_additions.clone();
 
         tokio::task::spawn_blocking(move || {
-            let runner = CommandRunner {
-                env_additions: env,
-            };
+            let runner = CommandRunner { env_additions: env };
             runner.run(&binary, input.as_deref(), &options)
         })
         .await

--- a/rust/src/host/mod.rs
+++ b/rust/src/host/mod.rs
@@ -4,4 +4,6 @@ pub mod command_runner;
 
 // Re-exports for future CLI integration
 #[allow(unused_imports)]
-pub use command_runner::{CommandError, CommandOptions, CommandResult, CommandRunner, RollingBuffer};
+pub use command_runner::{
+    CommandError, CommandOptions, CommandResult, CommandRunner, RollingBuffer,
+};

--- a/rust/src/login.rs
+++ b/rust/src/login.rs
@@ -4,9 +4,9 @@
 
 #![allow(dead_code)]
 
-use std::process::{Command, Stdio};
-use std::io::{BufRead, BufReader};
 use regex_lite::Regex;
+use std::io::{BufRead, BufReader};
+use std::process::{Command, Stdio};
 
 /// Result of a login attempt
 #[derive(Debug, Clone)]
@@ -40,11 +40,18 @@ pub async fn run_claude_login<F>(timeout_secs: u64, on_phase: F) -> LoginResult
 where
     F: Fn(LoginPhase) + Send + 'static,
 {
-    run_cli_login("claude", &["/login"], timeout_secs, on_phase, &[
-        "Successfully logged in",
-        "Login successful",
-        "Logged in successfully",
-    ]).await
+    run_cli_login(
+        "claude",
+        &["/login"],
+        timeout_secs,
+        on_phase,
+        &[
+            "Successfully logged in",
+            "Login successful",
+            "Logged in successfully",
+        ],
+    )
+    .await
 }
 
 /// Run Codex CLI login
@@ -52,11 +59,18 @@ pub async fn run_codex_login<F>(timeout_secs: u64, on_phase: F) -> LoginResult
 where
     F: Fn(LoginPhase) + Send + 'static,
 {
-    run_cli_login("codex", &["auth", "login"], timeout_secs, on_phase, &[
-        "Successfully logged in",
-        "Login successful",
-        "Logged in successfully",
-    ]).await
+    run_cli_login(
+        "codex",
+        &["auth", "login"],
+        timeout_secs,
+        on_phase,
+        &[
+            "Successfully logged in",
+            "Login successful",
+            "Logged in successfully",
+        ],
+    )
+    .await
 }
 
 /// Run Gemini/gcloud login
@@ -64,10 +78,14 @@ pub async fn run_gemini_login<F>(timeout_secs: u64, on_phase: F) -> LoginResult
 where
     F: Fn(LoginPhase) + Send + 'static,
 {
-    run_cli_login("gcloud", &["auth", "login"], timeout_secs, on_phase, &[
-        "You are now logged in",
-        "Credentials saved",
-    ]).await
+    run_cli_login(
+        "gcloud",
+        &["auth", "login"],
+        timeout_secs,
+        on_phase,
+        &["You are now logged in", "Credentials saved"],
+    )
+    .await
 }
 
 /// Run Copilot/GitHub device flow login
@@ -75,10 +93,14 @@ pub async fn run_copilot_login<F>(timeout_secs: u64, on_phase: F) -> LoginResult
 where
     F: Fn(LoginPhase) + Send + 'static,
 {
-    run_cli_login("gh", &["auth", "login", "-w"], timeout_secs, on_phase, &[
-        "Logged in as",
-        "Authentication complete",
-    ]).await
+    run_cli_login(
+        "gh",
+        &["auth", "login", "-w"],
+        timeout_secs,
+        on_phase,
+        &["Logged in as", "Authentication complete"],
+    )
+    .await
 }
 
 /// Generic CLI login runner

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -58,10 +58,14 @@ fn main() {
     let log_path = std::env::temp_dir().join("codexbar_launch.log");
     let args: Vec<String> = std::env::args().collect();
     let redacted_args = redact_sensitive_args(&args);
-    let _ = std::fs::write(&log_path, format!("main() started at {:?}\nArgs: {:?}\n",
-        std::time::SystemTime::now(),
-        redacted_args
-    ));
+    let _ = std::fs::write(
+        &log_path,
+        format!(
+            "main() started at {:?}\nArgs: {:?}\n",
+            std::time::SystemTime::now(),
+            redacted_args
+        ),
+    );
 
     let exit_code = run();
 
@@ -103,28 +107,24 @@ fn run() -> i32 {
     };
 
     match cli.command {
-        Some(Commands::Usage(args)) => {
-            rt.block_on(async {
-                match cli::usage::run(args).await {
-                    Ok(()) => exit_codes::SUCCESS,
-                    Err(e) => {
-                        eprintln!("Error: {}", e);
-                        categorize_error(&e)
-                    }
+        Some(Commands::Usage(args)) => rt.block_on(async {
+            match cli::usage::run(args).await {
+                Ok(()) => exit_codes::SUCCESS,
+                Err(e) => {
+                    eprintln!("Error: {}", e);
+                    categorize_error(&e)
                 }
-            })
-        }
-        Some(Commands::Cost(args)) => {
-            rt.block_on(async {
-                match cli::cost::run(args).await {
-                    Ok(()) => exit_codes::SUCCESS,
-                    Err(e) => {
-                        eprintln!("Error: {}", e);
-                        categorize_error(&e)
-                    }
+            }
+        }),
+        Some(Commands::Cost(args)) => rt.block_on(async {
+            match cli::cost::run(args).await {
+                Ok(()) => exit_codes::SUCCESS,
+                Err(e) => {
+                    eprintln!("Error: {}", e);
+                    categorize_error(&e)
                 }
-            })
-        }
+            }
+        }),
         Some(Commands::Menubar) => {
             // Hide the console window for GUI mode
             #[cfg(windows)]
@@ -144,44 +144,41 @@ fn run() -> i32 {
                 Err(_) => exit_codes::UNEXPECTED_FAILURE,
             }
         }
-        Some(Commands::Autostart(args)) => {
-            rt.block_on(async {
-                match cli::autostart::run(args).await {
-                    Ok(()) => exit_codes::SUCCESS,
-                    Err(e) => {
-                        eprintln!("Error: {}", e);
-                        exit_codes::UNEXPECTED_FAILURE
-                    }
+        Some(Commands::Autostart(args)) => rt.block_on(async {
+            match cli::autostart::run(args).await {
+                Ok(()) => exit_codes::SUCCESS,
+                Err(e) => {
+                    eprintln!("Error: {}", e);
+                    exit_codes::UNEXPECTED_FAILURE
                 }
-            })
-        }
-        Some(Commands::Account(args)) => {
-            rt.block_on(async {
-                match cli::account::run(args).await {
-                    Ok(()) => exit_codes::SUCCESS,
-                    Err(e) => {
-                        eprintln!("Error: {}", e);
-                        exit_codes::UNEXPECTED_FAILURE
-                    }
+            }
+        }),
+        Some(Commands::Account(args)) => rt.block_on(async {
+            match cli::account::run(args).await {
+                Ok(()) => exit_codes::SUCCESS,
+                Err(e) => {
+                    eprintln!("Error: {}", e);
+                    exit_codes::UNEXPECTED_FAILURE
                 }
-            })
-        }
-        Some(Commands::Config(args)) => {
-            rt.block_on(async {
-                match cli::config::run(args).await {
-                    Ok(()) => exit_codes::SUCCESS,
-                    Err(e) => {
-                        eprintln!("Error: {}", e);
-                        exit_codes::UNEXPECTED_FAILURE
-                    }
+            }
+        }),
+        Some(Commands::Config(args)) => rt.block_on(async {
+            match cli::config::run(args).await {
+                Ok(()) => exit_codes::SUCCESS,
+                Err(e) => {
+                    eprintln!("Error: {}", e);
+                    exit_codes::UNEXPECTED_FAILURE
                 }
-            })
-        }
+            }
+        }),
         None => {
             // Default: launch menubar GUI
             // Log to file since we can't see console output
             let log_path = std::env::temp_dir().join("codexbar_launch.log");
-            let _ = std::fs::write(&log_path, format!("Starting at {:?}\n", std::time::SystemTime::now()));
+            let _ = std::fs::write(
+                &log_path,
+                format!("Starting at {:?}\n", std::time::SystemTime::now()),
+            );
 
             let _guard = match single_instance::SingleInstanceGuard::try_acquire() {
                 Some(guard) => guard,

--- a/rust/src/native_ui/app.rs
+++ b/rust/src/native_ui/app.rs
@@ -1,7 +1,9 @@
 //! Main egui application - Modern refined menubar popup
 //! Clean, spacious design with rich visual hierarchy
 
-use eframe::egui::{self, Color32, FontData, FontDefinitions, FontFamily, Rect, RichText, Rounding, Stroke, Vec2};
+use eframe::egui::{
+    self, Color32, FontData, FontDefinitions, FontFamily, Rect, RichText, Rounding, Stroke, Vec2,
+};
 use std::sync::mpsc::{self, Receiver};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
@@ -13,19 +15,21 @@ use super::charts::{
 use super::preferences::PreferencesWindow;
 use super::provider_icons::ProviderIconCache;
 use super::theme::{provider_color, provider_icon, status_color, FontSize, Radius, Spacing, Theme};
+use crate::browser::cookies::get_cookie_header;
 use crate::core::{
-    FetchContext, OpenAIDashboardCacheStore, PersonalInfoRedactor, Provider, ProviderId,
-    ProviderFetchResult, RateWindow,
+    FetchContext, OpenAIDashboardCacheStore, PersonalInfoRedactor, Provider, ProviderFetchResult,
+    ProviderId, RateWindow,
 };
 use crate::core::{TokenAccountStore, TokenAccountSupport};
 use crate::cost_scanner::get_daily_cost_history;
 use crate::login::LoginPhase;
 use crate::providers::*;
 use crate::settings::{ApiKeys, ManualCookies, Settings};
-use crate::browser::cookies::get_cookie_header;
 use crate::shortcuts::{parse_shortcut, ShortcutManager};
 use crate::status::{fetch_provider_status, get_status_page_url, StatusLevel};
-use crate::tray::{LoadingPattern, ProviderUsage, SurpriseAnimation, TrayMenuAction, UnifiedTrayManager};
+use crate::tray::{
+    LoadingPattern, ProviderUsage, SurpriseAnimation, TrayMenuAction, UnifiedTrayManager,
+};
 use crate::updater::{self, UpdateInfo, UpdateState};
 
 #[cfg(windows)]
@@ -52,9 +56,7 @@ fn restore_main_window() {
 #[cfg(windows)]
 fn show_main_window_no_focus() {
     use windows::core::w;
-    use windows::Win32::UI::WindowsAndMessaging::{
-        FindWindowW, ShowWindow, SW_SHOWNOACTIVATE,
-    };
+    use windows::Win32::UI::WindowsAndMessaging::{FindWindowW, ShowWindow, SW_SHOWNOACTIVATE};
 
     unsafe {
         if let Ok(hwnd) = FindWindowW(None, w!("CodexBar")) {
@@ -75,7 +77,7 @@ fn restore_main_window() {}
 pub struct ProviderData {
     pub name: String,
     pub display_name: String,
-    pub account: Option<String>,  // Account email for display
+    pub account: Option<String>, // Account email for display
     pub session_percent: Option<f64>,
     pub session_reset: Option<String>,
     pub weekly_percent: Option<f64>,
@@ -125,7 +127,12 @@ impl ProviderData {
         }
     }
 
-    fn from_result(id: ProviderId, result: &ProviderFetchResult, metadata: &crate::core::ProviderMetadata, reset_time_relative: bool) -> Self {
+    fn from_result(
+        id: ProviderId,
+        result: &ProviderFetchResult,
+        metadata: &crate::core::ProviderMetadata,
+        reset_time_relative: bool,
+    ) -> Self {
         let snapshot = &result.usage;
         let (pace_percent, pace_lasts) = calculate_pace(&snapshot.primary);
 
@@ -141,11 +148,7 @@ impl ProviderData {
                 };
                 (None, Some(remaining), Some(percent))
             } else {
-                (
-                    Some(cost.format_used()),
-                    None,
-                    None,
-                )
+                (Some(cost.format_used()), None, None)
             }
         } else {
             (None, None, None)
@@ -154,13 +157,22 @@ impl ProviderData {
         Self {
             name: id.cli_name().to_string(),
             display_name: id.display_name().to_string(),
-            account: snapshot.account_email.clone(),  // Account email if available
+            account: snapshot.account_email.clone(), // Account email if available
             session_percent: Some(snapshot.primary.used_percent),
-            session_reset: snapshot.primary.resets_at.map(|t| format_reset_time(t, reset_time_relative)),
+            session_reset: snapshot
+                .primary
+                .resets_at
+                .map(|t| format_reset_time(t, reset_time_relative)),
             weekly_percent: snapshot.secondary.as_ref().map(|s| s.used_percent),
-            weekly_reset: snapshot.secondary.as_ref().and_then(|s| s.resets_at.map(|t| format_reset_time(t, reset_time_relative))),
+            weekly_reset: snapshot.secondary.as_ref().and_then(|s| {
+                s.resets_at
+                    .map(|t| format_reset_time(t, reset_time_relative))
+            }),
             model_percent: snapshot.model_specific.as_ref().map(|m| m.used_percent),
-            model_name: snapshot.model_specific.as_ref().and_then(|m| m.reset_description.clone()),
+            model_name: snapshot
+                .model_specific
+                .as_ref()
+                .and_then(|m| m.reset_description.clone()),
             plan: snapshot.login_method.clone(),
             error: None,
             dashboard_url: metadata.dashboard_url.map(|s| s.to_string()),
@@ -207,27 +219,39 @@ impl ProviderData {
     /// Get the preferred metric percent based on the MetricPreference setting
     pub fn get_preferred_metric(&self, pref: crate::settings::MetricPreference) -> f64 {
         match pref {
-            crate::settings::MetricPreference::Session => {
-                self.session_percent.unwrap_or(0.0)
-            }
-            crate::settings::MetricPreference::Weekly => {
-                self.weekly_percent.unwrap_or_else(|| self.session_percent.unwrap_or(0.0))
-            }
-            crate::settings::MetricPreference::Model => {
-                self.model_percent.unwrap_or_else(|| self.session_percent.unwrap_or(0.0))
-            }
+            crate::settings::MetricPreference::Session => self.session_percent.unwrap_or(0.0),
+            crate::settings::MetricPreference::Weekly => self
+                .weekly_percent
+                .unwrap_or_else(|| self.session_percent.unwrap_or(0.0)),
+            crate::settings::MetricPreference::Model => self
+                .model_percent
+                .unwrap_or_else(|| self.session_percent.unwrap_or(0.0)),
             crate::settings::MetricPreference::Credits => {
                 // For credits, we show the credits_percent (remaining as percentage of full scale)
-                self.credits_percent.unwrap_or_else(|| self.session_percent.unwrap_or(0.0))
+                self.credits_percent
+                    .unwrap_or_else(|| self.session_percent.unwrap_or(0.0))
             }
             crate::settings::MetricPreference::Average => {
                 // Average of all available metrics
                 let mut sum = 0.0;
                 let mut count = 0;
-                if let Some(v) = self.session_percent { sum += v; count += 1; }
-                if let Some(v) = self.weekly_percent { sum += v; count += 1; }
-                if let Some(v) = self.model_percent { sum += v; count += 1; }
-                if count > 0 { sum / count as f64 } else { 0.0 }
+                if let Some(v) = self.session_percent {
+                    sum += v;
+                    count += 1;
+                }
+                if let Some(v) = self.weekly_percent {
+                    sum += v;
+                    count += 1;
+                }
+                if let Some(v) = self.model_percent {
+                    sum += v;
+                    count += 1;
+                }
+                if count > 0 {
+                    sum / count as f64
+                } else {
+                    0.0
+                }
             }
             crate::settings::MetricPreference::Automatic => {
                 // Automatic: prefer the highest available metric (most concerning)
@@ -325,7 +349,10 @@ fn usage_display_label(display_percent: f64, show_as_used: bool) -> String {
     }
 }
 
-fn load_usage_breakdown_points(provider_id: ProviderId, account_email: Option<&str>) -> Vec<UsageBreakdownPoint> {
+fn load_usage_breakdown_points(
+    provider_id: ProviderId,
+    account_email: Option<&str>,
+) -> Vec<UsageBreakdownPoint> {
     if provider_id != ProviderId::Codex {
         return Vec::new();
     }
@@ -414,7 +441,8 @@ impl CodexBarApp {
                 "segoe_symbols".to_owned(),
                 FontData::from_owned(font_data).into(),
             );
-            fonts.families
+            fonts
+                .families
                 .entry(FontFamily::Proportional)
                 .or_default()
                 .push("segoe_symbols".to_owned());
@@ -502,7 +530,9 @@ impl CodexBarApp {
                     }
                 };
                 rt.block_on(async {
-                    if let Some(update) = updater::check_for_updates_with_channel(update_channel).await {
+                    if let Some(update) =
+                        updater::check_for_updates_with_channel(update_channel).await
+                    {
                         let should_download = {
                             if let Ok(mut s) = state.lock() {
                                 s.update_available = Some(update.clone());
@@ -516,7 +546,8 @@ impl CodexBarApp {
 
                         // Start background download if auto-download is enabled
                         if should_download {
-                            let (progress_tx, mut progress_rx) = tokio::sync::watch::channel(UpdateState::Available);
+                            let (progress_tx, mut progress_rx) =
+                                tokio::sync::watch::channel(UpdateState::Available);
                             let state_clone = Arc::clone(&state);
 
                             // Update state to downloading
@@ -562,9 +593,16 @@ impl CodexBarApp {
                 // Apply custom shortcut from settings if configured
                 if let Some((modifiers, key)) = parse_shortcut(&settings.global_shortcut) {
                     if let Err(e) = sm.set_open_menu_shortcut(modifiers, key) {
-                        tracing::warn!("Failed to set custom shortcut '{}': {}", settings.global_shortcut, e);
+                        tracing::warn!(
+                            "Failed to set custom shortcut '{}': {}",
+                            settings.global_shortcut,
+                            e
+                        );
                     } else {
-                        tracing::info!("Keyboard shortcut registered: {}", settings.global_shortcut);
+                        tracing::info!(
+                            "Keyboard shortcut registered: {}",
+                            settings.global_shortcut
+                        );
                     }
                 } else {
                     tracing::info!("Keyboard shortcut registered: Ctrl+Shift+U (default)");
@@ -717,12 +755,14 @@ impl CodexBarApp {
                     .enumerate()
                     .map(|(idx, &id)| {
                         // Check for active token account first
-                        let active_token = token_accounts.get(&id)
+                        let active_token = token_accounts
+                            .get(&id)
                             .and_then(|data| data.active_account())
                             .map(|account| account.token.clone());
 
                         // Check for environment override from token account (e.g., for Zai/Claude OAuth)
-                        let env_override = active_token.as_ref()
+                        let env_override = active_token
+                            .as_ref()
                             .and_then(|token| TokenAccountSupport::env_override(id, token));
 
                         // Set env override if present - providers will read from env vars
@@ -743,7 +783,8 @@ impl CodexBarApp {
                             Some(TokenAccountSupport::normalized_cookie_header(id, token))
                         } else {
                             // Fallback to manual cookie or browser extraction
-                            let manual_cookie = manual_cookies.get(id.cli_name()).map(|s| s.to_string());
+                            let manual_cookie =
+                                manual_cookies.get(id.cli_name()).map(|s| s.to_string());
                             manual_cookie.or_else(|| {
                                 // Try browser cookie extraction if no manual cookie
                                 id.cookie_domain().and_then(|domain| {
@@ -754,7 +795,9 @@ impl CodexBarApp {
 
                         let api_key = if env_override.is_some() {
                             // If we have env override, extract API key from it
-                            env_override.as_ref().and_then(|env| env.values().next().cloned())
+                            env_override
+                                .as_ref()
+                                .and_then(|env| env.values().next().cloned())
                         } else {
                             api_keys.get(id.cli_name()).map(|s| s.to_string())
                         };
@@ -774,19 +817,26 @@ impl CodexBarApp {
                                 async {
                                     tokio::time::timeout(
                                         std::time::Duration::from_secs(5),
-                                        provider.fetch_usage(&ctx)
-                                    ).await
+                                        provider.fetch_usage(&ctx),
+                                    )
+                                    .await
                                 },
                                 async {
                                     tokio::time::timeout(
                                         std::time::Duration::from_secs(5),
-                                        fetch_provider_status(&provider_name)
-                                    ).await
+                                        fetch_provider_status(&provider_name),
+                                    )
+                                    .await
                                 }
                             );
 
                             let mut result = match usage_result {
-                                Ok(Ok(result)) => ProviderData::from_result(id, &result, &metadata, reset_time_relative),
+                                Ok(Ok(result)) => ProviderData::from_result(
+                                    id,
+                                    &result,
+                                    &metadata,
+                                    reset_time_relative,
+                                ),
                                 Ok(Err(e)) => ProviderData::from_error(id, e.to_string()),
                                 Err(_) => ProviderData::from_error(id, "Timeout".to_string()),
                             };
@@ -797,12 +847,14 @@ impl CodexBarApp {
                             }
 
                             if result.error.is_none() {
-                                result.usage_breakdown = load_usage_breakdown_points(id, result.account.as_deref());
+                                result.usage_breakdown =
+                                    load_usage_breakdown_points(id, result.account.as_deref());
                             }
 
                             let provider_name_lower = provider_name.to_lowercase();
                             if provider_name_lower == "codex" || provider_name_lower == "claude" {
-                                result.cost_history = get_daily_cost_history(&provider_name_lower, 30);
+                                result.cost_history =
+                                    get_daily_cost_history(&provider_name_lower, 30);
                             }
 
                             if let Ok(mut s) = state.lock() {
@@ -866,8 +918,14 @@ fn work_area_rect(ctx: &egui::Context) -> Option<Rect> {
         if ok {
             let pixels_per_point = ctx.pixels_per_point().max(0.1);
             return Some(Rect::from_min_max(
-                egui::pos2(rect.left as f32 / pixels_per_point, rect.top as f32 / pixels_per_point),
-                egui::pos2(rect.right as f32 / pixels_per_point, rect.bottom as f32 / pixels_per_point),
+                egui::pos2(
+                    rect.left as f32 / pixels_per_point,
+                    rect.top as f32 / pixels_per_point,
+                ),
+                egui::pos2(
+                    rect.right as f32 / pixels_per_point,
+                    rect.bottom as f32 / pixels_per_point,
+                ),
             ));
         }
     }
@@ -1015,7 +1073,9 @@ impl eframe::App for CodexBarApp {
             if self.settings.refresh_interval_secs == 0 {
                 false
             } else if let Ok(state) = self.state.lock() {
-                !state.is_refreshing && state.last_refresh.elapsed() > Duration::from_secs(self.settings.refresh_interval_secs)
+                !state.is_refreshing
+                    && state.last_refresh.elapsed()
+                        > Duration::from_secs(self.settings.refresh_interval_secs)
             } else {
                 false
             }
@@ -1025,7 +1085,18 @@ impl eframe::App for CodexBarApp {
         }
 
         // Get state
-        let (providers, selected_idx, overview_active, is_refreshing, loading_pattern, loading_phase, surprise_state, update_info, update_download_state, login_state) = {
+        let (
+            providers,
+            selected_idx,
+            overview_active,
+            is_refreshing,
+            loading_pattern,
+            loading_phase,
+            surprise_state,
+            update_info,
+            update_download_state,
+            login_state,
+        ) = {
             if let Ok(mut state) = self.state.lock() {
                 if state.is_refreshing {
                     state.loading_phase += 0.05;
@@ -1071,20 +1142,44 @@ impl eframe::App for CodexBarApp {
                     state.login_message.clone(),
                 );
 
-                (state.providers.clone(), state.selected_provider_idx, state.overview_selected, state.is_refreshing, state.loading_pattern, state.loading_phase, surprise, update, update_download_state, login_state)
+                (
+                    state.providers.clone(),
+                    state.selected_provider_idx,
+                    state.overview_selected,
+                    state.is_refreshing,
+                    state.loading_pattern,
+                    state.loading_phase,
+                    surprise,
+                    update,
+                    update_download_state,
+                    login_state,
+                )
             } else {
-                (Vec::new(), 0, false, false, LoadingPattern::default(), 0.0, None, None, UpdateState::Idle, (None, LoginPhase::Idle, None))
+                (
+                    Vec::new(),
+                    0,
+                    false,
+                    false,
+                    LoadingPattern::default(),
+                    0.0,
+                    None,
+                    None,
+                    UpdateState::Idle,
+                    (None, LoginPhase::Idle, None),
+                )
             }
         };
 
         let (_login_provider, login_phase, _login_message) = login_state;
         let is_logging_in = _login_provider.is_some() && login_phase != LoginPhase::Idle;
 
-        ctx.request_repaint_after(if is_refreshing || surprise_state.is_some() || is_logging_in {
-            Duration::from_millis(50)
-        } else {
-            Duration::from_millis(200)
-        });
+        ctx.request_repaint_after(
+            if is_refreshing || surprise_state.is_some() || is_logging_in {
+                Duration::from_millis(50)
+            } else {
+                Duration::from_millis(200)
+            },
+        );
 
         // Update tray icon
         if let Some(ref tray) = self.tray_manager {
@@ -1111,11 +1206,12 @@ impl eframe::App for CodexBarApp {
                         let preferred_percent = p.get_preferred_metric(metric_pref);
                         // For credits metric, convert from "remaining" to "used" for consistent tray behavior
                         // Credits are stored as remaining %, but tray expects used % for severity coloring
-                        let used_percent = if metric_pref == crate::settings::MetricPreference::Credits {
-                            100.0 - preferred_percent // Convert remaining to used
-                        } else {
-                            preferred_percent // Already used %
-                        };
+                        let used_percent =
+                            if metric_pref == crate::settings::MetricPreference::Credits {
+                                100.0 - preferred_percent // Convert remaining to used
+                            } else {
+                                preferred_percent // Already used %
+                            };
                         // Weekly percent is always usage-based (not credits)
                         let weekly_percent = p.weekly_percent.unwrap_or(used_percent);
                         ProviderUsage {
@@ -1130,7 +1226,9 @@ impl eframe::App for CodexBarApp {
                     "minimal" => {
                         // Minimal: show only the highest-usage provider's session bar
                         if let Some(p) = provider_usages.iter().max_by(|a, b| {
-                            a.session_percent.partial_cmp(&b.session_percent).unwrap_or(std::cmp::Ordering::Equal)
+                            a.session_percent
+                                .partial_cmp(&b.session_percent)
+                                .unwrap_or(std::cmp::Ordering::Equal)
                         }) {
                             tray.update_usage(p.session_percent, p.weekly_percent, &p.name);
                         }
@@ -1172,7 +1270,9 @@ impl eframe::App for CodexBarApp {
                     TrayMenuAction::Settings => {
                         self.preferences_window.open();
                         // Move main window off-screen so only settings viewport is visible.
-                        ctx.send_viewport_cmd(egui::ViewportCommand::OuterPosition(egui::pos2(-10000.0, -10000.0)));
+                        ctx.send_viewport_cmd(egui::ViewportCommand::OuterPosition(egui::pos2(
+                            -10000.0, -10000.0,
+                        )));
                     }
                     TrayMenuAction::CheckForUpdates => {
                         // Trigger update check in background
@@ -1187,7 +1287,9 @@ impl eframe::App for CodexBarApp {
                                 }
                             };
                             rt.block_on(async {
-                                if let Some(update) = updater::check_for_updates_with_channel(update_channel).await {
+                                if let Some(update) =
+                                    updater::check_for_updates_with_channel(update_channel).await
+                                {
                                     if let Ok(mut s) = state.lock() {
                                         s.update_available = Some(update);
                                         s.update_checked = true;
@@ -1214,13 +1316,21 @@ impl eframe::App for CodexBarApp {
             }
         }
 
+        // Apply theme mode from settings
+        Theme::set_dark(self.settings.theme_mode.is_dark());
+
         // Apply refined style
         let mut style = (*ctx.style()).clone();
-        style.visuals.window_fill = Theme::BG_PRIMARY;
-        style.visuals.panel_fill = Theme::BG_PRIMARY;
-        style.visuals.widgets.noninteractive.bg_fill = Theme::BG_SECONDARY;
-        style.visuals.widgets.inactive.bg_fill = Theme::CARD_BG;
-        style.visuals.widgets.hovered.bg_fill = Theme::CARD_BG_HOVER;
+        style.visuals = if Theme::is_dark() {
+            egui::Visuals::dark()
+        } else {
+            egui::Visuals::light()
+        };
+        style.visuals.window_fill = Theme::bg_primary();
+        style.visuals.panel_fill = Theme::bg_primary();
+        style.visuals.widgets.noninteractive.bg_fill = Theme::bg_secondary();
+        style.visuals.widgets.inactive.bg_fill = Theme::card_bg();
+        style.visuals.widgets.hovered.bg_fill = Theme::card_bg_hover();
         style.visuals.widgets.active.bg_fill = Theme::ACCENT_PRIMARY;
         style.visuals.selection.bg_fill = Theme::selection_overlay();
         style.visuals.selection.stroke = Stroke::new(1.0, Theme::ACCENT_PRIMARY);
@@ -1234,7 +1344,7 @@ impl eframe::App for CodexBarApp {
         });
 
         egui::CentralPanel::default()
-            .frame(egui::Frame::none().fill(Theme::BG_PRIMARY).inner_margin(Spacing::SM))
+            .frame(egui::Frame::none().fill(Theme::bg_primary()).inner_margin(Spacing::SM))
             .show(ctx, |ui| {
                 egui::ScrollArea::vertical()
                     .auto_shrink([false, false])
@@ -1454,11 +1564,11 @@ impl eframe::App for CodexBarApp {
                                             ui.painter().rect_filled(
                                                 rect,
                                                 Rounding::same(Radius::SM),
-                                                Theme::CARD_BG_HOVER,
+                                                Theme::card_bg_hover(),
                                             );
                                         }
 
-                                        let icon_color = if is_selected { Color32::WHITE } else { Theme::TEXT_SECONDARY };
+                                        let icon_color = if is_selected { Color32::WHITE } else { Theme::text_secondary() };
                                         let icon_center_y = rect.min.y + 14.0;
                                         ui.painter().text(
                                             egui::pos2(rect.center().x, icon_center_y),
@@ -1468,7 +1578,7 @@ impl eframe::App for CodexBarApp {
                                             icon_color,
                                         );
 
-                                        let text_color = if is_selected { Color32::WHITE } else { Theme::TEXT_SECONDARY };
+                                        let text_color = if is_selected { Color32::WHITE } else { Theme::text_secondary() };
                                         ui.painter().text(
                                             egui::pos2(rect.center().x, rect.min.y + 32.0),
                                             egui::Align2::CENTER_CENTER,
@@ -1508,7 +1618,7 @@ impl eframe::App for CodexBarApp {
                                             ui.painter().rect_filled(
                                                 rect,
                                                 Rounding::same(Radius::SM),
-                                                Theme::CARD_BG_HOVER,
+                                                Theme::card_bg_hover(),
                                             );
                                         }
 
@@ -1541,7 +1651,7 @@ impl eframe::App for CodexBarApp {
                                         }
 
                                         // Provider name below icon
-                                        let text_color = if is_selected { Color32::WHITE } else { Theme::TEXT_SECONDARY };
+                                        let text_color = if is_selected { Color32::WHITE } else { Theme::text_secondary() };
                                         let name_y = rect.min.y + 32.0;
                                         // Truncate long names
                                         let display_name = if provider.display_name.len() > 7 {
@@ -1590,7 +1700,7 @@ impl eframe::App for CodexBarApp {
                             ui.painter().hline(
                                 sep_rect.x_range(),
                                 sep_rect.top(),
-                                Stroke::new(1.0, Theme::SEPARATOR),
+                                Stroke::new(1.0, Theme::separator()),
                             );
                             ui.add_space(2.0);
 
@@ -1618,11 +1728,11 @@ impl eframe::App for CodexBarApp {
                                         ui.add_space(Spacing::LG);
                                         ui.label(RichText::new("No providers selected for Overview")
                                             .size(FontSize::SM)
-                                            .color(Theme::TEXT_MUTED));
+                                            .color(Theme::text_muted()));
                                         ui.add_space(Spacing::SM);
                                         ui.label(RichText::new("Configure in Settings → Display")
                                             .size(FontSize::XS)
-                                            .color(Theme::TEXT_MUTED));
+                                            .color(Theme::text_muted()));
                                     });
                                 } else {
                                     for provider in &overview_data {
@@ -1669,10 +1779,10 @@ impl eframe::App for CodexBarApp {
                             }
                         } else if is_refreshing {
                             egui::Frame::none()
-                                .fill(Theme::CARD_BG)
+                                .fill(Theme::card_bg())
                                 .rounding(Rounding::same(Radius::LG))
                                 .inner_margin(Spacing::XXL)
-                                .stroke(Stroke::new(1.0, Theme::CARD_BORDER))
+                                .stroke(Stroke::new(1.0, Theme::card_border()))
                                 .show(ui, |ui| {
                                     ui.vertical_centered(|ui| {
                                         ui.spinner();
@@ -1680,22 +1790,22 @@ impl eframe::App for CodexBarApp {
                                         ui.label(
                                             RichText::new("Loading providers...")
                                                 .size(FontSize::BASE)
-                                                .color(Theme::TEXT_MUTED),
+                                                .color(Theme::text_muted()),
                                         );
                                     });
                                 });
                         } else {
                             egui::Frame::none()
-                                .fill(Theme::CARD_BG)
+                                .fill(Theme::card_bg())
                                 .rounding(Rounding::same(Radius::LG))
                                 .inner_margin(Spacing::XXL)
-                                .stroke(Stroke::new(1.0, Theme::CARD_BORDER))
+                                .stroke(Stroke::new(1.0, Theme::card_border()))
                                 .show(ui, |ui| {
                                     ui.vertical_centered(|ui| {
                                         ui.label(
                                             RichText::new("No provider data available.")
                                                 .size(FontSize::BASE)
-                                                .color(Theme::TEXT_MUTED),
+                                                .color(Theme::text_muted()),
                                         );
                                     });
                                 });
@@ -1703,10 +1813,10 @@ impl eframe::App for CodexBarApp {
                     } else {
                         let has_enabled_providers = !self.settings.get_enabled_provider_ids().is_empty();
                         egui::Frame::none()
-                            .fill(Theme::CARD_BG)
+                            .fill(Theme::card_bg())
                             .rounding(Rounding::same(Radius::LG))
                             .inner_margin(Spacing::XXL)
-                            .stroke(Stroke::new(1.0, Theme::CARD_BORDER))
+                            .stroke(Stroke::new(1.0, Theme::card_border()))
                             .show(ui, |ui| {
                                 ui.vertical_centered(|ui| {
                                     if has_enabled_providers {
@@ -1715,13 +1825,13 @@ impl eframe::App for CodexBarApp {
                                         ui.label(
                                             RichText::new("Loading providers...")
                                                 .size(FontSize::BASE)
-                                                .color(Theme::TEXT_MUTED),
+                                                .color(Theme::text_muted()),
                                         );
                                     } else {
                                         ui.label(
                                             RichText::new("No providers selected.")
                                                 .size(FontSize::BASE)
-                                                .color(Theme::TEXT_MUTED),
+                                                .color(Theme::text_muted()),
                                         );
                                         ui.add_space(Spacing::SM);
                                         if ui.button("Open Provider Settings").clicked() {
@@ -1799,10 +1909,10 @@ fn draw_overview_provider_row(
     let brand_color = provider_color(&provider.name);
 
     egui::Frame::none()
-        .fill(Theme::CARD_BG)
+        .fill(Theme::card_bg())
         .rounding(Rounding::same(Radius::SM))
         .inner_margin(egui::Margin::symmetric(12.0, 8.0))
-        .stroke(Stroke::new(0.5, Theme::CARD_BORDER))
+        .stroke(Stroke::new(0.5, Theme::card_border()))
         .show(ui, |ui| {
             ui.horizontal(|ui| {
                 let icon_char = provider_icon(&provider.name);
@@ -1819,7 +1929,7 @@ fn draw_overview_provider_row(
                         ui.label(
                             RichText::new(&provider.display_name)
                                 .size(FontSize::SM)
-                                .color(Theme::TEXT_PRIMARY)
+                                .color(Theme::text_primary())
                                 .strong(),
                         );
                         ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
@@ -1827,7 +1937,7 @@ fn draw_overview_provider_row(
                                 ui.label(
                                     RichText::new(reset_desc)
                                         .size(FontSize::XS)
-                                        .color(Theme::TEXT_MUTED),
+                                        .color(Theme::text_muted()),
                                 );
                             } else if let Some(error) = &provider.error {
                                 let short = if error.len() > 30 {
@@ -1835,17 +1945,17 @@ fn draw_overview_provider_row(
                                 } else {
                                     error.clone()
                                 };
-                                ui.label(
-                                    RichText::new(short)
-                                        .size(FontSize::XS)
-                                        .color(Theme::RED),
-                                );
+                                ui.label(RichText::new(short).size(FontSize::XS).color(Theme::RED));
                             }
                         });
                     });
 
                     if let Some(percent) = provider.session_percent {
-                        let display_percent = if show_as_used { percent } else { 100.0 - percent };
+                        let display_percent = if show_as_used {
+                            percent
+                        } else {
+                            100.0 - percent
+                        };
                         let bar_width = ui.available_width();
                         let bar_height = 6.0;
                         let (bar_rect, _) = ui.allocate_exact_size(
@@ -1856,13 +1966,23 @@ fn draw_overview_provider_row(
                         ui.painter().rect_filled(
                             bar_rect,
                             Rounding::same(3.0),
-                            Color32::from_rgba_unmultiplied(brand_color.r(), brand_color.g(), brand_color.b(), 40),
+                            Color32::from_rgba_unmultiplied(
+                                brand_color.r(),
+                                brand_color.g(),
+                                brand_color.b(),
+                                40,
+                            ),
                         );
 
-                        let fill_width = bar_rect.width() * (display_percent as f32 / 100.0).clamp(0.0, 1.0);
+                        let fill_width =
+                            bar_rect.width() * (display_percent as f32 / 100.0).clamp(0.0, 1.0);
                         if fill_width > 0.0 {
-                            let fill_rect = Rect::from_min_size(bar_rect.min, Vec2::new(fill_width, bar_height));
-                            ui.painter().rect_filled(fill_rect, Rounding::same(3.0), brand_color);
+                            let fill_rect = Rect::from_min_size(
+                                bar_rect.min,
+                                Vec2::new(fill_width, bar_height),
+                            );
+                            ui.painter()
+                                .rect_filled(fill_rect, Rounding::same(3.0), brand_color);
                         }
                     }
                 });
@@ -1903,23 +2023,23 @@ fn draw_provider_detail_card(
                     ui.label(
                         RichText::new(&provider.display_name)
                             .size(FontSize::BASE) // Slightly smaller
-                            .color(Theme::TEXT_PRIMARY)
+                            .color(Theme::text_primary())
                             .strong(),
                     );
 
                     ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
                         ui.add_space(16.0); // Right padding
-                        // Email - .subheadline, secondary color (redacted if privacy mode enabled)
+                                            // Email - .subheadline, secondary color (redacted if privacy mode enabled)
                         if let Some(account) = &provider.account {
                             let display_account = PersonalInfoRedactor::redact_email(
                                 Some(account.as_str()),
-                                hide_personal_info
+                                hide_personal_info,
                             );
                             if !display_account.is_empty() {
                                 ui.label(
                                     RichText::new(&display_account)
                                         .size(FontSize::XS) // Smaller
-                                        .color(Theme::TEXT_SECONDARY),
+                                        .color(Theme::text_secondary()),
                                 );
                             }
                         }
@@ -1941,25 +2061,27 @@ fn draw_provider_detail_card(
                         ui.label(
                             RichText::new("Updated just now")
                                 .size(FontSize::XS)
-                                .color(Theme::TEXT_SECONDARY),
+                                .color(Theme::text_secondary()),
                         );
                     }
 
                     ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
                         ui.add_space(16.0); // Right padding
-                        // Plan badge - .footnote, secondary
+                                            // Plan badge - .footnote, secondary
                         if let Some(plan) = &provider.plan {
                             ui.label(
                                 RichText::new(plan)
                                     .size(FontSize::XS)
-                                    .color(Theme::TEXT_SECONDARY),
+                                    .color(Theme::text_secondary()),
                             );
                         }
                     });
                 });
 
                 // Row 3: Status description (if non-Operational)
-                if provider.status_level != StatusLevel::Operational && provider.status_level != StatusLevel::Unknown {
+                if provider.status_level != StatusLevel::Operational
+                    && provider.status_level != StatusLevel::Unknown
+                {
                     if let Some(ref status_desc) = provider.status_description {
                         ui.add_space(2.0);
                         ui.horizontal(|ui| {
@@ -1983,7 +2105,8 @@ fn draw_provider_detail_card(
         let has_cost = provider.cost_used.is_some();
         let has_usage_breakdown = !provider.usage_breakdown.is_empty();
 
-        if has_metrics || provider.error.is_some() || has_credits || has_cost || has_usage_breakdown {
+        if has_metrics || provider.error.is_some() || has_credits || has_cost || has_usage_breakdown
+        {
             ui.add_space(4.0);
             draw_horizontal_separator(ui, 0.0);
         }
@@ -2004,7 +2127,7 @@ fn draw_provider_detail_card(
                     provider.session_reset.as_deref(),
                     brand_color,
                     content_width,
-                    None,  // No pace for session
+                    None, // No pace for session
                     false,
                 );
             }
@@ -2039,7 +2162,7 @@ fn draw_provider_detail_card(
                     None,
                     brand_color,
                     content_width,
-                    None,  // No pace for model
+                    None, // No pace for model
                     false,
                 );
             }
@@ -2052,7 +2175,7 @@ fn draw_provider_detail_card(
                 ui.label(
                     RichText::new("Unable to fetch usage")
                         .size(FontSize::SM)
-                        .color(Theme::TEXT_SECONDARY),
+                        .color(Theme::text_secondary()),
                 );
             });
             ui.add_space(2.0);
@@ -2074,22 +2197,28 @@ fn draw_provider_detail_card(
                 ui.label(
                     RichText::new("Credits")
                         .size(FontSize::BASE)
-                        .color(Theme::TEXT_PRIMARY)
-                        .strong()
+                        .color(Theme::text_primary())
+                        .strong(),
                 );
 
                 // Progress bar
                 if let Some(credits_pct) = provider.credits_percent {
                     ui.add_space(6.0);
                     let bar_height = 8.0;
-                    let (rect, _) = ui.allocate_exact_size(Vec2::new(bar_width, bar_height), egui::Sense::hover());
+                    let (rect, _) = ui.allocate_exact_size(
+                        Vec2::new(bar_width, bar_height),
+                        egui::Sense::hover(),
+                    );
 
-                    ui.painter().rect_filled(rect, Rounding::same(4.0), Theme::progress_track());
+                    ui.painter()
+                        .rect_filled(rect, Rounding::same(4.0), Theme::progress_track());
 
                     let fill_w = rect.width() * (credits_pct as f32 / 100.0).clamp(0.0, 1.0);
                     if fill_w > 0.0 {
-                        let fill_rect = Rect::from_min_size(rect.min, Vec2::new(fill_w, bar_height));
-                        ui.painter().rect_filled(fill_rect, Rounding::same(4.0), brand_color);
+                        let fill_rect =
+                            Rect::from_min_size(rect.min, Vec2::new(fill_w, bar_height));
+                        ui.painter()
+                            .rect_filled(fill_rect, Rounding::same(4.0), brand_color);
                     }
                 }
 
@@ -2099,13 +2228,13 @@ fn draw_provider_detail_card(
                     ui.label(
                         RichText::new(format!("{:.2} left", credits))
                             .size(FontSize::XS)
-                            .color(Theme::TEXT_PRIMARY)
+                            .color(Theme::text_primary()),
                     );
                     ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
                         ui.label(
                             RichText::new("1K tokens")
                                 .size(FontSize::XS)
-                                .color(Theme::TEXT_SECONDARY)
+                                .color(Theme::text_secondary()),
                         );
                     });
                 });
@@ -2121,7 +2250,8 @@ fn draw_provider_detail_card(
                 // Credits history chart
                 if !provider.credits_history.is_empty() {
                     ui.add_space(8.0);
-                    let chart_points: Vec<ChartPoint> = provider.credits_history
+                    let chart_points: Vec<ChartPoint> = provider
+                        .credits_history
                         .iter()
                         .map(|(date, value)| ChartPoint::new(date.clone(), *value))
                         .collect();
@@ -2143,7 +2273,7 @@ fn draw_provider_detail_card(
             ui.label(
                 RichText::new("Usage breakdown")
                     .size(FontSize::BASE)
-                    .color(Theme::TEXT_PRIMARY)
+                    .color(Theme::text_primary())
                     .strong(),
             );
             ui.add_space(6.0);
@@ -2155,7 +2285,8 @@ fn draw_provider_detail_card(
         // ═══════════════════════════════════════════════════════════════════
         // COST SECTION - macOS TokenUsageSection style
         // ═══════════════════════════════════════════════════════════════════
-        if show_credits_extra && (provider.cost_used.is_some() || !provider.cost_history.is_empty()) {
+        if show_credits_extra && (provider.cost_used.is_some() || !provider.cost_history.is_empty())
+        {
             if has_metrics || has_credits || has_usage_breakdown {
                 draw_horizontal_separator(ui, 0.0);
             }
@@ -2165,8 +2296,8 @@ fn draw_provider_detail_card(
             ui.label(
                 RichText::new("Cost")
                     .size(FontSize::BASE)
-                    .color(Theme::TEXT_PRIMARY)
-                    .strong()
+                    .color(Theme::text_primary())
+                    .strong(),
             );
 
             ui.add_space(6.0);
@@ -2179,25 +2310,26 @@ fn draw_provider_detail_card(
                 ui.label(
                     RichText::new(format!("Today: ${:.2}", today_cost))
                         .size(FontSize::XS)
-                        .color(Theme::TEXT_PRIMARY)
+                        .color(Theme::text_primary()),
                 );
                 ui.label(
                     RichText::new(format!("Last 30 days: ${:.2}", total_30d))
                         .size(FontSize::XS)
-                        .color(Theme::TEXT_PRIMARY)
+                        .color(Theme::text_primary()),
                 );
             } else if let Some(cost_used) = &provider.cost_used {
                 ui.label(
                     RichText::new(cost_used)
                         .size(FontSize::XS)
-                        .color(Theme::TEXT_PRIMARY)
+                        .color(Theme::text_primary()),
                 );
             }
 
             // Cost history chart
             if !provider.cost_history.is_empty() {
                 ui.add_space(8.0);
-                let chart_points: Vec<ChartPoint> = provider.cost_history
+                let chart_points: Vec<ChartPoint> = provider
+                    .cost_history
                     .iter()
                     .map(|(date, cost)| ChartPoint::new(date.clone(), *cost))
                     .collect();
@@ -2227,7 +2359,7 @@ fn draw_provider_detail_card(
 
             // Switch Account link - only show for providers that support token accounts
             if TokenAccountSupport::is_supported(
-                ProviderId::from_cli_name(&provider.name).unwrap_or(ProviderId::Claude)
+                ProviderId::from_cli_name(&provider.name).unwrap_or(ProviderId::Claude),
             ) {
                 if draw_menu_item(ui, "->", "Switch Account...") {
                     account_switch_requested = Some(provider.name.clone());
@@ -2263,7 +2395,8 @@ fn draw_provider_detail_card(
         }
 
         (refresh_requested, account_switch_requested)
-    }).inner
+    })
+    .inner
 }
 
 /// Draw a horizontal separator with left padding
@@ -2275,7 +2408,7 @@ fn draw_horizontal_separator(ui: &mut egui::Ui, left_padding: f32) {
         ui.painter().hline(
             sep_rect.left()..=(sep_rect.left() + sep_width),
             sep_rect.top(),
-            Stroke::new(1.0, Theme::SEPARATOR),
+            Stroke::new(1.0, Theme::separator()),
         );
     });
 }
@@ -2284,21 +2417,20 @@ fn draw_horizontal_separator(ui: &mut egui::Ui, left_padding: f32) {
 fn draw_text_menu_item(ui: &mut egui::Ui, label: &str) -> bool {
     let available_width = ui.available_width();
 
-    let (rect, response) = ui.allocate_exact_size(
-        Vec2::new(available_width, 24.0),
-        egui::Sense::click(),
-    );
+    let (rect, response) =
+        ui.allocate_exact_size(Vec2::new(available_width, 24.0), egui::Sense::click());
 
     let is_hovered = response.hovered();
 
     if is_hovered {
-        ui.painter().rect_filled(rect, Rounding::same(Radius::SM), Theme::menu_hover());
+        ui.painter()
+            .rect_filled(rect, Rounding::same(Radius::SM), Theme::menu_hover());
     }
 
     let text_color = if is_hovered {
-        Theme::TEXT_PRIMARY
+        Theme::text_primary()
     } else {
-        Theme::TEXT_SECONDARY
+        Theme::text_secondary()
     };
 
     // Label
@@ -2335,7 +2467,7 @@ fn draw_metric_row(
     ui.label(
         RichText::new(title)
             .size(FontSize::BASE)
-            .color(Theme::TEXT_PRIMARY)
+            .color(Theme::text_primary())
             .strong(),
     );
 
@@ -2350,13 +2482,15 @@ fn draw_metric_row(
     let (rect, _) = ui.allocate_exact_size(Vec2::new(bar_width, bar_height), egui::Sense::hover());
 
     // Track
-    ui.painter().rect_filled(rect, Rounding::same(4.0), Theme::progress_track());
+    ui.painter()
+        .rect_filled(rect, Rounding::same(4.0), Theme::progress_track());
 
     // Fill
     let fill_w = rect.width() * (display_percent as f32 / 100.0).clamp(0.0, 1.0);
     if fill_w > 0.0 {
         let fill_rect = Rect::from_min_size(rect.min, Vec2::new(fill_w, bar_height));
-        ui.painter().rect_filled(fill_rect, Rounding::same(4.0), color);
+        ui.painter()
+            .rect_filled(fill_rect, Rounding::same(4.0), color);
     }
 
     // Pace marker - thin vertical line showing expected usage position
@@ -2372,7 +2506,8 @@ fn draw_metric_row(
             egui::pos2(marker_x - marker_width / 2.0, rect.min.y),
             Vec2::new(marker_width, bar_height),
         );
-        ui.painter().rect_filled(marker_rect, Rounding::same(1.0), marker_color);
+        ui.painter()
+            .rect_filled(marker_rect, Rounding::same(1.0), marker_color);
     }
 
     ui.add_space(6.0);
@@ -2382,7 +2517,7 @@ fn draw_metric_row(
         ui.label(
             RichText::new(usage_display_label(display_percent, show_as_used))
                 .size(FontSize::XS)
-                .color(Theme::TEXT_PRIMARY),
+                .color(Theme::text_primary()),
         );
 
         // Pace status indicator
@@ -2405,7 +2540,7 @@ fn draw_metric_row(
                 ui.label(
                     RichText::new(format!("Resets in {}", reset))
                         .size(FontSize::XS)
-                        .color(Theme::TEXT_SECONDARY),
+                        .color(Theme::text_secondary()),
                 );
             }
         });
@@ -2417,20 +2552,21 @@ fn draw_menu_item(ui: &mut egui::Ui, icon: &str, label: &str) -> bool {
     let available_width = ui.available_width();
 
     let (rect, response) = ui.allocate_exact_size(
-        Vec2::new(available_width, 32.0),  // Slightly larger height
+        Vec2::new(available_width, 32.0), // Slightly larger height
         egui::Sense::click(),
     );
 
     let is_hovered = response.hovered();
 
     if is_hovered {
-        ui.painter().rect_filled(rect, Rounding::same(Radius::SM), Theme::menu_hover());
+        ui.painter()
+            .rect_filled(rect, Rounding::same(Radius::SM), Theme::menu_hover());
     }
 
     let text_color = if is_hovered {
-        Theme::TEXT_PRIMARY
+        Theme::text_primary()
     } else {
-        Theme::TEXT_SECONDARY
+        Theme::text_secondary()
     };
 
     // Icon
@@ -2476,7 +2612,7 @@ pub fn run() -> anyhow::Result<()> {
             .with_transparent(false)
             .with_always_on_top()
             .with_title("CodexBar"),
-        persist_window: false,  // Don't persist window state
+        persist_window: false, // Don't persist window state
         ..Default::default()
     };
 

--- a/rust/src/native_ui/charts.rs
+++ b/rust/src/native_ui/charts.rs
@@ -16,9 +16,9 @@ pub struct ModelBreakdown {
 /// A single data point for the chart
 #[derive(Clone, Debug)]
 pub struct ChartPoint {
-    pub date: String,      // "2025-01-15" format
-    pub value: f64,        // Cost in USD or credits used
-    pub tokens: Option<i64>, // Optional token count
+    pub date: String,                                  // "2025-01-15" format
+    pub value: f64,                                    // Cost in USD or credits used
+    pub tokens: Option<i64>,                           // Optional token count
     pub model_breakdowns: Option<Vec<ModelBreakdown>>, // Optional model-level breakdown
 }
 
@@ -104,7 +104,10 @@ impl CostHistoryChart {
             return;
         }
 
-        let peak_index = self.points.iter().enumerate()
+        let peak_index = self
+            .points
+            .iter()
+            .enumerate()
             .max_by(|(_, a), (_, b)| a.value.partial_cmp(&b.value).unwrap())
             .map(|(i, _)| i);
 
@@ -129,7 +132,8 @@ impl CostHistoryChart {
         let animation_needs_repaint = if self.is_animated {
             if let Some(start) = self.animation_start {
                 let elapsed = start.elapsed().as_millis() as f32;
-                let total_duration = TOTAL_ANIMATION_MS + (self.points.len() as f32 * STAGGER_PER_BAR_MS);
+                let total_duration =
+                    TOTAL_ANIMATION_MS + (self.points.len() as f32 * STAGGER_PER_BAR_MS);
                 elapsed < total_duration
             } else {
                 false
@@ -178,9 +182,9 @@ impl CostHistoryChart {
             );
 
             // Check hover
-            let is_hovered = response.hover_pos().map_or(false, |pos| {
-                pos.x >= x && pos.x <= x + bar_width
-            });
+            let is_hovered = response
+                .hover_pos()
+                .map_or(false, |pos| pos.x >= x && pos.x <= x + bar_width);
 
             if is_hovered {
                 self.selected_index = Some(i);
@@ -200,7 +204,11 @@ impl CostHistoryChart {
                     egui::pos2(x, rect.bottom() - bar_height),
                     Vec2::new(bar_width, 5.0),
                 );
-                painter.rect_filled(cap_rect, Rounding::same(2.0), Color32::from_rgb(255, 200, 50));
+                painter.rect_filled(
+                    cap_rect,
+                    Rounding::same(2.0),
+                    Color32::from_rgb(255, 200, 50),
+                );
                 continue;
             } else if is_hovered {
                 self.bar_color.gamma_multiply(1.2)
@@ -224,7 +232,11 @@ impl CostHistoryChart {
                     egui::pos2(x, rect.top()),
                     Vec2::new(bar_width + bar_spacing, chart_height),
                 );
-                painter.rect_filled(highlight_rect, Rounding::ZERO, Color32::from_rgba_unmultiplied(255, 255, 255, 20));
+                painter.rect_filled(
+                    highlight_rect,
+                    Rounding::ZERO,
+                    Color32::from_rgba_unmultiplied(255, 255, 255, 20),
+                );
             }
         }
 
@@ -240,16 +252,17 @@ impl CostHistoryChart {
                 let cost_display = format!("${:.2}", point.value);
 
                 let detail = if let Some(tokens) = point.tokens {
-                    format!("{}: {} · {} tokens", date_display, cost_display, format_tokens(tokens))
+                    format!(
+                        "{}: {} · {} tokens",
+                        date_display,
+                        cost_display,
+                        format_tokens(tokens)
+                    )
                 } else {
                     format!("{}: {}", date_display, cost_display)
                 };
 
-                ui.label(
-                    RichText::new(detail)
-                        .size(10.0)
-                        .color(Color32::GRAY),
-                );
+                ui.label(RichText::new(detail).size(10.0).color(Color32::GRAY));
             }
         }
         // Removed: "Hover a bar for details" and "Total (30d)" texts for compact layout
@@ -291,7 +304,10 @@ impl CreditsHistoryChart {
 
         let bar_color = Color32::from_rgb(73, 163, 176); // Teal color for credits
         let max_value = self.points.iter().map(|p| p.value).fold(0.0f64, f64::max);
-        let peak_index = self.points.iter().enumerate()
+        let peak_index = self
+            .points
+            .iter()
+            .enumerate()
             .max_by(|(_, a), (_, b)| a.value.partial_cmp(&b.value).unwrap())
             .map(|(i, _)| i);
 
@@ -319,9 +335,9 @@ impl CreditsHistoryChart {
             let x = rect.left() + (i as f32 * (bar_width + bar_spacing)) + bar_spacing / 2.0;
 
             // Check hover
-            let is_hovered = response.hover_pos().map_or(false, |pos| {
-                pos.x >= x && pos.x <= x + bar_width
-            });
+            let is_hovered = response
+                .hover_pos()
+                .map_or(false, |pos| pos.x >= x && pos.x <= x + bar_width);
 
             if is_hovered {
                 self.selected_index = Some(i);
@@ -341,7 +357,11 @@ impl CreditsHistoryChart {
                     egui::pos2(x, rect.bottom() - bar_height),
                     Vec2::new(bar_width, 5.0),
                 );
-                painter.rect_filled(cap_rect, Rounding::same(2.0), Color32::from_rgb(255, 200, 50));
+                painter.rect_filled(
+                    cap_rect,
+                    Rounding::same(2.0),
+                    Color32::from_rgb(255, 200, 50),
+                );
             } else {
                 let bar_rect = egui::Rect::from_min_size(
                     egui::pos2(x, rect.bottom() - bar_height),
@@ -369,11 +389,7 @@ impl CreditsHistoryChart {
                 let date_display = format_date_display(&point.date);
                 let detail = format!("{}: {:.2} credits", date_display, point.value);
 
-                ui.label(
-                    RichText::new(detail)
-                        .size(11.0)
-                        .color(Color32::GRAY),
-                );
+                ui.label(RichText::new(detail).size(11.0).color(Color32::GRAY));
             }
         } else {
             ui.label(
@@ -443,7 +459,7 @@ pub struct ServiceUsage {
 /// A single data point for usage breakdown chart
 #[derive(Clone, Debug)]
 pub struct UsageBreakdownPoint {
-    pub day: String,           // "2025-01-15" format
+    pub day: String, // "2025-01-15" format
     pub services: Vec<ServiceUsage>,
     pub total_credits_used: f64,
 }
@@ -480,10 +496,12 @@ impl UsageBreakdownChart {
 
     fn build_service_colors(points: &[UsageBreakdownPoint]) -> Vec<(String, Color32)> {
         // Collect all unique services and their total usage
-        let mut service_totals: std::collections::HashMap<String, f64> = std::collections::HashMap::new();
+        let mut service_totals: std::collections::HashMap<String, f64> =
+            std::collections::HashMap::new();
         for point in points {
             for service in &point.services {
-                *service_totals.entry(service.service.clone()).or_insert(0.0) += service.credits_used;
+                *service_totals.entry(service.service.clone()).or_insert(0.0) +=
+                    service.credits_used;
             }
         }
 
@@ -492,14 +510,18 @@ impl UsageBreakdownChart {
         sorted.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
 
         // Assign colors
-        sorted.into_iter().map(|(service, _)| {
-            let color = color_for_service(&service);
-            (service, color)
-        }).collect()
+        sorted
+            .into_iter()
+            .map(|(service, _)| {
+                let color = color_for_service(&service);
+                (service, color)
+            })
+            .collect()
     }
 
     fn get_service_color(&self, service: &str) -> Color32 {
-        self.service_colors.iter()
+        self.service_colors
+            .iter()
             .find(|(s, _)| s == service)
             .map(|(_, c)| *c)
             .unwrap_or(Color32::GRAY)
@@ -516,11 +538,20 @@ impl UsageBreakdownChart {
             return;
         }
 
-        let max_value = self.points.iter()
+        let max_value = self
+            .points
+            .iter()
             .map(|p| p.total_credits_used)
             .fold(0.0f64, f64::max);
-        let peak_index = self.points.iter().enumerate()
-            .max_by(|(_, a), (_, b)| a.total_credits_used.partial_cmp(&b.total_credits_used).unwrap())
+        let peak_index = self
+            .points
+            .iter()
+            .enumerate()
+            .max_by(|(_, a), (_, b)| {
+                a.total_credits_used
+                    .partial_cmp(&b.total_credits_used)
+                    .unwrap()
+            })
             .map(|(i, _)| i);
 
         // Chart area
@@ -547,9 +578,9 @@ impl UsageBreakdownChart {
             let x = rect.left() + (i as f32 * (bar_width + bar_spacing)) + bar_spacing / 2.0;
 
             // Check hover
-            let is_hovered = response.hover_pos().map_or(false, |pos| {
-                pos.x >= x && pos.x <= x + bar_width
-            });
+            let is_hovered = response
+                .hover_pos()
+                .map_or(false, |pos| pos.x >= x && pos.x <= x + bar_width);
 
             if is_hovered {
                 self.selected_index = Some(i);
@@ -589,7 +620,11 @@ impl UsageBreakdownChart {
                     egui::pos2(x, rect.bottom() - total_bar_height - cap_height),
                     Vec2::new(bar_width, cap_height),
                 );
-                painter.rect_filled(cap_rect, Rounding::same(2.0), Color32::from_rgb(255, 200, 50));
+                painter.rect_filled(
+                    cap_rect,
+                    Rounding::same(2.0),
+                    Color32::from_rgb(255, 200, 50),
+                );
             }
         }
 
@@ -607,7 +642,9 @@ impl UsageBreakdownChart {
                 let total_display = format!("{:.1}", point.total_credits_used);
 
                 // Show top services
-                let top_services: String = point.services.iter()
+                let top_services: String = point
+                    .services
+                    .iter()
                     .filter(|s| s.credits_used > 0.0)
                     .take(3)
                     .map(|s| format!("{} {:.1}", s.service, s.credits_used))
@@ -620,11 +657,7 @@ impl UsageBreakdownChart {
                         .color(Color32::GRAY),
                 );
                 if !top_services.is_empty() {
-                    ui.label(
-                        RichText::new(top_services)
-                            .size(10.0)
-                            .color(Color32::GRAY),
-                    );
+                    ui.label(RichText::new(top_services).size(10.0).color(Color32::GRAY));
                 }
             }
         }
@@ -676,12 +709,15 @@ fn format_top_models(breakdowns: &[ModelBreakdown]) -> String {
     }
 
     // Sort by cost descending and take top 3
-    let mut sorted: Vec<_> = breakdowns.iter()
-        .filter(|b| b.cost_usd > 0.0)
-        .collect();
-    sorted.sort_by(|a, b| b.cost_usd.partial_cmp(&a.cost_usd).unwrap_or(std::cmp::Ordering::Equal));
+    let mut sorted: Vec<_> = breakdowns.iter().filter(|b| b.cost_usd > 0.0).collect();
+    sorted.sort_by(|a, b| {
+        b.cost_usd
+            .partial_cmp(&a.cost_usd)
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
 
-    let top: Vec<String> = sorted.iter()
+    let top: Vec<String> = sorted
+        .iter()
         .take(3)
         .map(|b| format!("{} ${:.2}", format_model_name(&b.model_name), b.cost_usd))
         .collect();

--- a/rust/src/native_ui/preferences.rs
+++ b/rust/src/native_ui/preferences.rs
@@ -5,17 +5,19 @@
 
 #![allow(dead_code)] // Legacy show_* methods kept for potential future use
 
-use std::sync::{Arc, Mutex};
+use eframe::egui::{self, Color32, Rect, RichText, Rounding, Stroke, Vec2};
 use std::cell::RefCell;
-use eframe::egui::{self, Color32, RichText, Rounding, Stroke, Vec2, Rect};
+use std::sync::{Arc, Mutex};
 
 use super::provider_icons::ProviderIconCache;
 use super::theme::{provider_color, provider_icon, FontSize, Radius, Spacing, Theme};
-use crate::settings::{ApiKeys, ManualCookies, Settings, TrayIconMode, get_api_key_providers};
-use crate::core::{PersonalInfoRedactor, ProviderId, WidgetSnapshot, WidgetSnapshotStore};
-use crate::core::{TokenAccountStore, TokenAccount, TokenAccountSupport, ProviderAccountData};
-use crate::browser::detection::{BrowserDetector, BrowserType};
 use crate::browser::cookies::get_cookie_header_from_browser;
+use crate::browser::detection::{BrowserDetector, BrowserType};
+use crate::core::{PersonalInfoRedactor, ProviderId, WidgetSnapshot, WidgetSnapshotStore};
+use crate::core::{ProviderAccountData, TokenAccount, TokenAccountStore, TokenAccountSupport};
+use crate::settings::{
+    get_api_key_providers, ApiKeys, ManualCookies, Settings, ThemeMode, TrayIconMode,
+};
 use crate::shortcuts::format_shortcut;
 use std::collections::HashMap;
 
@@ -277,7 +279,11 @@ impl PreferencesWindow {
         );
         let settings_position = if self.needs_viewport_placement {
             match (main_outer_rect, work_area) {
-                (Some(main_rect), Some(area)) => Some(settings_position_near_main_window(main_rect, settings_size, area)),
+                (Some(main_rect), Some(area)) => Some(settings_position_near_main_window(
+                    main_rect,
+                    settings_size,
+                    area,
+                )),
                 _ => None,
             }
         } else {
@@ -294,36 +300,39 @@ impl PreferencesWindow {
             builder = builder.with_position(position);
         }
 
-        ctx.show_viewport_immediate(
-            settings_viewport_id,
-            builder,
-            |ctx, _class| {
-                // Check if window was closed
-                if ctx.input(|i| i.viewport().close_requested()) {
-                    if let Ok(mut state) = shared_state.lock() {
-                        state.is_open = false;
-                    }
+        ctx.show_viewport_immediate(settings_viewport_id, builder, |ctx, _class| {
+            // Check if window was closed
+            if ctx.input(|i| i.viewport().close_requested()) {
+                if let Ok(mut state) = shared_state.lock() {
+                    state.is_open = false;
                 }
+            }
 
-                // Apply dark theme
-                let mut style = (*ctx.style()).clone();
-                style.visuals.window_fill = Theme::BG_PRIMARY;
-                style.visuals.panel_fill = Theme::BG_PRIMARY;
-                style.visuals.widgets.noninteractive.bg_fill = Theme::BG_SECONDARY;
-                style.visuals.widgets.inactive.bg_fill = Theme::CARD_BG;
-                style.visuals.widgets.hovered.bg_fill = Theme::CARD_BG_HOVER;
-                style.visuals.widgets.active.bg_fill = Theme::ACCENT_PRIMARY;
-                ctx.set_style(style);
+            // Apply theme
+            let mut style = (*ctx.style()).clone();
+            style.visuals = if Theme::is_dark() {
+                egui::Visuals::dark()
+            } else {
+                egui::Visuals::light()
+            };
+            style.visuals.window_fill = Theme::bg_primary();
+            style.visuals.panel_fill = Theme::bg_primary();
+            style.visuals.widgets.noninteractive.bg_fill = Theme::bg_secondary();
+            style.visuals.widgets.inactive.bg_fill = Theme::card_bg();
+            style.visuals.widgets.hovered.bg_fill = Theme::card_bg_hover();
+            style.visuals.widgets.active.bg_fill = Theme::ACCENT_PRIMARY;
+            ctx.set_style(style);
 
-                egui::CentralPanel::default()
-                    .frame(egui::Frame::none()
-                        .fill(Theme::BG_PRIMARY)
-                        .inner_margin(Spacing::MD))
-                    .show(ctx, |ui| {
-                        render_settings_ui(ui, &shared_state);
-                    });
-            },
-        );
+            egui::CentralPanel::default()
+                .frame(
+                    egui::Frame::none()
+                        .fill(Theme::bg_primary())
+                        .inner_margin(Spacing::MD),
+                )
+                .show(ctx, |ui| {
+                    render_settings_ui(ui, &shared_state);
+                });
+        });
 
         if settings_position.is_some() {
             ctx.send_viewport_cmd_to(settings_viewport_id, egui::ViewportCommand::Focus);
@@ -345,7 +354,12 @@ impl PreferencesWindow {
 
         settings_card(ui, |ui| {
             let mut start_at_login = self.settings.start_at_login;
-            if setting_toggle(ui, "Start at login", "Launch CodexBar when you log in", &mut start_at_login) {
+            if setting_toggle(
+                ui,
+                "Start at login",
+                "Launch CodexBar when you log in",
+                &mut start_at_login,
+            ) {
                 if let Err(e) = self.settings.set_start_at_login(start_at_login) {
                     tracing::error!("Failed to set start at login: {}", e);
                 } else {
@@ -356,7 +370,12 @@ impl PreferencesWindow {
             setting_divider(ui);
 
             let mut start_minimized = self.settings.start_minimized;
-            if setting_toggle(ui, "Start minimized", "Start in the system tray", &mut start_minimized) {
+            if setting_toggle(
+                ui,
+                "Start minimized",
+                "Start in the system tray",
+                &mut start_minimized,
+            ) {
                 self.settings.start_minimized = start_minimized;
                 self.settings_changed = true;
             }
@@ -369,7 +388,12 @@ impl PreferencesWindow {
 
         settings_card(ui, |ui| {
             let mut show_notifications = self.settings.show_notifications;
-            if setting_toggle(ui, "Show notifications", "Alert when usage thresholds are reached", &mut show_notifications) {
+            if setting_toggle(
+                ui,
+                "Show notifications",
+                "Alert when usage thresholds are reached",
+                &mut show_notifications,
+            ) {
                 self.settings.show_notifications = show_notifications;
                 self.settings_changed = true;
             }
@@ -378,7 +402,12 @@ impl PreferencesWindow {
 
             // Sound effects toggle
             let mut sound_enabled = self.settings.sound_enabled;
-            if setting_toggle(ui, "Sound effects", "Play sound when thresholds are reached", &mut sound_enabled) {
+            if setting_toggle(
+                ui,
+                "Sound effects",
+                "Play sound when thresholds are reached",
+                &mut sound_enabled,
+            ) {
                 self.settings.sound_enabled = sound_enabled;
                 self.settings_changed = true;
             }
@@ -392,30 +421,43 @@ impl PreferencesWindow {
 
                     // Title row with volume badge on right
                     ui.horizontal(|ui| {
-                        ui.label(RichText::new("Sound volume").size(FontSize::MD).color(Theme::TEXT_PRIMARY));
+                        ui.label(
+                            RichText::new("Sound volume")
+                                .size(FontSize::MD)
+                                .color(Theme::text_primary()),
+                        );
                         ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
                             egui::Frame::none()
                                 .fill(Theme::ACCENT_PRIMARY.gamma_multiply(0.15))
                                 .rounding(Rounding::same(10.0))
                                 .inner_margin(egui::Margin::symmetric(10.0, 3.0))
                                 .show(ui, |ui| {
-                                    ui.label(RichText::new(format!("{}%", volume)).size(FontSize::SM).color(Theme::ACCENT_PRIMARY).strong());
+                                    ui.label(
+                                        RichText::new(format!("{}%", volume))
+                                            .size(FontSize::SM)
+                                            .color(Theme::ACCENT_PRIMARY)
+                                            .strong(),
+                                    );
                                 });
                         });
                     });
 
                     ui.add_space(2.0);
-                    ui.label(RichText::new("Volume level for alert sounds").size(FontSize::SM).color(Theme::TEXT_MUTED));
+                    ui.label(
+                        RichText::new("Volume level for alert sounds")
+                            .size(FontSize::SM)
+                            .color(Theme::text_muted()),
+                    );
                     ui.add_space(6.0);
 
-                    ui.style_mut().visuals.widgets.inactive.bg_fill = Theme::BG_TERTIARY;
-                    ui.style_mut().visuals.widgets.hovered.bg_fill = Theme::CARD_BG_HOVER;
+                    ui.style_mut().visuals.widgets.inactive.bg_fill = Theme::bg_tertiary();
+                    ui.style_mut().visuals.widgets.hovered.bg_fill = Theme::card_bg_hover();
                     ui.style_mut().visuals.widgets.active.bg_fill = Theme::ACCENT_PRIMARY;
 
                     let slider = ui.add(
                         egui::Slider::new(&mut volume, 0..=100)
                             .show_value(false)
-                            .trailing_fill(true)
+                            .trailing_fill(true),
                     );
 
                     if slider.changed() {
@@ -433,7 +475,11 @@ impl PreferencesWindow {
 
                 // Title row with percentage badge on right
                 ui.horizontal(|ui| {
-                    ui.label(RichText::new("High warning").size(FontSize::MD).color(Theme::TEXT_PRIMARY));
+                    ui.label(
+                        RichText::new("High warning")
+                            .size(FontSize::MD)
+                            .color(Theme::text_primary()),
+                    );
                     ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
                         // Percentage pill badge
                         egui::Frame::none()
@@ -441,24 +487,33 @@ impl PreferencesWindow {
                             .rounding(Rounding::same(10.0))
                             .inner_margin(egui::Margin::symmetric(10.0, 3.0))
                             .show(ui, |ui| {
-                                ui.label(RichText::new(format!("{}%", threshold)).size(FontSize::SM).color(Theme::ACCENT_PRIMARY).strong());
+                                ui.label(
+                                    RichText::new(format!("{}%", threshold))
+                                        .size(FontSize::SM)
+                                        .color(Theme::ACCENT_PRIMARY)
+                                        .strong(),
+                                );
                             });
                     });
                 });
 
                 ui.add_space(2.0);
-                ui.label(RichText::new("Show warning at this usage level").size(FontSize::SM).color(Theme::TEXT_MUTED));
+                ui.label(
+                    RichText::new("Show warning at this usage level")
+                        .size(FontSize::SM)
+                        .color(Theme::text_muted()),
+                );
                 ui.add_space(6.0);
 
                 // Full-width slider
-                ui.style_mut().visuals.widgets.inactive.bg_fill = Theme::BG_TERTIARY;
-                ui.style_mut().visuals.widgets.hovered.bg_fill = Theme::CARD_BG_HOVER;
+                ui.style_mut().visuals.widgets.inactive.bg_fill = Theme::bg_tertiary();
+                ui.style_mut().visuals.widgets.hovered.bg_fill = Theme::card_bg_hover();
                 ui.style_mut().visuals.widgets.active.bg_fill = Theme::ACCENT_PRIMARY;
 
                 let slider = ui.add(
                     egui::Slider::new(&mut threshold, 50..=95)
                         .show_value(false)
-                        .trailing_fill(true)
+                        .trailing_fill(true),
                 );
 
                 if slider.changed() && threshold as f64 != self.settings.high_usage_threshold {
@@ -476,7 +531,11 @@ impl PreferencesWindow {
 
                 // Title row with percentage badge on right
                 ui.horizontal(|ui| {
-                    ui.label(RichText::new("Critical alert").size(FontSize::MD).color(Theme::TEXT_PRIMARY));
+                    ui.label(
+                        RichText::new("Critical alert")
+                            .size(FontSize::MD)
+                            .color(Theme::text_primary()),
+                    );
                     ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
                         // Percentage pill badge - red tint for critical
                         egui::Frame::none()
@@ -484,24 +543,33 @@ impl PreferencesWindow {
                             .rounding(Rounding::same(10.0))
                             .inner_margin(egui::Margin::symmetric(10.0, 3.0))
                             .show(ui, |ui| {
-                                ui.label(RichText::new(format!("{}%", threshold)).size(FontSize::SM).color(badge_color).strong());
+                                ui.label(
+                                    RichText::new(format!("{}%", threshold))
+                                        .size(FontSize::SM)
+                                        .color(badge_color)
+                                        .strong(),
+                                );
                             });
                     });
                 });
 
                 ui.add_space(2.0);
-                ui.label(RichText::new("Show critical alert at this level").size(FontSize::SM).color(Theme::TEXT_MUTED));
+                ui.label(
+                    RichText::new("Show critical alert at this level")
+                        .size(FontSize::SM)
+                        .color(Theme::text_muted()),
+                );
                 ui.add_space(6.0);
 
                 // Full-width slider
-                ui.style_mut().visuals.widgets.inactive.bg_fill = Theme::BG_TERTIARY;
-                ui.style_mut().visuals.widgets.hovered.bg_fill = Theme::CARD_BG_HOVER;
+                ui.style_mut().visuals.widgets.inactive.bg_fill = Theme::bg_tertiary();
+                ui.style_mut().visuals.widgets.hovered.bg_fill = Theme::card_bg_hover();
                 ui.style_mut().visuals.widgets.active.bg_fill = badge_color;
 
                 let slider = ui.add(
                     egui::Slider::new(&mut threshold, 80..=100)
                         .show_value(false)
-                        .trailing_fill(true)
+                        .trailing_fill(true),
                 );
 
                 if slider.changed() && threshold as f64 != self.settings.critical_usage_threshold {
@@ -522,7 +590,7 @@ impl PreferencesWindow {
 
         // Calculate dimensions - responsive sidebar width
         let total_width = ui.available_width();
-        let sidebar_width = (total_width * 0.45).min(180.0).max(140.0);  // 45% of width, 140-180px range
+        let sidebar_width = (total_width * 0.45).min(180.0).max(140.0); // 45% of width, 140-180px range
         let gap = Spacing::SM;
         let detail_width = (total_width - sidebar_width - gap).max(150.0);
         let panel_height = available_height;
@@ -538,7 +606,7 @@ impl PreferencesWindow {
                     egui::Layout::top_down(egui::Align::LEFT),
                     |ui| {
                         self.draw_provider_sidebar(ui, providers, panel_height);
-                    }
+                    },
                 );
 
                 ui.add_space(gap);
@@ -549,15 +617,20 @@ impl PreferencesWindow {
                     egui::Layout::top_down(egui::Align::LEFT),
                     |ui| {
                         self.draw_provider_detail(ui, panel_height);
-                    }
+                    },
                 );
-            }
+            },
         );
     }
 
-    fn draw_provider_sidebar(&mut self, ui: &mut egui::Ui, providers: &[ProviderId], available_height: f32) {
+    fn draw_provider_sidebar(
+        &mut self,
+        ui: &mut egui::Ui,
+        providers: &[ProviderId],
+        available_height: f32,
+    ) {
         egui::Frame::none()
-            .fill(Theme::BG_TERTIARY)
+            .fill(Theme::bg_tertiary())
             .rounding(Rounding::same(Radius::MD))
             .inner_margin(Spacing::SM)
             .show(ui, |ui| {
@@ -571,7 +644,8 @@ impl PreferencesWindow {
                         for provider_id in providers {
                             let provider_name = provider_id.cli_name();
                             let is_selected = self.selected_provider.as_ref() == Some(provider_id);
-                            let is_enabled = self.settings.enabled_providers.contains(provider_name);
+                            let is_enabled =
+                                self.settings.enabled_providers.contains(provider_name);
 
                             // Add padding around each row
                             let frame_response = egui::Frame::none()
@@ -585,40 +659,70 @@ impl PreferencesWindow {
 
                                         // Icon
                                         let icon_size = 20.0;
-                                        if let Some(texture) = self.icon_cache.get_icon(ui.ctx(), provider_name, icon_size as u32) {
-                                            ui.add(egui::Image::new(texture).fit_to_exact_size(Vec2::splat(icon_size)));
+                                        if let Some(texture) = self.icon_cache.get_icon(
+                                            ui.ctx(),
+                                            provider_name,
+                                            icon_size as u32,
+                                        ) {
+                                            ui.add(
+                                                egui::Image::new(texture)
+                                                    .fit_to_exact_size(Vec2::splat(icon_size)),
+                                            );
                                         } else {
-                                            ui.label(RichText::new(provider_icon(provider_name)).size(FontSize::MD).color(provider_color(provider_name)));
+                                            ui.label(
+                                                RichText::new(provider_icon(provider_name))
+                                                    .size(FontSize::MD)
+                                                    .color(provider_color(provider_name)),
+                                            );
                                         }
 
                                         ui.add_space(8.0);
 
                                         // Provider name as plain label (no hover effect)
-                                        let text_color = if is_selected { Theme::TEXT_PRIMARY }
-                                            else if is_enabled { Theme::TEXT_SECONDARY }
-                                            else { Theme::TEXT_MUTED };
+                                        let text_color = if is_selected {
+                                            Theme::text_primary()
+                                        } else if is_enabled {
+                                            Theme::text_secondary()
+                                        } else {
+                                            Theme::text_muted()
+                                        };
 
-                                        ui.label(RichText::new(provider_id.display_name()).size(FontSize::SM).color(text_color));
+                                        ui.label(
+                                            RichText::new(provider_id.display_name())
+                                                .size(FontSize::SM)
+                                                .color(text_color),
+                                        );
 
                                         // Spacer to push checkbox to right
-                                        ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
-                                            // Checkbox
-                                            let mut enabled = is_enabled;
-                                            if ui.checkbox(&mut enabled, "").changed() {
-                                                if enabled {
-                                                    self.settings.enabled_providers.insert(provider_name.to_string());
-                                                } else {
-                                                    self.settings.enabled_providers.remove(provider_name);
+                                        ui.with_layout(
+                                            egui::Layout::right_to_left(egui::Align::Center),
+                                            |ui| {
+                                                // Checkbox
+                                                let mut enabled = is_enabled;
+                                                if ui.checkbox(&mut enabled, "").changed() {
+                                                    if enabled {
+                                                        self.settings
+                                                            .enabled_providers
+                                                            .insert(provider_name.to_string());
+                                                    } else {
+                                                        self.settings
+                                                            .enabled_providers
+                                                            .remove(provider_name);
+                                                    }
+                                                    self.settings_changed = true;
                                                 }
-                                                self.settings_changed = true;
-                                            }
-                                        });
+                                            },
+                                        );
                                     });
                                 });
 
                             // Check hover and click on the frame
                             let frame_rect = frame_response.response.rect;
-                            let row_response = ui.interact(frame_rect, ui.make_persistent_id(format!("row_{}", provider_name)), egui::Sense::click());
+                            let row_response = ui.interact(
+                                frame_rect,
+                                ui.make_persistent_id(format!("row_{}", provider_name)),
+                                egui::Sense::click(),
+                            );
                             let is_hovered = row_response.hovered();
 
                             if row_response.clicked() {
@@ -643,7 +747,7 @@ impl PreferencesWindow {
     fn draw_provider_detail(&mut self, ui: &mut egui::Ui, available_height: f32) {
         if let Some(ref selected_id) = self.selected_provider.clone() {
             egui::Frame::none()
-                .fill(Theme::BG_SECONDARY)
+                .fill(Theme::bg_secondary())
                 .rounding(Rounding::same(Radius::LG))
                 .inner_margin(Spacing::MD)
                 .show(ui, |ui| {
@@ -659,14 +763,18 @@ impl PreferencesWindow {
         } else {
             // Placeholder
             egui::Frame::none()
-                .fill(Theme::BG_SECONDARY)
+                .fill(Theme::bg_secondary())
                 .rounding(Rounding::same(Radius::LG))
                 .inner_margin(Spacing::MD)
                 .show(ui, |ui| {
                     ui.set_min_height(available_height);
                     ui.vertical_centered(|ui| {
                         ui.add_space(available_height / 3.0);
-                        ui.label(RichText::new("Select a provider").size(FontSize::MD).color(Theme::TEXT_MUTED));
+                        ui.label(
+                            RichText::new("Select a provider")
+                                .size(FontSize::MD)
+                                .color(Theme::text_muted()),
+                        );
                     });
                 });
         }
@@ -689,10 +797,17 @@ impl PreferencesWindow {
                 .inner_margin(Spacing::SM)
                 .show(ui, |ui| {
                     let icon_size = 32.0;
-                    if let Some(texture) = self.icon_cache.get_icon(ui.ctx(), provider_name, icon_size as u32) {
+                    if let Some(texture) =
+                        self.icon_cache
+                            .get_icon(ui.ctx(), provider_name, icon_size as u32)
+                    {
                         ui.add(egui::Image::new(texture).fit_to_exact_size(Vec2::splat(icon_size)));
                     } else {
-                        ui.label(RichText::new(provider_icon(provider_name)).size(icon_size).color(color));
+                        ui.label(
+                            RichText::new(provider_icon(provider_name))
+                                .size(icon_size)
+                                .color(color),
+                        );
                     }
                 });
 
@@ -702,18 +817,22 @@ impl PreferencesWindow {
                 ui.label(
                     RichText::new(display_name)
                         .size(FontSize::XL)
-                        .color(Theme::TEXT_PRIMARY)
-                        .strong()
+                        .color(Theme::text_primary())
+                        .strong(),
                 );
                 ui.horizontal(|ui| {
                     // Status indicator dot
-                    let status_color = if is_enabled { Theme::GREEN } else { Theme::TEXT_MUTED };
+                    let status_color = if is_enabled {
+                        Theme::GREEN
+                    } else {
+                        Theme::text_muted()
+                    };
                     ui.label(RichText::new("●").size(FontSize::XS).color(status_color));
                     ui.add_space(4.0);
                     ui.label(
                         RichText::new(if is_enabled { "Enabled" } else { "Disabled" })
                             .size(FontSize::SM)
-                            .color(status_color)
+                            .color(status_color),
                     );
                 });
             });
@@ -723,7 +842,9 @@ impl PreferencesWindow {
                 let mut enabled = is_enabled;
                 if ui.checkbox(&mut enabled, "").changed() {
                     if enabled {
-                        self.settings.enabled_providers.insert(provider_name.to_string());
+                        self.settings
+                            .enabled_providers
+                            .insert(provider_name.to_string());
                     } else {
                         self.settings.enabled_providers.remove(provider_name);
                     }
@@ -793,29 +914,33 @@ impl PreferencesWindow {
                         ui.label(
                             RichText::new("Live usage data in main window")
                                 .size(FontSize::MD)
-                                .color(Theme::TEXT_PRIMARY)
+                                .color(Theme::text_primary()),
                         );
                         ui.label(
                             RichText::new("Click the tray icon to view real-time metrics")
                                 .size(FontSize::SM)
-                                .color(Theme::TEXT_MUTED)
+                                .color(Theme::text_muted()),
                         );
                     });
                 });
             } else {
                 ui.horizontal(|ui| {
-                    ui.label(RichText::new("⏸").size(FontSize::LG).color(Theme::TEXT_MUTED));
+                    ui.label(
+                        RichText::new("⏸")
+                            .size(FontSize::LG)
+                            .color(Theme::text_muted()),
+                    );
                     ui.add_space(Spacing::SM);
                     ui.vertical(|ui| {
                         ui.label(
                             RichText::new("Provider disabled")
                                 .size(FontSize::MD)
-                                .color(Theme::TEXT_MUTED)
+                                .color(Theme::text_muted()),
                         );
                         ui.label(
                             RichText::new("Enable to start tracking usage")
                                 .size(FontSize::SM)
-                                .color(Theme::TEXT_DIM)
+                                .color(Theme::text_dim()),
                         );
                     });
                 });
@@ -864,14 +989,14 @@ impl PreferencesWindow {
                     ui.label(
                         RichText::new("Ollama runs locally - no dashboard")
                             .size(FontSize::SM)
-                            .color(Theme::TEXT_MUTED)
+                            .color(Theme::text_muted()),
                     );
                 }
                 _ => {
                     ui.label(
                         RichText::new("No quick actions available")
                             .size(FontSize::SM)
-                            .color(Theme::TEXT_MUTED)
+                            .color(Theme::text_muted()),
                     );
                 }
             }
@@ -883,13 +1008,13 @@ impl PreferencesWindow {
             ui.label(
                 RichText::new(label)
                     .size(FontSize::SM)
-                    .color(Theme::TEXT_MUTED)
+                    .color(Theme::text_muted()),
             );
             ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
                 ui.label(
                     RichText::new(value)
                         .size(FontSize::SM)
-                        .color(Theme::TEXT_SECONDARY)
+                        .color(Theme::text_secondary()),
                 );
             });
         });
@@ -904,7 +1029,7 @@ impl PreferencesWindow {
             ui.label(
                 RichText::new(format!("Import cookies from your browser for {}", domain))
                     .size(FontSize::SM)
-                    .color(Theme::TEXT_MUTED)
+                    .color(Theme::text_muted()),
             );
 
             ui.add_space(Spacing::SM);
@@ -916,15 +1041,20 @@ impl PreferencesWindow {
                 ui.label(
                     RichText::new("No supported browsers detected")
                         .size(FontSize::SM)
-                        .color(Theme::YELLOW)
+                        .color(Theme::YELLOW),
                 );
             } else {
                 // Browser selection dropdown
                 ui.horizontal(|ui| {
-                    ui.label(RichText::new("Browser").size(FontSize::MD).color(Theme::TEXT_PRIMARY));
+                    ui.label(
+                        RichText::new("Browser")
+                            .size(FontSize::MD)
+                            .color(Theme::text_primary()),
+                    );
 
                     ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
-                        let selected_text = self.selected_browser
+                        let selected_text = self
+                            .selected_browser
                             .map(|b| b.display_name())
                             .unwrap_or("Select browser...");
 
@@ -933,10 +1063,13 @@ impl PreferencesWindow {
                             .show_ui(ui, |ui| {
                                 for browser in &browsers {
                                     let browser_type = browser.browser_type;
-                                    if ui.selectable_label(
-                                        self.selected_browser == Some(browser_type),
-                                        browser_type.display_name(),
-                                    ).clicked() {
+                                    if ui
+                                        .selectable_label(
+                                            self.selected_browser == Some(browser_type),
+                                            browser_type.display_name(),
+                                        )
+                                        .clicked()
+                                    {
                                         self.selected_browser = Some(browser_type);
                                         self.browser_import_status = None;
                                     }
@@ -949,32 +1082,49 @@ impl PreferencesWindow {
 
                 // Import button
                 let can_import = self.selected_browser.is_some();
-                if ui.add_enabled(
-                    can_import,
-                    egui::Button::new(
-                        RichText::new("Import Cookies")
-                            .size(FontSize::SM)
-                            .color(if can_import { Color32::WHITE } else { Theme::TEXT_MUTED })
+                if ui
+                    .add_enabled(
+                        can_import,
+                        egui::Button::new(
+                            RichText::new("Import Cookies").size(FontSize::SM).color(
+                                if can_import {
+                                    Color32::WHITE
+                                } else {
+                                    Theme::text_muted()
+                                },
+                            ),
+                        )
+                        .fill(if can_import {
+                            Theme::ACCENT_PRIMARY
+                        } else {
+                            Theme::bg_tertiary()
+                        })
+                        .rounding(Rounding::same(Radius::MD))
+                        .min_size(Vec2::new(120.0, 36.0)),
                     )
-                    .fill(if can_import { Theme::ACCENT_PRIMARY } else { Theme::BG_TERTIARY })
-                    .rounding(Rounding::same(Radius::MD))
-                    .min_size(Vec2::new(120.0, 36.0))
-                ).clicked() {
+                    .clicked()
+                {
                     // Attempt to import cookies from selected browser
                     if let Some(browser_type) = self.selected_browser {
                         // Find the detected browser matching the selected type
                         let browsers = BrowserDetector::detect_all();
-                        if let Some(browser) = browsers.iter().find(|b| b.browser_type == browser_type) {
+                        if let Some(browser) =
+                            browsers.iter().find(|b| b.browser_type == browser_type)
+                        {
                             match get_cookie_header_from_browser(domain, browser) {
                                 Ok(cookie_header) if !cookie_header.is_empty() => {
                                     // Save the cookie
                                     self.cookies.set(provider_id.cli_name(), &cookie_header);
                                     if let Err(e) = self.cookies.save() {
-                                        self.browser_import_status = Some((format!("Failed to save: {}", e), true));
+                                        self.browser_import_status =
+                                            Some((format!("Failed to save: {}", e), true));
                                     } else {
                                         self.browser_import_status = Some((
-                                            format!("Cookies imported for {}", provider_id.display_name()),
-                                            false
+                                            format!(
+                                                "Cookies imported for {}",
+                                                provider_id.display_name()
+                                            ),
+                                            false,
                                         ));
                                     }
                                 }
@@ -985,13 +1135,14 @@ impl PreferencesWindow {
                                     ));
                                 }
                                 Err(e) => {
-                                    self.browser_import_status = Some((format!("Import failed: {}", e), true));
+                                    self.browser_import_status =
+                                        Some((format!("Import failed: {}", e), true));
                                 }
                             }
                         } else {
                             self.browser_import_status = Some((
                                 format!("Browser {} not found", browser_type.display_name()),
-                                true
+                                true,
                             ));
                         }
                     }
@@ -1012,7 +1163,12 @@ impl PreferencesWindow {
 
         settings_card(ui, |ui| {
             let mut show_as_used = self.settings.show_as_used;
-            if setting_toggle(ui, "Show usage as used", "Show usage as percentage used (vs remaining)", &mut show_as_used) {
+            if setting_toggle(
+                ui,
+                "Show usage as used",
+                "Show usage as percentage used (vs remaining)",
+                &mut show_as_used,
+            ) {
                 self.settings.show_as_used = show_as_used;
                 self.settings_changed = true;
             }
@@ -1020,7 +1176,12 @@ impl PreferencesWindow {
             setting_divider(ui);
 
             let mut reset_time_relative = self.settings.reset_time_relative;
-            if setting_toggle(ui, "Relative reset times", "Show '2h 30m' instead of '3:00 PM'", &mut reset_time_relative) {
+            if setting_toggle(
+                ui,
+                "Relative reset times",
+                "Show '2h 30m' instead of '3:00 PM'",
+                &mut reset_time_relative,
+            ) {
                 self.settings.reset_time_relative = reset_time_relative;
                 self.settings_changed = true;
             }
@@ -1028,7 +1189,12 @@ impl PreferencesWindow {
             setting_divider(ui);
 
             let mut show_credits_extra = self.settings.show_credits_extra_usage;
-            if setting_toggle(ui, "Show credits + extra usage", "Display credit balance and extra usage information", &mut show_credits_extra) {
+            if setting_toggle(
+                ui,
+                "Show credits + extra usage",
+                "Display credit balance and extra usage information",
+                &mut show_credits_extra,
+            ) {
                 self.settings.show_credits_extra_usage = show_credits_extra;
                 self.settings_changed = true;
             }
@@ -1040,7 +1206,12 @@ impl PreferencesWindow {
 
         settings_card(ui, |ui| {
             let mut merge_icons = self.settings.merge_tray_icons;
-            if setting_toggle(ui, "Merge tray icons", "Show all providers in a single tray icon", &mut merge_icons) {
+            if setting_toggle(
+                ui,
+                "Merge tray icons",
+                "Show all providers in a single tray icon",
+                &mut merge_icons,
+            ) {
                 self.settings.merge_tray_icons = merge_icons;
                 self.settings_changed = true;
             }
@@ -1048,7 +1219,12 @@ impl PreferencesWindow {
             setting_divider(ui);
 
             let mut per_provider = self.settings.tray_icon_mode == TrayIconMode::PerProvider;
-            if setting_toggle(ui, "Per-provider icons", "Show a separate tray icon for each enabled provider", &mut per_provider) {
+            if setting_toggle(
+                ui,
+                "Per-provider icons",
+                "Show a separate tray icon for each enabled provider",
+                &mut per_provider,
+            ) {
                 self.settings.tray_icon_mode = if per_provider {
                     TrayIconMode::PerProvider
                 } else {
@@ -1070,7 +1246,7 @@ impl PreferencesWindow {
                         Settings::MAX_OVERVIEW_PROVIDERS
                     ))
                     .size(FontSize::SM)
-                    .color(Theme::TEXT_MUTED),
+                    .color(Theme::text_muted()),
                 );
 
                 ui.add_space(Spacing::XS);
@@ -1102,7 +1278,7 @@ impl PreferencesWindow {
                         ui.label(
                             RichText::new(label)
                                 .size(FontSize::SM)
-                                .color(Theme::TEXT_PRIMARY),
+                                .color(Theme::text_primary()),
                         );
                     });
                 }
@@ -1111,7 +1287,7 @@ impl PreferencesWindow {
                     ui.label(
                         RichText::new("No enabled providers.")
                             .size(FontSize::SM)
-                            .color(Theme::TEXT_MUTED),
+                            .color(Theme::text_muted()),
                     );
                 }
             });
@@ -1124,7 +1300,7 @@ impl PreferencesWindow {
         ui.label(
             RichText::new("Configure access tokens for providers that require authentication.")
                 .size(FontSize::SM)
-                .color(Theme::TEXT_MUTED),
+                .color(Theme::text_muted()),
         );
 
         ui.add_space(Spacing::MD);
@@ -1146,19 +1322,22 @@ impl PreferencesWindow {
             let color = provider_color(provider_id);
 
             // Card with left accent bar
-            let accent_color = if has_key { Theme::GREEN } else if is_enabled { Theme::ORANGE } else { Theme::BG_TERTIARY };
+            let accent_color = if has_key {
+                Theme::GREEN
+            } else if is_enabled {
+                Theme::ORANGE
+            } else {
+                Theme::bg_tertiary()
+            };
 
             egui::Frame::none()
-                .fill(Theme::BG_SECONDARY)
+                .fill(Theme::bg_secondary())
                 .rounding(Rounding::same(Radius::MD))
                 .inner_margin(egui::Margin::same(0.0))
                 .show(ui, |ui| {
                     ui.horizontal(|ui| {
                         // Left accent bar - reduced height for compact layout
-                        let bar_rect = Rect::from_min_size(
-                            ui.cursor().min,
-                            Vec2::new(3.0, 48.0),
-                        );
+                        let bar_rect = Rect::from_min_size(ui.cursor().min, Vec2::new(3.0, 48.0));
                         ui.painter().rect_filled(
                             bar_rect,
                             Rounding {
@@ -1183,8 +1362,8 @@ impl PreferencesWindow {
                                 ui.label(
                                     RichText::new(provider_info.name)
                                         .size(FontSize::MD)
-                                        .color(Theme::TEXT_PRIMARY)
-                                        .strong()
+                                        .color(Theme::text_primary())
+                                        .strong(),
                                 );
 
                                 ui.add_space(Spacing::XS);
@@ -1201,22 +1380,25 @@ impl PreferencesWindow {
                                             ui.label(
                                                 RichText::new("Needs key")
                                                     .size(FontSize::XS)
-                                                    .color(Color32::BLACK)
+                                                    .color(Color32::BLACK),
                                             );
                                         });
                                 }
 
                                 // Right-aligned: Add Key button for providers without keys
-                                ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
-                                    ui.add_space(Spacing::XS);
-                                    if !has_key {
-                                        if primary_button(ui, "+ Add Key") {
-                                            self.new_api_key_provider = provider_id.to_string();
-                                            self.show_api_key_input = true;
-                                            self.new_api_key_value.clear();
+                                ui.with_layout(
+                                    egui::Layout::right_to_left(egui::Align::Center),
+                                    |ui| {
+                                        ui.add_space(Spacing::XS);
+                                        if !has_key {
+                                            if primary_button(ui, "+ Add Key") {
+                                                self.new_api_key_provider = provider_id.to_string();
+                                                self.show_api_key_input = true;
+                                                self.new_api_key_value.clear();
+                                            }
                                         }
-                                    }
-                                });
+                                    },
+                                );
                             });
 
                             // Row 2: Single line with env var, masked key, and actions
@@ -1228,46 +1410,61 @@ impl PreferencesWindow {
                                     ui.label(
                                         RichText::new(format!("Env: {}", env_var))
                                             .size(FontSize::XS)
-                                            .color(Theme::TEXT_MUTED)
-                                            .monospace()
+                                            .color(Theme::text_muted())
+                                            .monospace(),
                                     );
                                 }
 
                                 if has_key {
                                     ui.add_space(Spacing::SM);
                                     // Show masked key inline
-                                    if let Some(key_info) = self.api_keys.get_all_for_display()
+                                    if let Some(key_info) = self
+                                        .api_keys
+                                        .get_all_for_display()
                                         .iter()
                                         .find(|k| k.provider_id == provider_id)
                                     {
                                         ui.label(
                                             RichText::new(&key_info.masked_key)
                                                 .size(FontSize::XS)
-                                                .color(Theme::TEXT_MUTED)
-                                                .monospace()
+                                                .color(Theme::text_muted())
+                                                .monospace(),
                                         );
                                     }
 
-                                    ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
-                                        ui.add_space(Spacing::XS);
-                                        if small_button(ui, "Remove", Theme::RED) {
-                                            self.api_keys.remove(provider_id);
-                                            let _ = self.api_keys.save();
-                                            self.api_key_status_msg = Some((
-                                                format!("Removed API key for {}", provider_info.name),
-                                                false,
-                                            ));
-                                        }
-                                    });
-                                } else {
-                                    ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
-                                        ui.add_space(Spacing::XS);
-                                        if let Some(url) = provider_info.dashboard_url {
-                                            if text_button(ui, "Get key →", Theme::ACCENT_PRIMARY) {
-                                                let _ = open::that(url);
+                                    ui.with_layout(
+                                        egui::Layout::right_to_left(egui::Align::Center),
+                                        |ui| {
+                                            ui.add_space(Spacing::XS);
+                                            if small_button(ui, "Remove", Theme::RED) {
+                                                self.api_keys.remove(provider_id);
+                                                let _ = self.api_keys.save();
+                                                self.api_key_status_msg = Some((
+                                                    format!(
+                                                        "Removed API key for {}",
+                                                        provider_info.name
+                                                    ),
+                                                    false,
+                                                ));
                                             }
-                                        }
-                                    });
+                                        },
+                                    );
+                                } else {
+                                    ui.with_layout(
+                                        egui::Layout::right_to_left(egui::Align::Center),
+                                        |ui| {
+                                            ui.add_space(Spacing::XS);
+                                            if let Some(url) = provider_info.dashboard_url {
+                                                if text_button(
+                                                    ui,
+                                                    "Get key →",
+                                                    Theme::ACCENT_PRIMARY,
+                                                ) {
+                                                    let _ = open::that(url);
+                                                }
+                                            }
+                                        },
+                                    );
                                 }
                             });
 
@@ -1288,7 +1485,7 @@ impl PreferencesWindow {
                 .unwrap_or(&self.new_api_key_provider);
 
             egui::Frame::none()
-                .fill(Theme::BG_TERTIARY)
+                .fill(Theme::bg_tertiary())
                 .stroke(Stroke::new(1.0, Theme::ACCENT_PRIMARY.gamma_multiply(0.4)))
                 .rounding(Rounding::same(Radius::LG))
                 .inner_margin(Spacing::LG)
@@ -1296,8 +1493,8 @@ impl PreferencesWindow {
                     ui.label(
                         RichText::new(format!("Enter API Key for {}", provider_name))
                             .size(FontSize::MD)
-                            .color(Theme::TEXT_PRIMARY)
-                            .strong()
+                            .color(Theme::text_primary())
+                            .strong(),
                     );
 
                     ui.add_space(Spacing::SM);
@@ -1313,29 +1510,35 @@ impl PreferencesWindow {
                     ui.horizontal(|ui| {
                         let can_save = !self.new_api_key_value.trim().is_empty();
 
-                        if ui.add_enabled(
-                            can_save,
-                            egui::Button::new(
-                                RichText::new("Save")
-                                    .size(FontSize::SM)
-                                    .color(Color32::WHITE)
+                        if ui
+                            .add_enabled(
+                                can_save,
+                                egui::Button::new(
+                                    RichText::new("Save")
+                                        .size(FontSize::SM)
+                                        .color(Color32::WHITE),
+                                )
+                                .fill(if can_save {
+                                    Theme::GREEN
+                                } else {
+                                    Theme::bg_tertiary()
+                                })
+                                .rounding(Rounding::same(Radius::SM))
+                                .min_size(Vec2::new(80.0, 32.0)),
                             )
-                            .fill(if can_save { Theme::GREEN } else { Theme::BG_TERTIARY })
-                            .rounding(Rounding::same(Radius::SM))
-                            .min_size(Vec2::new(80.0, 32.0))
-                        ).clicked() {
+                            .clicked()
+                        {
                             self.api_keys.set(
                                 &self.new_api_key_provider,
                                 self.new_api_key_value.trim(),
                                 None,
                             );
                             if let Err(e) = self.api_keys.save() {
-                                self.api_key_status_msg = Some((format!("Failed to save: {}", e), true));
+                                self.api_key_status_msg =
+                                    Some((format!("Failed to save: {}", e), true));
                             } else {
-                                self.api_key_status_msg = Some((
-                                    format!("API key saved for {}", provider_name),
-                                    false,
-                                ));
+                                self.api_key_status_msg =
+                                    Some((format!("API key saved for {}", provider_name), false));
                                 self.show_api_key_input = false;
                                 self.new_api_key_value.clear();
                             }
@@ -1343,16 +1546,19 @@ impl PreferencesWindow {
 
                         ui.add_space(Spacing::XS);
 
-                        if ui.add(
-                            egui::Button::new(
-                                RichText::new("Cancel")
-                                    .size(FontSize::SM)
-                                    .color(Theme::TEXT_MUTED)
+                        if ui
+                            .add(
+                                egui::Button::new(
+                                    RichText::new("Cancel")
+                                        .size(FontSize::SM)
+                                        .color(Theme::text_muted()),
+                                )
+                                .fill(Color32::TRANSPARENT)
+                                .stroke(Stroke::new(1.0, Theme::border_subtle()))
+                                .rounding(Rounding::same(Radius::SM)),
                             )
-                            .fill(Color32::TRANSPARENT)
-                            .stroke(Stroke::new(1.0, Theme::BORDER_SUBTLE))
-                            .rounding(Rounding::same(Radius::SM))
-                        ).clicked() {
+                            .clicked()
+                        {
                             self.show_api_key_input = false;
                             self.new_api_key_value.clear();
                         }
@@ -1365,9 +1571,11 @@ impl PreferencesWindow {
         section_header(ui, "Browser Cookies");
 
         ui.label(
-            RichText::new("Cookies are automatically extracted from Chrome, Edge, Brave, and Firefox.")
-                .size(FontSize::SM)
-                .color(Theme::TEXT_MUTED),
+            RichText::new(
+                "Cookies are automatically extracted from Chrome, Edge, Brave, and Firefox.",
+            )
+            .size(FontSize::SM)
+            .color(Theme::text_muted()),
         );
 
         ui.add_space(Spacing::LG);
@@ -1393,12 +1601,12 @@ impl PreferencesWindow {
                         ui.label(
                             RichText::new(&cookie_info.provider)
                                 .size(FontSize::MD)
-                                .color(Theme::TEXT_PRIMARY)
+                                .color(Theme::text_primary()),
                         );
                         ui.label(
                             RichText::new(format!("· {}", &cookie_info.saved_at))
                                 .size(FontSize::SM)
-                                .color(Theme::TEXT_MUTED)
+                                .color(Theme::text_muted()),
                         );
 
                         ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
@@ -1416,7 +1624,8 @@ impl PreferencesWindow {
                 if let Some(provider_id) = to_remove {
                     self.cookies.remove(&provider_id);
                     let _ = self.cookies.save();
-                    self.cookie_status_msg = Some((format!("Removed cookie for {}", provider_id), false));
+                    self.cookie_status_msg =
+                        Some((format!("Removed cookie for {}", provider_id), false));
                 }
             });
 
@@ -1429,7 +1638,11 @@ impl PreferencesWindow {
         settings_card(ui, |ui| {
             // Provider selection row
             ui.horizontal(|ui| {
-                ui.label(RichText::new("Provider").size(FontSize::MD).color(Theme::TEXT_PRIMARY));
+                ui.label(
+                    RichText::new("Provider")
+                        .size(FontSize::MD)
+                        .color(Theme::text_primary()),
+                );
                 ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
                     egui::ComboBox::from_id_salt("cookie_provider")
                         .selected_text(if self.new_cookie_provider.is_empty() {
@@ -1441,10 +1654,13 @@ impl PreferencesWindow {
                             let web_providers = ["claude", "cursor", "kimi"];
                             for provider_name in web_providers {
                                 if let Some(id) = ProviderId::from_cli_name(provider_name) {
-                                    if ui.selectable_label(
-                                        self.new_cookie_provider == provider_name,
-                                        id.display_name(),
-                                    ).clicked() {
+                                    if ui
+                                        .selectable_label(
+                                            self.new_cookie_provider == provider_name,
+                                            id.display_name(),
+                                        )
+                                        .clicked()
+                                    {
                                         self.new_cookie_provider = provider_name.to_string();
                                     }
                                 }
@@ -1458,13 +1674,17 @@ impl PreferencesWindow {
             ui.add_space(Spacing::SM);
 
             // Cookie header label
-            ui.label(RichText::new("Cookie header").size(FontSize::MD).color(Theme::TEXT_PRIMARY));
+            ui.label(
+                RichText::new("Cookie header")
+                    .size(FontSize::MD)
+                    .color(Theme::text_primary()),
+            );
             ui.add_space(Spacing::SM);
 
             // Styled text input with visible border and rounded corners
             egui::Frame::none()
-                .fill(Theme::INPUT_BG)
-                .stroke(Stroke::new(1.0, Theme::BORDER_SUBTLE))
+                .fill(Theme::input_bg())
+                .stroke(Stroke::new(1.0, Theme::border_subtle()))
                 .rounding(Rounding::same(Radius::SM))
                 .inner_margin(Spacing::SM)
                 .show(ui, |ui| {
@@ -1479,28 +1699,44 @@ impl PreferencesWindow {
             ui.add_space(Spacing::LG);
 
             // Save button - filled primary style with proper sizing
-            let can_save = !self.new_cookie_provider.is_empty() && !self.new_cookie_value.is_empty();
+            let can_save =
+                !self.new_cookie_provider.is_empty() && !self.new_cookie_value.is_empty();
 
-            if ui.add_enabled(
-                can_save,
-                egui::Button::new(
-                    RichText::new("Save Cookie")
-                        .size(FontSize::SM)
-                        .color(if can_save { Color32::WHITE } else { Theme::TEXT_MUTED })
+            if ui
+                .add_enabled(
+                    can_save,
+                    egui::Button::new(RichText::new("Save Cookie").size(FontSize::SM).color(
+                        if can_save {
+                            Color32::WHITE
+                        } else {
+                            Theme::text_muted()
+                        },
+                    ))
+                    .fill(if can_save {
+                        Theme::ACCENT_PRIMARY
+                    } else {
+                        Theme::bg_tertiary()
+                    })
+                    .stroke(if can_save {
+                        Stroke::NONE
+                    } else {
+                        Stroke::new(1.0, Theme::border_subtle())
+                    })
+                    .rounding(Rounding::same(Radius::MD))
+                    .min_size(Vec2::new(120.0, 36.0)),
                 )
-                .fill(if can_save { Theme::ACCENT_PRIMARY } else { Theme::BG_TERTIARY })
-                .stroke(if can_save { Stroke::NONE } else { Stroke::new(1.0, Theme::BORDER_SUBTLE) })
-                .rounding(Rounding::same(Radius::MD))
-                .min_size(Vec2::new(120.0, 36.0))
-            ).clicked() {
-                self.cookies.set(&self.new_cookie_provider, &self.new_cookie_value);
+                .clicked()
+            {
+                self.cookies
+                    .set(&self.new_cookie_provider, &self.new_cookie_value);
                 if let Err(e) = self.cookies.save() {
                     self.cookie_status_msg = Some((format!("Failed to save: {}", e), true));
                 } else {
                     let provider_name = ProviderId::from_cli_name(&self.new_cookie_provider)
                         .map(|id| id.display_name().to_string())
                         .unwrap_or_else(|| self.new_cookie_provider.clone());
-                    self.cookie_status_msg = Some((format!("Cookie saved for {}", provider_name), false));
+                    self.cookie_status_msg =
+                        Some((format!("Cookie saved for {}", provider_name), false));
                     self.new_cookie_provider.clear();
                     self.new_cookie_value.clear();
                 }
@@ -1514,8 +1750,16 @@ impl PreferencesWindow {
         settings_card(ui, |ui| {
             ui.horizontal(|ui| {
                 ui.vertical(|ui| {
-                    ui.label(RichText::new("Auto-refresh interval").size(FontSize::MD).color(Theme::TEXT_PRIMARY));
-                    ui.label(RichText::new("How often to fetch usage data").size(FontSize::SM).color(Theme::TEXT_MUTED));
+                    ui.label(
+                        RichText::new("Auto-refresh interval")
+                            .size(FontSize::MD)
+                            .color(Theme::text_primary()),
+                    );
+                    ui.label(
+                        RichText::new("How often to fetch usage data")
+                            .size(FontSize::SM)
+                            .color(Theme::text_muted()),
+                    );
                 });
 
                 ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
@@ -1529,8 +1773,8 @@ impl PreferencesWindow {
                     ];
 
                     egui::Frame::none()
-                        .fill(Theme::BG_TERTIARY)
-                        .stroke(Stroke::new(1.0, Theme::BORDER_SUBTLE))
+                        .fill(Theme::bg_tertiary())
+                        .stroke(Stroke::new(1.0, Theme::border_subtle()))
                         .rounding(Rounding::same(Radius::SM))
                         .inner_margin(egui::Margin::symmetric(Spacing::XS, 2.0))
                         .show(ui, |ui| {
@@ -1538,17 +1782,22 @@ impl PreferencesWindow {
                                 .selected_text(
                                     intervals
                                         .iter()
-                                        .find(|(secs, _)| *secs == self.settings.refresh_interval_secs)
+                                        .find(|(secs, _)| {
+                                            *secs == self.settings.refresh_interval_secs
+                                        })
                                         .map(|(_, label)| *label)
                                         .unwrap_or("5 min"),
                                 )
                                 .show_ui(ui, |ui| {
                                     for (secs, label) in intervals {
-                                        if ui.selectable_value(
-                                            &mut self.settings.refresh_interval_secs,
-                                            secs,
-                                            label,
-                                        ).changed() {
+                                        if ui
+                                            .selectable_value(
+                                                &mut self.settings.refresh_interval_secs,
+                                                secs,
+                                                label,
+                                            )
+                                            .changed()
+                                        {
                                             self.settings_changed = true;
                                         }
                                     }
@@ -1564,7 +1813,12 @@ impl PreferencesWindow {
 
         settings_card(ui, |ui| {
             let mut enable_animations = self.settings.enable_animations;
-            if setting_toggle(ui, "Enable animations", "Animate charts and UI transitions", &mut enable_animations) {
+            if setting_toggle(
+                ui,
+                "Enable animations",
+                "Animate charts and UI transitions",
+                &mut enable_animations,
+            ) {
                 self.settings.enable_animations = enable_animations;
                 self.settings_changed = true;
             }
@@ -1577,8 +1831,16 @@ impl PreferencesWindow {
         settings_card(ui, |ui| {
             ui.horizontal(|ui| {
                 ui.vertical(|ui| {
-                    ui.label(RichText::new("Display mode").size(FontSize::MD).color(Theme::TEXT_PRIMARY));
-                    ui.label(RichText::new("How much detail to show in menu bar").size(FontSize::SM).color(Theme::TEXT_MUTED));
+                    ui.label(
+                        RichText::new("Display mode")
+                            .size(FontSize::MD)
+                            .color(Theme::text_primary()),
+                    );
+                    ui.label(
+                        RichText::new("How much detail to show in menu bar")
+                            .size(FontSize::SM)
+                            .color(Theme::text_muted()),
+                    );
                 });
 
                 ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
@@ -1589,8 +1851,8 @@ impl PreferencesWindow {
                     ];
 
                     egui::Frame::none()
-                        .fill(Theme::BG_TERTIARY)
-                        .stroke(Stroke::new(1.0, Theme::BORDER_SUBTLE))
+                        .fill(Theme::bg_tertiary())
+                        .stroke(Stroke::new(1.0, Theme::border_subtle()))
                         .rounding(Rounding::same(Radius::SM))
                         .inner_margin(egui::Margin::symmetric(Spacing::XS, 2.0))
                         .show(ui, |ui| {
@@ -1598,17 +1860,22 @@ impl PreferencesWindow {
                                 .selected_text(
                                     display_modes
                                         .iter()
-                                        .find(|(val, _)| *val == self.settings.menu_bar_display_mode)
+                                        .find(|(val, _)| {
+                                            *val == self.settings.menu_bar_display_mode
+                                        })
                                         .map(|(_, label)| *label)
                                         .unwrap_or("Detailed"),
                                 )
                                 .show_ui(ui, |ui| {
                                     for (value, label) in display_modes {
-                                        if ui.selectable_value(
-                                            &mut self.settings.menu_bar_display_mode,
-                                            value.to_string(),
-                                            label,
-                                        ).changed() {
+                                        if ui
+                                            .selectable_value(
+                                                &mut self.settings.menu_bar_display_mode,
+                                                value.to_string(),
+                                                label,
+                                            )
+                                            .changed()
+                                        {
                                             self.settings_changed = true;
                                         }
                                     }
@@ -1624,7 +1891,12 @@ impl PreferencesWindow {
 
         settings_card(ui, |ui| {
             let mut surprise = self.settings.surprise_animations;
-            if setting_toggle(ui, "Surprise me", "Random animations on tray icon", &mut surprise) {
+            if setting_toggle(
+                ui,
+                "Surprise me",
+                "Random animations on tray icon",
+                &mut surprise,
+            ) {
                 self.settings.surprise_animations = surprise;
                 self.settings_changed = true;
             }
@@ -1642,12 +1914,7 @@ impl PreferencesWindow {
                 .rounding(Rounding::same(16.0))
                 .inner_margin(Spacing::MD)
                 .show(ui, |ui| {
-                    ui.label(
-                        RichText::new("C")
-                            .size(32.0)
-                            .color(Color32::WHITE)
-                            .strong()
-                    );
+                    ui.label(RichText::new("C").size(32.0).color(Color32::WHITE).strong());
                 });
 
             ui.add_space(Spacing::MD);
@@ -1655,14 +1922,14 @@ impl PreferencesWindow {
             ui.label(
                 RichText::new("CodexBar")
                     .size(FontSize::XXL)
-                    .color(Theme::TEXT_PRIMARY)
-                    .strong()
+                    .color(Theme::text_primary())
+                    .strong(),
             );
 
             ui.label(
                 RichText::new(format!("Version {}", env!("CARGO_PKG_VERSION")))
                     .size(FontSize::SM)
-                    .color(Theme::TEXT_MUTED)
+                    .color(Theme::text_muted()),
             );
         });
 
@@ -1672,12 +1939,12 @@ impl PreferencesWindow {
             ui.label(
                 RichText::new("A Windows port of the macOS CodexBar app.")
                     .size(FontSize::MD)
-                    .color(Theme::TEXT_SECONDARY)
+                    .color(Theme::text_secondary()),
             );
             ui.label(
                 RichText::new("Track your AI provider usage from the system tray.")
                     .size(FontSize::MD)
-                    .color(Theme::TEXT_SECONDARY)
+                    .color(Theme::text_secondary()),
             );
         });
 
@@ -1688,7 +1955,7 @@ impl PreferencesWindow {
                 if ui.link("GitHub Repository").clicked() {
                     let _ = open::that("https://github.com/Finesssee/Win-CodexBar");
                 }
-                ui.label(RichText::new("·").color(Theme::TEXT_DIM));
+                ui.label(RichText::new("·").color(Theme::text_dim()));
                 if ui.link("Original macOS Version").clicked() {
                     let _ = open::that("https://github.com/steipete/CodexBar");
                 }
@@ -1698,16 +1965,19 @@ impl PreferencesWindow {
         ui.add_space(Spacing::LG);
 
         ui.vertical_centered(|ui| {
-            if ui.add(
-                egui::Button::new(
-                    RichText::new("Check for Updates")
-                        .size(FontSize::SM)
-                        .color(Theme::TEXT_PRIMARY)
+            if ui
+                .add(
+                    egui::Button::new(
+                        RichText::new("Check for Updates")
+                            .size(FontSize::SM)
+                            .color(Theme::text_primary()),
+                    )
+                    .fill(Theme::bg_secondary())
+                    .stroke(Stroke::new(1.0, Theme::border_subtle()))
+                    .rounding(Rounding::same(Radius::SM)),
                 )
-                .fill(Theme::BG_SECONDARY)
-                .stroke(Stroke::new(1.0, Theme::BORDER_SUBTLE))
-                .rounding(Rounding::same(Radius::SM))
-            ).clicked() {
+                .clicked()
+            {
                 let _ = open::that("https://github.com/Finesssee/Win-CodexBar/releases");
             }
         });
@@ -1718,14 +1988,17 @@ impl PreferencesWindow {
             ui.label(
                 RichText::new("Built with Rust + egui")
                     .size(FontSize::XS)
-                    .color(Theme::TEXT_DIM)
+                    .color(Theme::text_dim()),
             );
         });
     }
-
 }
 
-fn settings_position_near_main_window(main_rect: Rect, settings_size: Vec2, monitor_size: Rect) -> egui::Pos2 {
+fn settings_position_near_main_window(
+    main_rect: Rect,
+    settings_size: Vec2,
+    monitor_size: Rect,
+) -> egui::Pos2 {
     let margin = 12.0;
     let gap = 12.0;
 
@@ -1767,18 +2040,12 @@ fn settings_position_near_main_window(main_rect: Rect, settings_size: Vec2, moni
     };
 
     let (x, y) = match best_side {
-        "right" => (
-            clamp_x(main_rect.max.x + gap),
-            clamp_y(main_rect.min.y),
-        ),
+        "right" => (clamp_x(main_rect.max.x + gap), clamp_y(main_rect.min.y)),
         "left" => (
             clamp_x(main_rect.min.x - settings_size.x - gap),
             clamp_y(main_rect.min.y),
         ),
-        "bottom" => (
-            clamp_x(main_rect.min.x),
-            clamp_y(main_rect.max.y + gap),
-        ),
+        "bottom" => (clamp_x(main_rect.min.x), clamp_y(main_rect.max.y + gap)),
         _ => (
             clamp_x(main_rect.min.x),
             clamp_y(main_rect.min.y - settings_size.y - gap),
@@ -1810,8 +2077,14 @@ fn work_area_rect(ctx: &egui::Context) -> Option<Rect> {
         if ok {
             let pixels_per_point = ctx.pixels_per_point().max(0.1);
             return Some(Rect::from_min_max(
-                egui::pos2(rect.left as f32 / pixels_per_point, rect.top as f32 / pixels_per_point),
-                egui::pos2(rect.right as f32 / pixels_per_point, rect.bottom as f32 / pixels_per_point),
+                egui::pos2(
+                    rect.left as f32 / pixels_per_point,
+                    rect.top as f32 / pixels_per_point,
+                ),
+                egui::pos2(
+                    rect.right as f32 / pixels_per_point,
+                    rect.bottom as f32 / pixels_per_point,
+                ),
             ));
         }
     }
@@ -1858,26 +2131,33 @@ fn render_settings_ui(ui: &mut egui::Ui, shared_state: &Arc<Mutex<PreferencesSha
         // Allocate the entire tab bar as one row
         let (tab_bar_rect, _) = ui.allocate_exact_size(
             Vec2::new(ui.available_width(), tab_height),
-            egui::Sense::hover()
+            egui::Sense::hover(),
         );
 
         for (i, tab) in tabs.iter().enumerate() {
             let is_selected = active_tab == *tab;
 
             let tab_rect = Rect::from_min_size(
-                egui::pos2(tab_bar_rect.min.x + start_x + i as f32 * tab_width, tab_bar_rect.min.y),
+                egui::pos2(
+                    tab_bar_rect.min.x + start_x + i as f32 * tab_width,
+                    tab_bar_rect.min.y,
+                ),
                 Vec2::new(tab_width, tab_height),
             );
 
             // Check for click
-            let response = ui.interact(tab_rect, ui.id().with(format!("tab_{}", i)), egui::Sense::click());
+            let response = ui.interact(
+                tab_rect,
+                ui.id().with(format!("tab_{}", i)),
+                egui::Sense::click(),
+            );
 
             // Background for selected/hovered
             if is_selected {
                 ui.painter().rect_filled(
                     tab_rect.shrink(2.0),
                     Rounding::same(Radius::MD),
-                    Theme::CARD_BG,
+                    Theme::card_bg(),
                 );
             } else if response.hovered() {
                 ui.painter().rect_filled(
@@ -1888,7 +2168,11 @@ fn render_settings_ui(ui: &mut egui::Ui, shared_state: &Arc<Mutex<PreferencesSha
             }
 
             // Icon (centered, larger)
-            let icon_color = if is_selected { Theme::ACCENT_PRIMARY } else { Theme::TEXT_MUTED };
+            let icon_color = if is_selected {
+                Theme::ACCENT_PRIMARY
+            } else {
+                Theme::text_muted()
+            };
             ui.painter().text(
                 egui::pos2(tab_rect.center().x, tab_rect.min.y + 20.0),
                 egui::Align2::CENTER_CENTER,
@@ -1898,7 +2182,11 @@ fn render_settings_ui(ui: &mut egui::Ui, shared_state: &Arc<Mutex<PreferencesSha
             );
 
             // Label below icon
-            let label_color = if is_selected { Theme::TEXT_PRIMARY } else { Theme::TEXT_MUTED };
+            let label_color = if is_selected {
+                Theme::text_primary()
+            } else {
+                Theme::text_muted()
+            };
             ui.painter().text(
                 egui::pos2(tab_rect.center().x, tab_rect.min.y + 44.0),
                 egui::Align2::CENTER_CENTER,
@@ -1916,11 +2204,10 @@ fn render_settings_ui(ui: &mut egui::Ui, shared_state: &Arc<Mutex<PreferencesSha
 
         // Separator line
         ui.add_space(Spacing::SM);
-        let separator_rect = Rect::from_min_size(
-            ui.cursor().min,
-            Vec2::new(ui.available_width(), 1.0),
-        );
-        ui.painter().rect_filled(separator_rect, 0.0, Theme::SEPARATOR);
+        let separator_rect =
+            Rect::from_min_size(ui.cursor().min, Vec2::new(ui.available_width(), 1.0));
+        ui.painter()
+            .rect_filled(separator_rect, 0.0, Theme::separator());
         ui.add_space(Spacing::SM);
 
         // ═══════════════════════════════════════════════════════════
@@ -1956,13 +2243,17 @@ fn render_settings_ui(ui: &mut egui::Ui, shared_state: &Arc<Mutex<PreferencesSha
 }
 
 /// Render Providers tab with macOS-style sidebar + detail layout
-fn render_providers_tab_macos(ui: &mut egui::Ui, available_height: f32, shared_state: &Arc<Mutex<PreferencesSharedState>>) {
+fn render_providers_tab_macos(
+    ui: &mut egui::Ui,
+    available_height: f32,
+    shared_state: &Arc<Mutex<PreferencesSharedState>>,
+) {
     // macOS metrics
-    let sidebar_width = 240.0;  // ProviderSettingsMetrics.sidebarWidth
-    let sidebar_corner_radius = 12.0;  // sidebarCornerRadius
-    let icon_size = 18.0;  // iconSize
+    let sidebar_width = 240.0; // ProviderSettingsMetrics.sidebarWidth
+    let sidebar_corner_radius = 12.0; // sidebarCornerRadius
+    let icon_size = 18.0; // iconSize
     let total_width = ui.available_width();
-    let detail_width = (total_width - sidebar_width - Spacing::LG).min(640.0);  // detailMaxWidth
+    let detail_width = (total_width - sidebar_width - Spacing::LG).min(640.0); // detailMaxWidth
 
     // Get selected provider
     let selected_provider = if let Ok(state) = shared_state.lock() {
@@ -1983,9 +2274,9 @@ fn render_providers_tab_macos(ui: &mut egui::Ui, available_height: f32, shared_s
         egui::Layout::top_down(egui::Align::LEFT),
         |ui| {
             egui::Frame::none()
-                .fill(Theme::BG_SECONDARY)
+                .fill(Theme::bg_secondary())
                 .rounding(Rounding::same(sidebar_corner_radius))
-                .stroke(Stroke::new(1.0, Theme::SEPARATOR))
+                .stroke(Stroke::new(1.0, Theme::separator()))
                 .inner_margin(Spacing::SM)
                 .show(ui, |ui| {
                     egui::ScrollArea::vertical()
@@ -1996,11 +2287,16 @@ fn render_providers_tab_macos(ui: &mut egui::Ui, available_height: f32, shared_s
                             for provider_id in providers {
                                 let is_selected = *provider_id == selected;
                                 let is_enabled = if let Ok(state) = shared_state.lock() {
-                                    state.settings.enabled_providers.contains(provider_id.cli_name())
-                                } else { true };
+                                    state
+                                        .settings
+                                        .enabled_providers
+                                        .contains(provider_id.cli_name())
+                                } else {
+                                    true
+                                };
 
                                 let brand_color = provider_color(provider_id.cli_name());
-                                let row_height = 44.0;  // Compact rows
+                                let row_height = 44.0; // Compact rows
                                 let row_width = sidebar_width - Spacing::SM * 4.0;
 
                                 // Row with vertical padding of 2px
@@ -2008,7 +2304,7 @@ fn render_providers_tab_macos(ui: &mut egui::Ui, available_height: f32, shared_s
 
                                 let (rect, response) = ui.allocate_exact_size(
                                     Vec2::new(row_width, row_height),
-                                    egui::Sense::click()
+                                    egui::Sense::click(),
                                 );
 
                                 // Selection/hover background - use gray like macOS
@@ -2039,7 +2335,7 @@ fn render_providers_tab_macos(ui: &mut egui::Ui, available_height: f32, shared_s
                                         ui.painter().circle_filled(
                                             egui::pos2(x, y),
                                             1.0,
-                                            Theme::TEXT_MUTED,
+                                            Theme::text_muted(),
                                         );
                                     }
                                 }
@@ -2054,12 +2350,19 @@ fn render_providers_tab_macos(ui: &mut egui::Ui, available_height: f32, shared_s
                                 // Try to get SVG icon from cache
                                 let has_svg_icon = VIEWPORT_ICON_CACHE.with(|cache| {
                                     let mut cache = cache.borrow_mut();
-                                    if let Some(texture) = cache.get_icon(ui.ctx(), provider_id.cli_name(), icon_size as u32) {
+                                    if let Some(texture) = cache.get_icon(
+                                        ui.ctx(),
+                                        provider_id.cli_name(),
+                                        icon_size as u32,
+                                    ) {
                                         // Paint the texture
                                         ui.painter().image(
                                             texture.id(),
                                             icon_rect,
-                                            Rect::from_min_max(egui::pos2(0.0, 0.0), egui::pos2(1.0, 1.0)),
+                                            Rect::from_min_max(
+                                                egui::pos2(0.0, 0.0),
+                                                egui::pos2(1.0, 1.0),
+                                            ),
                                             Color32::WHITE,
                                         );
                                         true
@@ -2087,12 +2390,12 @@ fn render_providers_tab_macos(ui: &mut egui::Ui, available_height: f32, shared_s
                                 let name_galley = ui.painter().layout_no_wrap(
                                     name_text.to_string(),
                                     egui::FontId::proportional(14.0),
-                                    Theme::TEXT_PRIMARY,
+                                    Theme::text_primary(),
                                 );
                                 ui.painter().galley(
                                     egui::pos2(text_x, rect.center().y - 10.0),
                                     name_galley,
-                                    Theme::TEXT_PRIMARY,
+                                    Theme::text_primary(),
                                 );
 
                                 // Status dot (small, after name) - only shown for enabled
@@ -2112,7 +2415,7 @@ fn render_providers_tab_macos(ui: &mut egui::Ui, available_height: f32, shared_s
                                     egui::Align2::LEFT_CENTER,
                                     provider_id.cli_name(),
                                     egui::FontId::proportional(11.0),
-                                    Theme::TEXT_SECONDARY,
+                                    Theme::text_secondary(),
                                 );
 
                                 // Toggle checkbox on right - use small checkbox style like macOS
@@ -2127,7 +2430,14 @@ fn render_providers_tab_macos(ui: &mut egui::Ui, available_height: f32, shared_s
                                 ui.painter().rect_stroke(
                                     checkbox_rect,
                                     Rounding::same(3.0),
-                                    Stroke::new(1.0, if is_enabled { Theme::ACCENT_PRIMARY } else { Theme::TEXT_MUTED }),
+                                    Stroke::new(
+                                        1.0,
+                                        if is_enabled {
+                                            Theme::ACCENT_PRIMARY
+                                        } else {
+                                            Theme::text_muted()
+                                        },
+                                    ),
                                 );
 
                                 // Fill and checkmark if enabled
@@ -2157,12 +2467,15 @@ fn render_providers_tab_macos(ui: &mut egui::Ui, available_height: f32, shared_s
                             }
                         });
                 });
-        }
+        },
     );
 
     // Move cursor to the right of sidebar
     let detail_rect = egui::Rect::from_min_size(
-        egui::pos2(sidebar_rect.min.x + sidebar_width + Spacing::MD, sidebar_rect.min.y),
+        egui::pos2(
+            sidebar_rect.min.x + sidebar_width + Spacing::MD,
+            sidebar_rect.min.y,
+        ),
         Vec2::new(detail_width, available_height),
     );
 
@@ -2179,16 +2492,28 @@ fn render_providers_tab_macos(ui: &mut egui::Ui, available_height: f32, shared_s
 }
 
 /// Render the provider detail panel (right side)
-fn render_provider_detail_panel(ui: &mut egui::Ui, provider_id: ProviderId, shared_state: &Arc<Mutex<PreferencesSharedState>>) {
+fn render_provider_detail_panel(
+    ui: &mut egui::Ui,
+    provider_id: ProviderId,
+    shared_state: &Arc<Mutex<PreferencesSharedState>>,
+) {
     let brand_color = provider_color(provider_id.cli_name());
 
     let is_enabled = if let Ok(state) = shared_state.lock() {
-        state.settings.enabled_providers.contains(provider_id.cli_name())
-    } else { true };
+        state
+            .settings
+            .enabled_providers
+            .contains(provider_id.cli_name())
+    } else {
+        true
+    };
 
     // Use cached snapshot data for this provider (loaded once, not every frame)
     let entry = if let Ok(state) = shared_state.lock() {
-        state.cached_snapshot.as_ref().and_then(|s| s.entry_for(provider_id).cloned())
+        state
+            .cached_snapshot
+            .as_ref()
+            .and_then(|s| s.entry_for(provider_id).cloned())
     } else {
         None
     };
@@ -2212,7 +2537,9 @@ fn render_provider_detail_panel(ui: &mut egui::Ui, provider_id: ProviderId, shar
         let icon_size = 28.0;
         let has_svg = VIEWPORT_ICON_CACHE.with(|cache| {
             let mut cache = cache.borrow_mut();
-            if let Some(texture) = cache.get_icon(ui.ctx(), provider_id.cli_name(), icon_size as u32) {
+            if let Some(texture) =
+                cache.get_icon(ui.ctx(), provider_id.cli_name(), icon_size as u32)
+            {
                 ui.add(egui::Image::new(texture).fit_to_exact_size(Vec2::splat(icon_size)));
                 true
             } else {
@@ -2224,7 +2551,7 @@ fn render_provider_detail_panel(ui: &mut egui::Ui, provider_id: ProviderId, shar
             ui.label(
                 RichText::new(provider_icon(provider_id.cli_name()))
                     .size(icon_size)
-                    .color(brand_color)
+                    .color(brand_color),
             );
         }
 
@@ -2234,8 +2561,8 @@ fn render_provider_detail_panel(ui: &mut egui::Ui, provider_id: ProviderId, shar
             ui.label(
                 RichText::new(provider_id.display_name())
                     .size(FontSize::LG)
-                    .color(Theme::TEXT_PRIMARY)
-                    .strong()
+                    .color(Theme::text_primary())
+                    .strong(),
             );
             let updated_str = if let Some(ts) = updated_at {
                 let now = chrono::Utc::now();
@@ -2255,14 +2582,18 @@ fn render_provider_detail_panel(ui: &mut egui::Ui, provider_id: ProviderId, shar
             ui.label(
                 RichText::new(format!("{} • {}", provider_id.cli_name(), updated_str))
                     .size(FontSize::SM)
-                    .color(Theme::TEXT_MUTED)
+                    .color(Theme::text_muted()),
             );
         });
 
         ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
             // Toggle switch
             let mut enabled = is_enabled;
-            if switch_toggle(ui, egui::Id::new(format!("detail_toggle_{}", provider_id.cli_name())), &mut enabled) {
+            if switch_toggle(
+                ui,
+                egui::Id::new(format!("detail_toggle_{}", provider_id.cli_name())),
+                &mut enabled,
+            ) {
                 if let Ok(mut state) = shared_state.lock() {
                     let name = provider_id.cli_name().to_string();
                     if enabled {
@@ -2277,13 +2608,20 @@ fn render_provider_detail_panel(ui: &mut egui::Ui, provider_id: ProviderId, shar
             ui.add_space(16.0);
 
             // Refresh button
-            if ui.add(
-                egui::Button::new(RichText::new("↻").size(FontSize::MD).color(Theme::TEXT_SECONDARY))
+            if ui
+                .add(
+                    egui::Button::new(
+                        RichText::new("↻")
+                            .size(FontSize::MD)
+                            .color(Theme::text_secondary()),
+                    )
                     .fill(Color32::TRANSPARENT)
-                    .stroke(Stroke::new(1.0, Theme::CARD_BORDER))
+                    .stroke(Stroke::new(1.0, Theme::card_border()))
                     .rounding(Rounding::same(Radius::SM))
-                    .min_size(Vec2::new(32.0, 32.0))
-            ).clicked() {
+                    .min_size(Vec2::new(32.0, 32.0)),
+                )
+                .clicked()
+            {
                 if let Ok(mut state) = shared_state.lock() {
                     state.refresh_requested = true;
                 }
@@ -2313,13 +2651,19 @@ fn render_provider_detail_panel(ui: &mut egui::Ui, provider_id: ProviderId, shar
     };
     let hide_personal_info = if let Ok(state) = shared_state.lock() {
         state.settings.hide_personal_info
-    } else { false };
+    } else {
+        false
+    };
     let account_display = if account_email.is_some() {
         PersonalInfoRedactor::redact_email(account_email.as_deref(), hide_personal_info)
     } else {
         "Not logged in".to_string()
     };
-    let account_display = if account_display.is_empty() { "Not logged in".to_string() } else { account_display };
+    let account_display = if account_display.is_empty() {
+        "Not logged in".to_string()
+    } else {
+        account_display
+    };
     let plan_display = login_method.as_deref().unwrap_or("Unknown");
 
     egui::Grid::new("provider_info_grid")
@@ -2343,8 +2687,8 @@ fn render_provider_detail_panel(ui: &mut egui::Ui, provider_id: ProviderId, shar
     ui.label(
         RichText::new("Usage")
             .size(FontSize::MD)
-            .color(Theme::TEXT_PRIMARY)
-            .strong()
+            .color(Theme::text_primary())
+            .strong(),
     );
     ui.add_space(Spacing::SM);
 
@@ -2357,9 +2701,17 @@ fn render_provider_detail_panel(ui: &mut egui::Ui, provider_id: ProviderId, shar
             if diff.num_seconds() <= 0 {
                 return Some("Resetting...".to_string());
             } else if diff.num_hours() >= 24 {
-                return Some(format!("Resets in {}d {}h", diff.num_days(), diff.num_hours() % 24));
+                return Some(format!(
+                    "Resets in {}d {}h",
+                    diff.num_days(),
+                    diff.num_hours() % 24
+                ));
             } else {
-                return Some(format!("Resets in {}h {}m", diff.num_hours(), diff.num_minutes() % 60));
+                return Some(format!(
+                    "Resets in {}h {}m",
+                    diff.num_hours(),
+                    diff.num_minutes() % 60
+                ));
             }
         }
         // Fall back to reset_description if available (for CLI/web sources without parsed timestamp)
@@ -2368,13 +2720,22 @@ fn render_provider_detail_panel(ui: &mut egui::Ui, provider_id: ProviderId, shar
 
     let show_as_used = if let Ok(state) = shared_state.lock() {
         state.settings.show_as_used
-    } else { true };
+    } else {
+        true
+    };
 
     // Session usage bar (primary rate)
     if let Some(ref rate) = primary_rate {
         let (percent, label) = usage_display(rate.used_percent, show_as_used);
         let reset_str = format_reset(rate);
-        usage_bar_row(ui, "Session", percent as f32, &label, reset_str.as_deref(), brand_color);
+        usage_bar_row(
+            ui,
+            "Session",
+            percent as f32,
+            &label,
+            reset_str.as_deref(),
+            brand_color,
+        );
         ui.add_space(8.0);
     }
 
@@ -2382,7 +2743,14 @@ fn render_provider_detail_panel(ui: &mut egui::Ui, provider_id: ProviderId, shar
     if let Some(ref rate) = secondary_rate {
         let (percent, label) = usage_display(rate.used_percent, show_as_used);
         let reset_str = format_reset(rate);
-        usage_bar_row(ui, "Weekly", percent as f32, &label, reset_str.as_deref(), brand_color);
+        usage_bar_row(
+            ui,
+            "Weekly",
+            percent as f32,
+            &label,
+            reset_str.as_deref(),
+            brand_color,
+        );
         ui.add_space(8.0);
     }
 
@@ -2390,7 +2758,14 @@ fn render_provider_detail_panel(ui: &mut egui::Ui, provider_id: ProviderId, shar
     if let Some(ref rate) = tertiary_rate {
         let (percent, label) = usage_display(rate.used_percent, show_as_used);
         let reset_str = rate.reset_description.as_deref();
-        usage_bar_row(ui, "Code review", percent as f32, &label, reset_str, brand_color);
+        usage_bar_row(
+            ui,
+            "Code review",
+            percent as f32,
+            &label,
+            reset_str,
+            brand_color,
+        );
         ui.add_space(8.0);
     }
 
@@ -2412,13 +2787,17 @@ fn render_provider_detail_panel(ui: &mut egui::Ui, provider_id: ProviderId, shar
     ui.label(
         RichText::new("Tray Display")
             .size(FontSize::MD)
-            .color(Theme::TEXT_PRIMARY)
-            .strong()
+            .color(Theme::text_primary())
+            .strong(),
     );
     ui.add_space(Spacing::SM);
 
     ui.horizontal(|ui| {
-        ui.label(RichText::new("Show in tray").size(FontSize::SM).color(Theme::TEXT_SECONDARY));
+        ui.label(
+            RichText::new("Show in tray")
+                .size(FontSize::SM)
+                .color(Theme::text_secondary()),
+        );
         ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
             let current_metric = if let Ok(state) = shared_state.lock() {
                 state.settings.get_provider_metric(provider_id)
@@ -2427,8 +2806,8 @@ fn render_provider_detail_panel(ui: &mut egui::Ui, provider_id: ProviderId, shar
             };
 
             egui::Frame::none()
-                .fill(Theme::BG_TERTIARY)
-                .stroke(Stroke::new(1.0, Theme::BORDER_SUBTLE))
+                .fill(Theme::bg_tertiary())
+                .stroke(Stroke::new(1.0, Theme::border_subtle()))
                 .rounding(Rounding::same(Radius::SM))
                 .inner_margin(egui::Margin::symmetric(Spacing::XS, 2.0))
                 .show(ui, |ui| {
@@ -2439,7 +2818,10 @@ fn render_provider_detail_panel(ui: &mut egui::Ui, provider_id: ProviderId, shar
                         .selected_text(selected.display_name())
                         .show_ui(ui, |ui| {
                             for metric in metrics {
-                                if ui.selectable_value(&mut selected, *metric, metric.display_name()).changed() {
+                                if ui
+                                    .selectable_value(&mut selected, *metric, metric.display_name())
+                                    .changed()
+                                {
                                     if let Ok(mut state) = shared_state.lock() {
                                         state.settings.set_provider_metric(provider_id, selected);
                                         state.settings_changed = true;
@@ -2461,13 +2843,13 @@ fn render_provider_detail_panel(ui: &mut egui::Ui, provider_id: ProviderId, shar
             ui.label(
                 RichText::new("Credits")
                     .size(FontSize::SM)
-                    .color(Theme::TEXT_SECONDARY)
+                    .color(Theme::text_secondary()),
             );
             ui.add_space(16.0);
             ui.label(
                 RichText::new(format!("{:.1} left", credits))
                     .size(FontSize::SM)
-                    .color(Theme::TEXT_PRIMARY)
+                    .color(Theme::text_primary()),
             );
         });
         ui.add_space(Spacing::SM);
@@ -2476,34 +2858,41 @@ fn render_provider_detail_panel(ui: &mut egui::Ui, provider_id: ProviderId, shar
     // ═══════════════════════════════════════════════════════════
     // COST SECTION
     // ═══════════════════════════════════════════════════════════
-    let (today_cost, today_tokens, monthly_cost, monthly_tokens) = if let Some(ref usage) = token_usage {
-        (
-            usage.session_cost_usd.unwrap_or(0.0),
-            usage.session_tokens.unwrap_or(0),
-            usage.last_30_days_cost_usd.unwrap_or(0.0),
-            usage.last_30_days_tokens.unwrap_or(0),
-        )
-    } else {
-        (0.0, 0, 0.0, 0)
-    };
+    let (today_cost, today_tokens, monthly_cost, monthly_tokens) =
+        if let Some(ref usage) = token_usage {
+            (
+                usage.session_cost_usd.unwrap_or(0.0),
+                usage.session_tokens.unwrap_or(0),
+                usage.last_30_days_cost_usd.unwrap_or(0.0),
+                usage.last_30_days_tokens.unwrap_or(0),
+            )
+        } else {
+            (0.0, 0, 0.0, 0)
+        };
 
     ui.horizontal(|ui| {
         ui.label(
             RichText::new("Cost")
                 .size(FontSize::SM)
-                .color(Theme::TEXT_SECONDARY)
+                .color(Theme::text_secondary()),
         );
         ui.add_space(32.0);
         ui.vertical(|ui| {
             ui.label(
-                RichText::new(format!("Today: ${:.2} • {} tokens", today_cost, today_tokens))
-                    .size(FontSize::SM)
-                    .color(Theme::TEXT_PRIMARY)
+                RichText::new(format!(
+                    "Today: ${:.2} • {} tokens",
+                    today_cost, today_tokens
+                ))
+                .size(FontSize::SM)
+                .color(Theme::text_primary()),
             );
             ui.label(
-                RichText::new(format!("Last 30 days: ${:.2} • {} tokens", monthly_cost, monthly_tokens))
-                    .size(FontSize::SM)
-                    .color(Theme::TEXT_MUTED)
+                RichText::new(format!(
+                    "Last 30 days: ${:.2} • {} tokens",
+                    monthly_cost, monthly_tokens
+                ))
+                .size(FontSize::SM)
+                .color(Theme::text_muted()),
             );
         });
     });
@@ -2516,8 +2905,8 @@ fn render_provider_detail_panel(ui: &mut egui::Ui, provider_id: ProviderId, shar
     ui.label(
         RichText::new("Settings")
             .size(FontSize::MD)
-            .color(Theme::TEXT_PRIMARY)
-            .strong()
+            .color(Theme::text_primary())
+            .strong(),
     );
     ui.add_space(Spacing::SM);
 
@@ -2526,7 +2915,7 @@ fn render_provider_detail_panel(ui: &mut egui::Ui, provider_id: ProviderId, shar
         ui.label(
             RichText::new("Menu bar metric")
                 .size(FontSize::SM)
-                .color(Theme::TEXT_SECONDARY)
+                .color(Theme::text_secondary()),
         );
 
         ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
@@ -2545,7 +2934,7 @@ fn render_provider_detail_panel(ui: &mut egui::Ui, provider_id: ProviderId, shar
     ui.label(
         RichText::new("Choose which window drives the menu bar percent.")
             .size(FontSize::XS)
-            .color(Theme::TEXT_MUTED)
+            .color(Theme::text_muted()),
     );
 
     ui.add_space(Spacing::MD);
@@ -2555,14 +2944,14 @@ fn render_provider_detail_panel(ui: &mut egui::Ui, provider_id: ProviderId, shar
         ui.label(
             RichText::new("Usage source")
                 .size(FontSize::SM)
-                .color(Theme::TEXT_SECONDARY)
+                .color(Theme::text_secondary()),
         );
 
         ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
             ui.label(
                 RichText::new("oauth + web")
                     .size(FontSize::XS)
-                    .color(Theme::TEXT_MUTED)
+                    .color(Theme::text_muted()),
             );
             ui.add_space(8.0);
             egui::ComboBox::from_id_salt(format!("source_{}", provider_id.cli_name()))
@@ -2580,7 +2969,7 @@ fn render_provider_detail_panel(ui: &mut egui::Ui, provider_id: ProviderId, shar
     ui.label(
         RichText::new("Auto falls back to the next source if the preferred one fails.")
             .size(FontSize::XS)
-            .color(Theme::TEXT_MUTED)
+            .color(Theme::text_muted()),
     );
 
     // ═══════════════════════════════════════════════════════════
@@ -2597,37 +2986,47 @@ fn info_row(ui: &mut egui::Ui, label: &str, value: &str) {
     ui.label(
         RichText::new(label)
             .size(FontSize::SM)
-            .color(Theme::TEXT_SECONDARY)
+            .color(Theme::text_secondary()),
     );
     ui.label(
         RichText::new(value)
             .size(FontSize::SM)
-            .color(Theme::TEXT_PRIMARY)
+            .color(Theme::text_primary()),
     );
     ui.end_row();
 }
 
 /// Helper: Usage bar row with label, percentage, info text
-fn usage_bar_row(ui: &mut egui::Ui, label: &str, percent: f32, info: &str, reset: Option<&str>, color: Color32) {
+fn usage_bar_row(
+    ui: &mut egui::Ui,
+    label: &str,
+    percent: f32,
+    info: &str,
+    reset: Option<&str>,
+    color: Color32,
+) {
     ui.horizontal(|ui| {
         ui.label(
             RichText::new(label)
                 .size(FontSize::SM)
-                .color(Theme::TEXT_SECONDARY)
+                .color(Theme::text_secondary()),
         );
         ui.add_space(8.0);
 
         // Progress bar
         let bar_width = 200.0;
         let bar_height = 8.0;
-        let (rect, _) = ui.allocate_exact_size(Vec2::new(bar_width, bar_height), egui::Sense::hover());
+        let (rect, _) =
+            ui.allocate_exact_size(Vec2::new(bar_width, bar_height), egui::Sense::hover());
 
-        ui.painter().rect_filled(rect, Rounding::same(4.0), Theme::progress_track());
+        ui.painter()
+            .rect_filled(rect, Rounding::same(4.0), Theme::progress_track());
 
         let fill_width = rect.width() * (percent / 100.0).clamp(0.0, 1.0);
         if fill_width > 0.0 {
             let fill_rect = Rect::from_min_size(rect.min, Vec2::new(fill_width, bar_height));
-            ui.painter().rect_filled(fill_rect, Rounding::same(4.0), color);
+            ui.painter()
+                .rect_filled(fill_rect, Rounding::same(4.0), color);
         }
 
         ui.add_space(8.0);
@@ -2635,7 +3034,7 @@ fn usage_bar_row(ui: &mut egui::Ui, label: &str, percent: f32, info: &str, reset
         ui.label(
             RichText::new(info)
                 .size(FontSize::XS)
-                .color(Theme::TEXT_MUTED)
+                .color(Theme::text_muted()),
         );
 
         if let Some(reset_text) = reset {
@@ -2643,7 +3042,7 @@ fn usage_bar_row(ui: &mut egui::Ui, label: &str, percent: f32, info: &str, reset
                 ui.label(
                     RichText::new(reset_text)
                         .size(FontSize::XS)
-                        .color(Theme::TEXT_MUTED)
+                        .color(Theme::text_muted()),
                 );
             });
         }
@@ -2668,7 +3067,11 @@ fn usage_display(used_percent: f64, show_as_used: bool) -> (f64, String) {
 }
 
 /// Render Accounts section for token account switching
-fn render_accounts_section(ui: &mut egui::Ui, provider_id: ProviderId, shared_state: &Arc<Mutex<PreferencesSharedState>>) {
+fn render_accounts_section(
+    ui: &mut egui::Ui,
+    provider_id: ProviderId,
+    shared_state: &Arc<Mutex<PreferencesSharedState>>,
+) {
     let support = match TokenAccountSupport::for_provider(provider_id) {
         Some(s) => s,
         None => return,
@@ -2677,21 +3080,29 @@ fn render_accounts_section(ui: &mut egui::Ui, provider_id: ProviderId, shared_st
     ui.label(
         RichText::new(support.title)
             .size(FontSize::MD)
-            .color(Theme::TEXT_PRIMARY)
-            .strong()
+            .color(Theme::text_primary())
+            .strong(),
     );
     ui.add_space(4.0);
     ui.label(
         RichText::new(support.subtitle)
             .size(FontSize::XS)
-            .color(Theme::TEXT_MUTED)
+            .color(Theme::text_muted()),
     );
     ui.add_space(Spacing::SM);
 
     // Get current accounts for this provider
     let (accounts_data, show_add, status_msg) = if let Ok(state) = shared_state.lock() {
-        let data = state.token_accounts.get(&provider_id).cloned().unwrap_or_default();
-        (data, state.show_add_account_input, state.token_account_status_msg.clone())
+        let data = state
+            .token_accounts
+            .get(&provider_id)
+            .cloned()
+            .unwrap_or_default();
+        (
+            data,
+            state.show_add_account_input,
+            state.token_account_status_msg.clone(),
+        )
     } else {
         (ProviderAccountData::default(), false, None)
     };
@@ -2721,9 +3132,11 @@ fn render_accounts_section(ui: &mut egui::Ui, provider_id: ProviderId, shared_st
                         // Save to disk
                         let store = TokenAccountStore::new();
                         if let Err(e) = store.save(&state.token_accounts) {
-                            state.token_account_status_msg = Some((format!("Failed to save: {}", e), true));
+                            state.token_account_status_msg =
+                                Some((format!("Failed to save: {}", e), true));
                         } else {
-                            state.token_account_status_msg = Some(("Account switched".to_string(), false));
+                            state.token_account_status_msg =
+                                Some(("Account switched".to_string(), false));
                         }
                     }
                 }
@@ -2734,7 +3147,11 @@ fn render_accounts_section(ui: &mut egui::Ui, provider_id: ProviderId, shared_st
                 ui.label(
                     RichText::new(account.display_name())
                         .size(FontSize::SM)
-                        .color(if is_active { Theme::TEXT_PRIMARY } else { Theme::TEXT_SECONDARY })
+                        .color(if is_active {
+                            Theme::text_primary()
+                        } else {
+                            Theme::text_secondary()
+                        }),
                 );
 
                 // Truncated token preview
@@ -2746,8 +3163,8 @@ fn render_accounts_section(ui: &mut egui::Ui, provider_id: ProviderId, shared_st
                 ui.label(
                     RichText::new(token_preview)
                         .size(FontSize::XS)
-                        .color(Theme::TEXT_MUTED)
-                        .monospace()
+                        .color(Theme::text_muted())
+                        .monospace(),
                 );
 
                 ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
@@ -2761,9 +3178,11 @@ fn render_accounts_section(ui: &mut egui::Ui, provider_id: ProviderId, shared_st
                             // Save to disk
                             let store = TokenAccountStore::new();
                             if let Err(e) = store.save(&state.token_accounts) {
-                                state.token_account_status_msg = Some((format!("Failed to save: {}", e), true));
+                                state.token_account_status_msg =
+                                    Some((format!("Failed to save: {}", e), true));
                             } else {
-                                state.token_account_status_msg = Some(("Account removed".to_string(), false));
+                                state.token_account_status_msg =
+                                    Some(("Account removed".to_string(), false));
                             }
                         }
                     }
@@ -2780,7 +3199,7 @@ fn render_accounts_section(ui: &mut egui::Ui, provider_id: ProviderId, shared_st
     if show_add {
         // Input form for adding new account
         egui::Frame::none()
-            .fill(Theme::BG_TERTIARY)
+            .fill(Theme::bg_tertiary())
             .stroke(Stroke::new(1.0, Theme::ACCENT_PRIMARY.gamma_multiply(0.4)))
             .rounding(Rounding::same(Radius::MD))
             .inner_margin(Spacing::MD)
@@ -2788,17 +3207,23 @@ fn render_accounts_section(ui: &mut egui::Ui, provider_id: ProviderId, shared_st
                 ui.label(
                     RichText::new("Add Account")
                         .size(FontSize::MD)
-                        .color(Theme::TEXT_PRIMARY)
-                        .strong()
+                        .color(Theme::text_primary())
+                        .strong(),
                 );
 
                 ui.add_space(Spacing::SM);
 
                 // Label input
-                ui.label(RichText::new("Label").size(FontSize::SM).color(Theme::TEXT_SECONDARY));
+                ui.label(
+                    RichText::new("Label")
+                        .size(FontSize::SM)
+                        .color(Theme::text_secondary()),
+                );
                 let mut label = if let Ok(state) = shared_state.lock() {
                     state.new_account_label.clone()
-                } else { String::new() };
+                } else {
+                    String::new()
+                };
                 let label_edit = egui::TextEdit::singleline(&mut label)
                     .desired_width(ui.available_width())
                     .hint_text("e.g., Work Account, Personal...");
@@ -2811,10 +3236,16 @@ fn render_accounts_section(ui: &mut egui::Ui, provider_id: ProviderId, shared_st
                 ui.add_space(Spacing::SM);
 
                 // Token input
-                ui.label(RichText::new("Token").size(FontSize::SM).color(Theme::TEXT_SECONDARY));
+                ui.label(
+                    RichText::new("Token")
+                        .size(FontSize::SM)
+                        .color(Theme::text_secondary()),
+                );
                 let mut token = if let Ok(state) = shared_state.lock() {
                     state.new_account_token.clone()
-                } else { String::new() };
+                } else {
+                    String::new()
+                };
                 let token_edit = egui::TextEdit::singleline(&mut token)
                     .password(true)
                     .desired_width(ui.available_width())
@@ -2831,22 +3262,33 @@ fn render_accounts_section(ui: &mut egui::Ui, provider_id: ProviderId, shared_st
                     let (can_save, label_val, token_val) = if let Ok(state) = shared_state.lock() {
                         let can = !state.new_account_label.trim().is_empty()
                             && !state.new_account_token.trim().is_empty();
-                        (can, state.new_account_label.clone(), state.new_account_token.clone())
+                        (
+                            can,
+                            state.new_account_label.clone(),
+                            state.new_account_token.clone(),
+                        )
                     } else {
                         (false, String::new(), String::new())
                     };
 
-                    if ui.add_enabled(
-                        can_save,
-                        egui::Button::new(
-                            RichText::new("Save")
-                                .size(FontSize::SM)
-                                .color(Color32::WHITE)
+                    if ui
+                        .add_enabled(
+                            can_save,
+                            egui::Button::new(
+                                RichText::new("Save")
+                                    .size(FontSize::SM)
+                                    .color(Color32::WHITE),
+                            )
+                            .fill(if can_save {
+                                Theme::GREEN
+                            } else {
+                                Theme::bg_tertiary()
+                            })
+                            .rounding(Rounding::same(Radius::SM))
+                            .min_size(Vec2::new(80.0, 32.0)),
                         )
-                        .fill(if can_save { Theme::GREEN } else { Theme::BG_TERTIARY })
-                        .rounding(Rounding::same(Radius::SM))
-                        .min_size(Vec2::new(80.0, 32.0))
-                    ).clicked() {
+                        .clicked()
+                    {
                         if let Ok(mut state) = shared_state.lock() {
                             // Create new account
                             let account = TokenAccount::new(label_val.trim(), token_val.trim());
@@ -2858,9 +3300,11 @@ fn render_accounts_section(ui: &mut egui::Ui, provider_id: ProviderId, shared_st
                             // Save to disk
                             let store = TokenAccountStore::new();
                             if let Err(e) = store.save(&state.token_accounts) {
-                                state.token_account_status_msg = Some((format!("Failed to save: {}", e), true));
+                                state.token_account_status_msg =
+                                    Some((format!("Failed to save: {}", e), true));
                             } else {
-                                state.token_account_status_msg = Some(("Account added".to_string(), false));
+                                state.token_account_status_msg =
+                                    Some(("Account added".to_string(), false));
                                 state.new_account_label.clear();
                                 state.new_account_token.clear();
                                 state.show_add_account_input = false;
@@ -2870,16 +3314,19 @@ fn render_accounts_section(ui: &mut egui::Ui, provider_id: ProviderId, shared_st
 
                     ui.add_space(Spacing::XS);
 
-                    if ui.add(
-                        egui::Button::new(
-                            RichText::new("Cancel")
-                                .size(FontSize::SM)
-                                .color(Theme::TEXT_MUTED)
+                    if ui
+                        .add(
+                            egui::Button::new(
+                                RichText::new("Cancel")
+                                    .size(FontSize::SM)
+                                    .color(Theme::text_muted()),
+                            )
+                            .fill(Color32::TRANSPARENT)
+                            .stroke(Stroke::new(1.0, Theme::border_subtle()))
+                            .rounding(Rounding::same(Radius::SM)),
                         )
-                        .fill(Color32::TRANSPARENT)
-                        .stroke(Stroke::new(1.0, Theme::BORDER_SUBTLE))
-                        .rounding(Rounding::same(Radius::SM))
-                    ).clicked() {
+                        .clicked()
+                    {
                         if let Ok(mut state) = shared_state.lock() {
                             state.show_add_account_input = false;
                             state.new_account_label.clear();
@@ -2908,9 +3355,16 @@ fn render_general_tab(ui: &mut egui::Ui, shared_state: &Arc<Mutex<PreferencesSha
     settings_card(ui, |ui| {
         let mut start_at_login = if let Ok(state) = shared_state.lock() {
             state.settings.start_at_login
-        } else { false };
+        } else {
+            false
+        };
 
-        if setting_toggle(ui, "Start at login", "Launch CodexBar when you log in", &mut start_at_login) {
+        if setting_toggle(
+            ui,
+            "Start at login",
+            "Launch CodexBar when you log in",
+            &mut start_at_login,
+        ) {
             if let Ok(mut state) = shared_state.lock() {
                 if let Err(e) = state.settings.set_start_at_login(start_at_login) {
                     tracing::error!("Failed to set start at login: {}", e);
@@ -2924,9 +3378,16 @@ fn render_general_tab(ui: &mut egui::Ui, shared_state: &Arc<Mutex<PreferencesSha
 
         let mut start_minimized = if let Ok(state) = shared_state.lock() {
             state.settings.start_minimized
-        } else { false };
+        } else {
+            false
+        };
 
-        if setting_toggle(ui, "Start minimized", "Start in the system tray", &mut start_minimized) {
+        if setting_toggle(
+            ui,
+            "Start minimized",
+            "Start in the system tray",
+            &mut start_minimized,
+        ) {
             if let Ok(mut state) = shared_state.lock() {
                 state.settings.start_minimized = start_minimized;
                 state.settings_changed = true;
@@ -2941,9 +3402,16 @@ fn render_general_tab(ui: &mut egui::Ui, shared_state: &Arc<Mutex<PreferencesSha
     settings_card(ui, |ui| {
         let mut show_notifications = if let Ok(state) = shared_state.lock() {
             state.settings.show_notifications
-        } else { true };
+        } else {
+            true
+        };
 
-        if setting_toggle(ui, "Show notifications", "Alert when usage thresholds are reached", &mut show_notifications) {
+        if setting_toggle(
+            ui,
+            "Show notifications",
+            "Alert when usage thresholds are reached",
+            &mut show_notifications,
+        ) {
             if let Ok(mut state) = shared_state.lock() {
                 state.settings.show_notifications = show_notifications;
                 state.settings_changed = true;
@@ -2955,9 +3423,16 @@ fn render_general_tab(ui: &mut egui::Ui, shared_state: &Arc<Mutex<PreferencesSha
         // Sound effects toggle
         let mut sound_enabled = if let Ok(state) = shared_state.lock() {
             state.settings.sound_enabled
-        } else { true };
+        } else {
+            true
+        };
 
-        if setting_toggle(ui, "Sound effects", "Play sound when thresholds are reached", &mut sound_enabled) {
+        if setting_toggle(
+            ui,
+            "Sound effects",
+            "Play sound when thresholds are reached",
+            &mut sound_enabled,
+        ) {
             if let Ok(mut state) = shared_state.lock() {
                 state.settings.sound_enabled = sound_enabled;
                 state.settings_changed = true;
@@ -2971,32 +3446,47 @@ fn render_general_tab(ui: &mut egui::Ui, shared_state: &Arc<Mutex<PreferencesSha
             ui.vertical(|ui| {
                 let mut volume = if let Ok(state) = shared_state.lock() {
                     state.settings.sound_volume as i32
-                } else { 100 };
+                } else {
+                    100
+                };
 
                 // Title row with volume badge on right
                 ui.horizontal(|ui| {
-                    ui.label(RichText::new("Sound volume").size(FontSize::MD).color(Theme::TEXT_PRIMARY));
+                    ui.label(
+                        RichText::new("Sound volume")
+                            .size(FontSize::MD)
+                            .color(Theme::text_primary()),
+                    );
                     ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
                         egui::Frame::none()
                             .fill(Theme::ACCENT_PRIMARY.gamma_multiply(0.15))
                             .rounding(Rounding::same(10.0))
                             .inner_margin(egui::Margin::symmetric(10.0, 3.0))
                             .show(ui, |ui| {
-                                ui.label(RichText::new(format!("{}%", volume)).size(FontSize::SM).color(Theme::ACCENT_PRIMARY).strong());
+                                ui.label(
+                                    RichText::new(format!("{}%", volume))
+                                        .size(FontSize::SM)
+                                        .color(Theme::ACCENT_PRIMARY)
+                                        .strong(),
+                                );
                             });
                     });
                 });
 
                 ui.add_space(2.0);
-                ui.label(RichText::new("Volume level for alert sounds").size(FontSize::SM).color(Theme::TEXT_MUTED));
+                ui.label(
+                    RichText::new("Volume level for alert sounds")
+                        .size(FontSize::SM)
+                        .color(Theme::text_muted()),
+                );
                 ui.add_space(6.0);
 
-                ui.style_mut().visuals.widgets.inactive.bg_fill = Theme::BG_TERTIARY;
+                ui.style_mut().visuals.widgets.inactive.bg_fill = Theme::bg_tertiary();
 
                 let slider = ui.add(
                     egui::Slider::new(&mut volume, 0..=100)
                         .show_value(false)
-                        .trailing_fill(true)
+                        .trailing_fill(true),
                 );
 
                 if slider.changed() {
@@ -3014,32 +3504,47 @@ fn render_general_tab(ui: &mut egui::Ui, shared_state: &Arc<Mutex<PreferencesSha
         ui.vertical(|ui| {
             let mut threshold = if let Ok(state) = shared_state.lock() {
                 state.settings.high_usage_threshold as i32
-            } else { 70 };
+            } else {
+                70
+            };
 
             // Title row with percentage badge on right
             ui.horizontal(|ui| {
-                ui.label(RichText::new("High warning").size(FontSize::MD).color(Theme::TEXT_PRIMARY));
+                ui.label(
+                    RichText::new("High warning")
+                        .size(FontSize::MD)
+                        .color(Theme::text_primary()),
+                );
                 ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
                     egui::Frame::none()
                         .fill(Theme::ACCENT_PRIMARY.gamma_multiply(0.15))
                         .rounding(Rounding::same(10.0))
                         .inner_margin(egui::Margin::symmetric(10.0, 3.0))
                         .show(ui, |ui| {
-                            ui.label(RichText::new(format!("{}%", threshold)).size(FontSize::SM).color(Theme::ACCENT_PRIMARY).strong());
+                            ui.label(
+                                RichText::new(format!("{}%", threshold))
+                                    .size(FontSize::SM)
+                                    .color(Theme::ACCENT_PRIMARY)
+                                    .strong(),
+                            );
                         });
                 });
             });
 
             ui.add_space(2.0);
-            ui.label(RichText::new("Show warning at this usage level").size(FontSize::SM).color(Theme::TEXT_MUTED));
+            ui.label(
+                RichText::new("Show warning at this usage level")
+                    .size(FontSize::SM)
+                    .color(Theme::text_muted()),
+            );
             ui.add_space(6.0);
 
-            ui.style_mut().visuals.widgets.inactive.bg_fill = Theme::BG_TERTIARY;
+            ui.style_mut().visuals.widgets.inactive.bg_fill = Theme::bg_tertiary();
 
             let slider = ui.add(
                 egui::Slider::new(&mut threshold, 50..=95)
                     .show_value(false)
-                    .trailing_fill(true)
+                    .trailing_fill(true),
             );
 
             if slider.changed() {
@@ -3056,34 +3561,49 @@ fn render_general_tab(ui: &mut egui::Ui, shared_state: &Arc<Mutex<PreferencesSha
         ui.vertical(|ui| {
             let mut threshold = if let Ok(state) = shared_state.lock() {
                 state.settings.critical_usage_threshold as i32
-            } else { 90 };
+            } else {
+                90
+            };
 
             let badge_color = Color32::from_rgb(239, 68, 68);
 
             // Title row with percentage badge on right
             ui.horizontal(|ui| {
-                ui.label(RichText::new("Critical alert").size(FontSize::MD).color(Theme::TEXT_PRIMARY));
+                ui.label(
+                    RichText::new("Critical alert")
+                        .size(FontSize::MD)
+                        .color(Theme::text_primary()),
+                );
                 ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
                     egui::Frame::none()
                         .fill(badge_color.gamma_multiply(0.15))
                         .rounding(Rounding::same(10.0))
                         .inner_margin(egui::Margin::symmetric(10.0, 3.0))
                         .show(ui, |ui| {
-                            ui.label(RichText::new(format!("{}%", threshold)).size(FontSize::SM).color(badge_color).strong());
+                            ui.label(
+                                RichText::new(format!("{}%", threshold))
+                                    .size(FontSize::SM)
+                                    .color(badge_color)
+                                    .strong(),
+                            );
                         });
                 });
             });
 
             ui.add_space(2.0);
-            ui.label(RichText::new("Show critical alert at this level").size(FontSize::SM).color(Theme::TEXT_MUTED));
+            ui.label(
+                RichText::new("Show critical alert at this level")
+                    .size(FontSize::SM)
+                    .color(Theme::text_muted()),
+            );
             ui.add_space(6.0);
 
-            ui.style_mut().visuals.widgets.inactive.bg_fill = Theme::BG_TERTIARY;
+            ui.style_mut().visuals.widgets.inactive.bg_fill = Theme::bg_tertiary();
 
             let slider = ui.add(
                 egui::Slider::new(&mut threshold, 80..=100)
                     .show_value(false)
-                    .trailing_fill(true)
+                    .trailing_fill(true),
             );
 
             if slider.changed() {
@@ -3102,9 +3622,16 @@ fn render_general_tab(ui: &mut egui::Ui, shared_state: &Arc<Mutex<PreferencesSha
     settings_card(ui, |ui| {
         let mut hide_personal_info = if let Ok(state) = shared_state.lock() {
             state.settings.hide_personal_info
-        } else { false };
+        } else {
+            false
+        };
 
-        if setting_toggle(ui, "Hide personal info", "Mask emails and account names (useful for streaming)", &mut hide_personal_info) {
+        if setting_toggle(
+            ui,
+            "Hide personal info",
+            "Mask emails and account names (useful for streaming)",
+            &mut hide_personal_info,
+        ) {
             if let Ok(mut state) = shared_state.lock() {
                 state.settings.hide_personal_info = hide_personal_info;
                 state.settings_changed = true;
@@ -3119,8 +3646,16 @@ fn render_general_tab(ui: &mut egui::Ui, shared_state: &Arc<Mutex<PreferencesSha
     settings_card(ui, |ui| {
         ui.horizontal(|ui| {
             ui.vertical(|ui| {
-                ui.label(RichText::new("Update channel").size(FontSize::MD).color(Theme::TEXT_PRIMARY));
-                ui.label(RichText::new("Choose between stable releases or beta previews").size(FontSize::SM).color(Theme::TEXT_MUTED));
+                ui.label(
+                    RichText::new("Update channel")
+                        .size(FontSize::MD)
+                        .color(Theme::text_primary()),
+                );
+                ui.label(
+                    RichText::new("Choose between stable releases or beta previews")
+                        .size(FontSize::SM)
+                        .color(Theme::text_muted()),
+                );
             });
 
             ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
@@ -3131,8 +3666,8 @@ fn render_general_tab(ui: &mut egui::Ui, shared_state: &Arc<Mutex<PreferencesSha
                 };
 
                 egui::Frame::none()
-                    .fill(Theme::BG_TERTIARY)
-                    .stroke(Stroke::new(1.0, Theme::BORDER_SUBTLE))
+                    .fill(Theme::bg_tertiary())
+                    .stroke(Stroke::new(1.0, Theme::border_subtle()))
                     .rounding(Rounding::same(Radius::SM))
                     .inner_margin(egui::Margin::symmetric(Spacing::XS, 2.0))
                     .show(ui, |ui| {
@@ -3152,7 +3687,8 @@ fn render_general_tab(ui: &mut egui::Ui, shared_state: &Arc<Mutex<PreferencesSha
                             )
                             .show_ui(ui, |ui| {
                                 for (channel, label) in channels {
-                                    if ui.selectable_value(&mut selected, channel, label).changed() {
+                                    if ui.selectable_value(&mut selected, channel, label).changed()
+                                    {
                                         if let Ok(mut state) = shared_state.lock() {
                                             state.settings.update_channel = selected;
                                             state.settings_changed = true;
@@ -3172,13 +3708,24 @@ fn render_general_tab(ui: &mut egui::Ui, shared_state: &Arc<Mutex<PreferencesSha
     settings_card(ui, |ui| {
         ui.horizontal(|ui| {
             ui.vertical(|ui| {
-                ui.label(RichText::new("Global shortcut").size(FontSize::MD).color(Theme::TEXT_PRIMARY));
-                ui.label(RichText::new("Press this key combination to open CodexBar from anywhere").size(FontSize::SM).color(Theme::TEXT_MUTED));
+                ui.label(
+                    RichText::new("Global shortcut")
+                        .size(FontSize::MD)
+                        .color(Theme::text_primary()),
+                );
+                ui.label(
+                    RichText::new("Press this key combination to open CodexBar from anywhere")
+                        .size(FontSize::SM)
+                        .color(Theme::text_muted()),
+                );
             });
 
             ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
                 let (mut shortcut_input, status_msg) = if let Ok(state) = shared_state.lock() {
-                    (state.shortcut_input.clone(), state.shortcut_status_msg.clone())
+                    (
+                        state.shortcut_input.clone(),
+                        state.shortcut_status_msg.clone(),
+                    )
                 } else {
                     ("Ctrl+Shift+U".to_string(), None)
                 };
@@ -3191,8 +3738,8 @@ fn render_general_tab(ui: &mut egui::Ui, shared_state: &Arc<Mutex<PreferencesSha
                 }
 
                 egui::Frame::none()
-                    .fill(Theme::BG_TERTIARY)
-                    .stroke(Stroke::new(1.0, Theme::BORDER_SUBTLE))
+                    .fill(Theme::bg_tertiary())
+                    .stroke(Stroke::new(1.0, Theme::border_subtle()))
                     .rounding(Rounding::same(Radius::SM))
                     .inner_margin(egui::Margin::symmetric(Spacing::SM, 4.0))
                     .show(ui, |ui| {
@@ -3212,18 +3759,22 @@ fn render_general_tab(ui: &mut egui::Ui, shared_state: &Arc<Mutex<PreferencesSha
                             let shortcut_str = shortcut_input.trim().to_string();
                             if !shortcut_str.is_empty() {
                                 // Try to parse the shortcut to validate it
-                                if let Some((modifiers, key)) = crate::shortcuts::parse_shortcut(&shortcut_str) {
+                                if let Some((modifiers, key)) =
+                                    crate::shortcuts::parse_shortcut(&shortcut_str)
+                                {
                                     // Format it back to canonical form
                                     let formatted = format_shortcut(modifiers, key);
                                     if let Ok(mut state) = shared_state.lock() {
                                         state.settings.global_shortcut = formatted.clone();
                                         state.shortcut_input = formatted;
                                         state.settings_changed = true;
-                                        state.shortcut_status_msg = Some(("Saved (restart to apply)".to_string(), false));
+                                        state.shortcut_status_msg =
+                                            Some(("Saved (restart to apply)".to_string(), false));
                                     }
                                 } else {
                                     if let Ok(mut state) = shared_state.lock() {
-                                        state.shortcut_status_msg = Some(("Invalid shortcut format".to_string(), true));
+                                        state.shortcut_status_msg =
+                                            Some(("Invalid shortcut format".to_string(), true));
                                     }
                                 }
                             }
@@ -3234,23 +3785,96 @@ fn render_general_tab(ui: &mut egui::Ui, shared_state: &Arc<Mutex<PreferencesSha
 
         ui.add_space(4.0);
         ui.label(
-            RichText::new("Format: Ctrl+Shift+Key, Alt+Ctrl+Key, etc. Restart required to apply changes.")
-                .size(FontSize::XS)
-                .color(Theme::TEXT_MUTED)
+            RichText::new(
+                "Format: Ctrl+Shift+Key, Alt+Ctrl+Key, etc. Restart required to apply changes.",
+            )
+            .size(FontSize::XS)
+            .color(Theme::text_muted()),
         );
     });
 }
 
 /// Render Display tab for viewport
 fn render_display_tab(ui: &mut egui::Ui, shared_state: &Arc<Mutex<PreferencesSharedState>>) {
+    section_header(ui, "Theme");
+
+    settings_card(ui, |ui| {
+        ui.horizontal(|ui| {
+            ui.vertical(|ui| {
+                ui.label(
+                    RichText::new("Appearance")
+                        .size(FontSize::MD)
+                        .color(Theme::text_primary()),
+                );
+                ui.label(
+                    RichText::new("Choose light, dark, or match your system setting")
+                        .size(FontSize::SM)
+                        .color(Theme::text_muted()),
+                );
+            });
+
+            ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+                let current_mode = if let Ok(state) = shared_state.lock() {
+                    state.settings.theme_mode
+                } else {
+                    ThemeMode::default()
+                };
+
+                egui::Frame::none()
+                    .fill(Theme::bg_tertiary())
+                    .stroke(Stroke::new(1.0, Theme::border_subtle()))
+                    .rounding(Rounding::same(Radius::SM))
+                    .inner_margin(egui::Margin::symmetric(Spacing::XS, 2.0))
+                    .show(ui, |ui| {
+                        let modes = [
+                            (ThemeMode::System, "System"),
+                            (ThemeMode::Light, "Light"),
+                            (ThemeMode::Dark, "Dark"),
+                        ];
+
+                        let mut selected = current_mode;
+                        egui::ComboBox::from_id_salt("theme_mode")
+                            .selected_text(
+                                modes
+                                    .iter()
+                                    .find(|(m, _)| *m == selected)
+                                    .map(|(_, label)| *label)
+                                    .unwrap_or("System"),
+                            )
+                            .show_ui(ui, |ui| {
+                                for (mode, label) in modes {
+                                    if ui.selectable_value(&mut selected, mode, label).changed() {
+                                        if let Ok(mut state) = shared_state.lock() {
+                                            state.settings.theme_mode = selected;
+                                            state.settings_changed = true;
+                                        }
+                                        // Apply theme change immediately
+                                        Theme::set_dark(selected.is_dark());
+                                    }
+                                }
+                            });
+                    });
+            });
+        });
+    });
+
+    ui.add_space(Spacing::LG);
+
     section_header(ui, "Appearance");
 
     settings_card(ui, |ui| {
         let mut relative_time = if let Ok(state) = shared_state.lock() {
             state.settings.reset_time_relative
-        } else { true };
+        } else {
+            true
+        };
 
-        if setting_toggle(ui, "Relative time", "Show reset time as relative (3h 45m) instead of absolute", &mut relative_time) {
+        if setting_toggle(
+            ui,
+            "Relative time",
+            "Show reset time as relative (3h 45m) instead of absolute",
+            &mut relative_time,
+        ) {
             if let Ok(mut state) = shared_state.lock() {
                 state.settings.reset_time_relative = relative_time;
                 state.settings_changed = true;
@@ -3261,9 +3885,16 @@ fn render_display_tab(ui: &mut egui::Ui, shared_state: &Arc<Mutex<PreferencesSha
 
         let mut surprise = if let Ok(state) = shared_state.lock() {
             state.settings.surprise_animations
-        } else { false };
+        } else {
+            false
+        };
 
-        if setting_toggle(ui, "Surprise animations", "Show occasional fun animations in the tray icon", &mut surprise) {
+        if setting_toggle(
+            ui,
+            "Surprise animations",
+            "Show occasional fun animations in the tray icon",
+            &mut surprise,
+        ) {
             if let Ok(mut state) = shared_state.lock() {
                 state.settings.surprise_animations = surprise;
                 state.settings_changed = true;
@@ -3279,7 +3910,7 @@ fn render_api_keys_tab(ui: &mut egui::Ui, shared_state: &Arc<Mutex<PreferencesSh
     ui.label(
         RichText::new("Configure access tokens for providers that require authentication.")
             .size(FontSize::SM)
-            .color(Theme::TEXT_MUTED),
+            .color(Theme::text_muted()),
     );
 
     ui.add_space(Spacing::MD);
@@ -3287,7 +3918,9 @@ fn render_api_keys_tab(ui: &mut egui::Ui, shared_state: &Arc<Mutex<PreferencesSh
     // Status message
     let status_msg = if let Ok(state) = shared_state.lock() {
         state.api_key_status_msg.clone()
-    } else { None };
+    } else {
+        None
+    };
 
     if let Some((msg, is_error)) = &status_msg {
         status_message(ui, msg, *is_error);
@@ -3295,16 +3928,17 @@ fn render_api_keys_tab(ui: &mut egui::Ui, shared_state: &Arc<Mutex<PreferencesSh
     }
 
     // Get state for rendering
-    let (api_keys_data, settings_data, show_input, input_provider) = if let Ok(state) = shared_state.lock() {
-        (
-            state.api_keys.clone(),
-            state.settings.clone(),
-            state.show_api_key_input,
-            state.new_api_key_provider.clone(),
-        )
-    } else {
-        return;
-    };
+    let (api_keys_data, settings_data, show_input, input_provider) =
+        if let Ok(state) = shared_state.lock() {
+            (
+                state.api_keys.clone(),
+                state.settings.clone(),
+                state.show_api_key_input,
+                state.new_api_key_provider.clone(),
+            )
+        } else {
+            return;
+        };
 
     // Provider cards - one per provider
     let api_key_providers = get_api_key_providers();
@@ -3317,19 +3951,22 @@ fn render_api_keys_tab(ui: &mut egui::Ui, shared_state: &Arc<Mutex<PreferencesSh
         let color = provider_color(provider_id);
 
         // Card with left accent bar
-        let accent_color = if has_key { Theme::GREEN } else if is_enabled { Theme::ORANGE } else { Theme::BG_TERTIARY };
+        let accent_color = if has_key {
+            Theme::GREEN
+        } else if is_enabled {
+            Theme::ORANGE
+        } else {
+            Theme::bg_tertiary()
+        };
 
         egui::Frame::none()
-            .fill(Theme::BG_SECONDARY)
+            .fill(Theme::bg_secondary())
             .rounding(Rounding::same(Radius::MD))
             .inner_margin(egui::Margin::same(0.0))
             .show(ui, |ui| {
                 ui.horizontal(|ui| {
                     // Left accent bar
-                    let bar_rect = Rect::from_min_size(
-                        ui.cursor().min,
-                        Vec2::new(3.0, 48.0),
-                    );
+                    let bar_rect = Rect::from_min_size(ui.cursor().min, Vec2::new(3.0, 48.0));
                     ui.painter().rect_filled(
                         bar_rect,
                         Rounding {
@@ -3353,8 +3990,15 @@ fn render_api_keys_tab(ui: &mut egui::Ui, shared_state: &Arc<Mutex<PreferencesSh
                             // Try to render SVG icon from cache
                             let icon_size = 20.0;
                             VIEWPORT_ICON_CACHE.with(|cache| {
-                                if let Some(texture) = cache.borrow_mut().get_icon(ui.ctx(), provider_id, icon_size as u32) {
-                                    ui.add(egui::Image::new(texture).fit_to_exact_size(Vec2::splat(icon_size)));
+                                if let Some(texture) = cache.borrow_mut().get_icon(
+                                    ui.ctx(),
+                                    provider_id,
+                                    icon_size as u32,
+                                ) {
+                                    ui.add(
+                                        egui::Image::new(texture)
+                                            .fit_to_exact_size(Vec2::splat(icon_size)),
+                                    );
                                 } else {
                                     ui.label(RichText::new(icon).size(FontSize::LG).color(color));
                                 }
@@ -3364,8 +4008,8 @@ fn render_api_keys_tab(ui: &mut egui::Ui, shared_state: &Arc<Mutex<PreferencesSh
                             ui.label(
                                 RichText::new(provider_info.name)
                                     .size(FontSize::MD)
-                                    .color(Theme::TEXT_PRIMARY)
-                                    .strong()
+                                    .color(Theme::text_primary())
+                                    .strong(),
                             );
 
                             ui.add_space(Spacing::XS);
@@ -3381,24 +4025,28 @@ fn render_api_keys_tab(ui: &mut egui::Ui, shared_state: &Arc<Mutex<PreferencesSh
                                         ui.label(
                                             RichText::new("Needs key")
                                                 .size(FontSize::XS)
-                                                .color(Color32::BLACK)
+                                                .color(Color32::BLACK),
                                         );
                                     });
                             }
 
                             // Right-aligned: Add Key button
-                            ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
-                                ui.add_space(Spacing::XS);
-                                if !has_key {
-                                    if primary_button(ui, "+ Add Key") {
-                                        if let Ok(mut state) = shared_state.lock() {
-                                            state.new_api_key_provider = provider_id.to_string();
-                                            state.show_api_key_input = true;
-                                            state.new_api_key_value.clear();
+                            ui.with_layout(
+                                egui::Layout::right_to_left(egui::Align::Center),
+                                |ui| {
+                                    ui.add_space(Spacing::XS);
+                                    if !has_key {
+                                        if primary_button(ui, "+ Add Key") {
+                                            if let Ok(mut state) = shared_state.lock() {
+                                                state.new_api_key_provider =
+                                                    provider_id.to_string();
+                                                state.show_api_key_input = true;
+                                                state.new_api_key_value.clear();
+                                            }
                                         }
                                     }
-                                }
-                            });
+                                },
+                            );
                         });
 
                         // Row 2: Env var, masked key, and actions
@@ -3409,47 +4057,58 @@ fn render_api_keys_tab(ui: &mut egui::Ui, shared_state: &Arc<Mutex<PreferencesSh
                                 ui.label(
                                     RichText::new(format!("Env: {}", env_var))
                                         .size(FontSize::XS)
-                                        .color(Theme::TEXT_MUTED)
-                                        .monospace()
+                                        .color(Theme::text_muted())
+                                        .monospace(),
                                 );
                             }
 
                             if has_key {
                                 ui.add_space(Spacing::SM);
-                                if let Some(key_info) = api_keys_data.get_all_for_display()
+                                if let Some(key_info) = api_keys_data
+                                    .get_all_for_display()
                                     .iter()
                                     .find(|k| k.provider_id == provider_id)
                                 {
                                     ui.label(
                                         RichText::new(&key_info.masked_key)
                                             .size(FontSize::XS)
-                                            .color(Theme::TEXT_MUTED)
-                                            .monospace()
+                                            .color(Theme::text_muted())
+                                            .monospace(),
                                     );
                                 }
 
-                                ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
-                                    ui.add_space(Spacing::XS);
-                                    if small_button(ui, "Remove", Theme::RED) {
-                                        if let Ok(mut state) = shared_state.lock() {
-                                            state.api_keys.remove(provider_id);
-                                            let _ = state.api_keys.save();
-                                            state.api_key_status_msg = Some((
-                                                format!("Removed API key for {}", provider_info.name),
-                                                false,
-                                            ));
+                                ui.with_layout(
+                                    egui::Layout::right_to_left(egui::Align::Center),
+                                    |ui| {
+                                        ui.add_space(Spacing::XS);
+                                        if small_button(ui, "Remove", Theme::RED) {
+                                            if let Ok(mut state) = shared_state.lock() {
+                                                state.api_keys.remove(provider_id);
+                                                let _ = state.api_keys.save();
+                                                state.api_key_status_msg = Some((
+                                                    format!(
+                                                        "Removed API key for {}",
+                                                        provider_info.name
+                                                    ),
+                                                    false,
+                                                ));
+                                            }
                                         }
-                                    }
-                                });
+                                    },
+                                );
                             } else {
-                                ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
-                                    ui.add_space(Spacing::XS);
-                                    if let Some(url) = provider_info.dashboard_url {
-                                        if text_button(ui, "Get key →", Theme::ACCENT_PRIMARY) {
-                                            let _ = open::that(url);
+                                ui.with_layout(
+                                    egui::Layout::right_to_left(egui::Align::Center),
+                                    |ui| {
+                                        ui.add_space(Spacing::XS);
+                                        if let Some(url) = provider_info.dashboard_url {
+                                            if text_button(ui, "Get key →", Theme::ACCENT_PRIMARY)
+                                            {
+                                                let _ = open::that(url);
+                                            }
                                         }
-                                    }
-                                });
+                                    },
+                                );
                             }
                         });
 
@@ -3470,7 +4129,7 @@ fn render_api_keys_tab(ui: &mut egui::Ui, shared_state: &Arc<Mutex<PreferencesSh
             .unwrap_or(&input_provider);
 
         egui::Frame::none()
-            .fill(Theme::BG_TERTIARY)
+            .fill(Theme::bg_tertiary())
             .stroke(Stroke::new(1.0, Theme::ACCENT_PRIMARY.gamma_multiply(0.4)))
             .rounding(Rounding::same(Radius::LG))
             .inner_margin(Spacing::LG)
@@ -3478,8 +4137,8 @@ fn render_api_keys_tab(ui: &mut egui::Ui, shared_state: &Arc<Mutex<PreferencesSh
                 ui.label(
                     RichText::new(format!("Enter API Key for {}", provider_name))
                         .size(FontSize::MD)
-                        .color(Theme::TEXT_PRIMARY)
-                        .strong()
+                        .color(Theme::text_primary())
+                        .strong(),
                 );
 
                 ui.add_space(Spacing::SM);
@@ -3508,32 +4167,34 @@ fn render_api_keys_tab(ui: &mut egui::Ui, shared_state: &Arc<Mutex<PreferencesSh
                 ui.horizontal(|ui| {
                     let can_save = !current_value.trim().is_empty();
 
-                    if ui.add_enabled(
-                        can_save,
-                        egui::Button::new(
-                            RichText::new("Save")
-                                .size(FontSize::SM)
-                                .color(Color32::WHITE)
+                    if ui
+                        .add_enabled(
+                            can_save,
+                            egui::Button::new(
+                                RichText::new("Save")
+                                    .size(FontSize::SM)
+                                    .color(Color32::WHITE),
+                            )
+                            .fill(if can_save {
+                                Theme::GREEN
+                            } else {
+                                Theme::bg_tertiary()
+                            })
+                            .rounding(Rounding::same(Radius::SM))
+                            .min_size(Vec2::new(80.0, 32.0)),
                         )
-                        .fill(if can_save { Theme::GREEN } else { Theme::BG_TERTIARY })
-                        .rounding(Rounding::same(Radius::SM))
-                        .min_size(Vec2::new(80.0, 32.0))
-                    ).clicked() {
+                        .clicked()
+                    {
                         if let Ok(mut state) = shared_state.lock() {
                             let provider = state.new_api_key_provider.clone();
                             let value = state.new_api_key_value.trim().to_string();
-                            state.api_keys.set(
-                                &provider,
-                                &value,
-                                None,
-                            );
+                            state.api_keys.set(&provider, &value, None);
                             if let Err(e) = state.api_keys.save() {
-                                state.api_key_status_msg = Some((format!("Failed to save: {}", e), true));
+                                state.api_key_status_msg =
+                                    Some((format!("Failed to save: {}", e), true));
                             } else {
-                                state.api_key_status_msg = Some((
-                                    format!("API key saved for {}", provider_name),
-                                    false,
-                                ));
+                                state.api_key_status_msg =
+                                    Some((format!("API key saved for {}", provider_name), false));
                                 state.show_api_key_input = false;
                                 state.new_api_key_value.clear();
                             }
@@ -3542,16 +4203,19 @@ fn render_api_keys_tab(ui: &mut egui::Ui, shared_state: &Arc<Mutex<PreferencesSh
 
                     ui.add_space(Spacing::XS);
 
-                    if ui.add(
-                        egui::Button::new(
-                            RichText::new("Cancel")
-                                .size(FontSize::SM)
-                                .color(Theme::TEXT_MUTED)
+                    if ui
+                        .add(
+                            egui::Button::new(
+                                RichText::new("Cancel")
+                                    .size(FontSize::SM)
+                                    .color(Theme::text_muted()),
+                            )
+                            .fill(Color32::TRANSPARENT)
+                            .stroke(Stroke::new(1.0, Theme::border_subtle()))
+                            .rounding(Rounding::same(Radius::SM)),
                         )
-                        .fill(Color32::TRANSPARENT)
-                        .stroke(Stroke::new(1.0, Theme::BORDER_SUBTLE))
-                        .rounding(Rounding::same(Radius::SM))
-                    ).clicked() {
+                        .clicked()
+                    {
                         if let Ok(mut state) = shared_state.lock() {
                             state.show_api_key_input = false;
                             state.new_api_key_value.clear();
@@ -3569,7 +4233,7 @@ fn render_cookies_tab(ui: &mut egui::Ui, shared_state: &Arc<Mutex<PreferencesSha
     ui.label(
         RichText::new("Cookies are automatically extracted from Chrome, Edge, Brave, and Firefox.")
             .size(FontSize::SM)
-            .color(Theme::TEXT_MUTED),
+            .color(Theme::text_muted()),
     );
 
     ui.add_space(Spacing::LG);
@@ -3577,7 +4241,9 @@ fn render_cookies_tab(ui: &mut egui::Ui, shared_state: &Arc<Mutex<PreferencesSha
     // Status message
     let status_msg = if let Ok(state) = shared_state.lock() {
         state.cookie_status_msg.clone()
-    } else { None };
+    } else {
+        None
+    };
 
     if let Some((msg, is_error)) = &status_msg {
         status_message(ui, msg, *is_error);
@@ -3603,12 +4269,12 @@ fn render_cookies_tab(ui: &mut egui::Ui, shared_state: &Arc<Mutex<PreferencesSha
                     ui.label(
                         RichText::new(&cookie_info.provider)
                             .size(FontSize::MD)
-                            .color(Theme::TEXT_PRIMARY)
+                            .color(Theme::text_primary()),
                     );
                     ui.label(
                         RichText::new(format!("· {}", &cookie_info.saved_at))
                             .size(FontSize::SM)
-                            .color(Theme::TEXT_MUTED)
+                            .color(Theme::text_muted()),
                     );
 
                     ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
@@ -3627,7 +4293,8 @@ fn render_cookies_tab(ui: &mut egui::Ui, shared_state: &Arc<Mutex<PreferencesSha
                 if let Ok(mut state) = shared_state.lock() {
                     state.cookies.remove(&provider_id);
                     let _ = state.cookies.save();
-                    state.cookie_status_msg = Some((format!("Removed cookie for {}", provider_id), false));
+                    state.cookie_status_msg =
+                        Some((format!("Removed cookie for {}", provider_id), false));
                 }
             }
         });
@@ -3648,7 +4315,11 @@ fn render_cookies_tab(ui: &mut egui::Ui, shared_state: &Arc<Mutex<PreferencesSha
 
         // Provider selection row
         ui.horizontal(|ui| {
-            ui.label(RichText::new("Provider").size(FontSize::MD).color(Theme::TEXT_PRIMARY));
+            ui.label(
+                RichText::new("Provider")
+                    .size(FontSize::MD)
+                    .color(Theme::text_primary()),
+            );
             ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
                 let combo = egui::ComboBox::from_id_salt("cookie_provider_viewport")
                     .selected_text(if current_provider.is_empty() {
@@ -3660,10 +4331,13 @@ fn render_cookies_tab(ui: &mut egui::Ui, shared_state: &Arc<Mutex<PreferencesSha
                         let web_providers = ["claude", "cursor", "kimi"];
                         for provider_name in web_providers {
                             if let Some(id) = ProviderId::from_cli_name(provider_name) {
-                                if ui.selectable_label(
-                                    current_provider == provider_name,
-                                    id.display_name(),
-                                ).clicked() {
+                                if ui
+                                    .selectable_label(
+                                        current_provider == provider_name,
+                                        id.display_name(),
+                                    )
+                                    .clicked()
+                                {
                                     if let Ok(mut state) = shared_state.lock() {
                                         state.new_cookie_provider = provider_name.to_string();
                                     }
@@ -3680,7 +4354,11 @@ fn render_cookies_tab(ui: &mut egui::Ui, shared_state: &Arc<Mutex<PreferencesSha
         ui.add_space(Spacing::SM);
 
         // Cookie header label
-        ui.label(RichText::new("Cookie header").size(FontSize::MD).color(Theme::TEXT_PRIMARY));
+        ui.label(
+            RichText::new("Cookie header")
+                .size(FontSize::MD)
+                .color(Theme::text_primary()),
+        );
         ui.add_space(Spacing::SM);
 
         // Get current cookie value
@@ -3692,8 +4370,8 @@ fn render_cookies_tab(ui: &mut egui::Ui, shared_state: &Arc<Mutex<PreferencesSha
 
         // Styled text input
         egui::Frame::none()
-            .fill(Theme::INPUT_BG)
-            .stroke(Stroke::new(1.0, Theme::BORDER_SUBTLE))
+            .fill(Theme::input_bg())
+            .stroke(Stroke::new(1.0, Theme::border_subtle()))
             .rounding(Rounding::same(Radius::SM))
             .inner_margin(Spacing::SM)
             .show(ui, |ui| {
@@ -3715,25 +4393,41 @@ fn render_cookies_tab(ui: &mut egui::Ui, shared_state: &Arc<Mutex<PreferencesSha
 
         // Re-fetch current provider for save button check
         let (save_provider, save_value) = if let Ok(state) = shared_state.lock() {
-            (state.new_cookie_provider.clone(), state.new_cookie_value.clone())
+            (
+                state.new_cookie_provider.clone(),
+                state.new_cookie_value.clone(),
+            )
         } else {
             (String::new(), String::new())
         };
 
         let can_save = !save_provider.is_empty() && !save_value.is_empty();
 
-        if ui.add_enabled(
-            can_save,
-            egui::Button::new(
-                RichText::new("Save Cookie")
-                    .size(FontSize::SM)
-                    .color(if can_save { Color32::WHITE } else { Theme::TEXT_MUTED })
+        if ui
+            .add_enabled(
+                can_save,
+                egui::Button::new(RichText::new("Save Cookie").size(FontSize::SM).color(
+                    if can_save {
+                        Color32::WHITE
+                    } else {
+                        Theme::text_muted()
+                    },
+                ))
+                .fill(if can_save {
+                    Theme::ACCENT_PRIMARY
+                } else {
+                    Theme::bg_tertiary()
+                })
+                .stroke(if can_save {
+                    Stroke::NONE
+                } else {
+                    Stroke::new(1.0, Theme::border_subtle())
+                })
+                .rounding(Rounding::same(Radius::MD))
+                .min_size(Vec2::new(120.0, 36.0)),
             )
-            .fill(if can_save { Theme::ACCENT_PRIMARY } else { Theme::BG_TERTIARY })
-            .stroke(if can_save { Stroke::NONE } else { Stroke::new(1.0, Theme::BORDER_SUBTLE) })
-            .rounding(Rounding::same(Radius::MD))
-            .min_size(Vec2::new(120.0, 36.0))
-        ).clicked() {
+            .clicked()
+        {
             if let Ok(mut state) = shared_state.lock() {
                 let provider = state.new_cookie_provider.clone();
                 let value = state.new_cookie_value.clone();
@@ -3744,7 +4438,8 @@ fn render_cookies_tab(ui: &mut egui::Ui, shared_state: &Arc<Mutex<PreferencesSha
                     let provider_name = ProviderId::from_cli_name(&provider)
                         .map(|id| id.display_name().to_string())
                         .unwrap_or_else(|| provider.clone());
-                    state.cookie_status_msg = Some((format!("Cookie saved for {}", provider_name), false));
+                    state.cookie_status_msg =
+                        Some((format!("Cookie saved for {}", provider_name), false));
                     state.new_cookie_provider.clear();
                     state.new_cookie_value.clear();
                 }
@@ -3762,13 +4457,15 @@ fn render_advanced_tab(ui: &mut egui::Ui, shared_state: &Arc<Mutex<PreferencesSh
             ui.label(
                 RichText::new("Auto-refresh interval")
                     .size(FontSize::MD)
-                    .color(Theme::TEXT_PRIMARY)
+                    .color(Theme::text_primary()),
             );
 
             ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
                 let current_interval = if let Ok(state) = shared_state.lock() {
                     state.settings.refresh_interval_secs
-                } else { 60 };
+                } else {
+                    60
+                };
 
                 let intervals = [
                     (0, "Never"),
@@ -3778,16 +4475,17 @@ fn render_advanced_tab(ui: &mut egui::Ui, shared_state: &Arc<Mutex<PreferencesSh
                     (600, "10 min"),
                 ];
 
-                let current_label = intervals.iter()
+                let current_label = intervals
+                    .iter()
                     .find(|(v, _)| *v == current_interval)
                     .map(|(_, l)| *l)
                     .unwrap_or("Custom");
 
                 // Style combobox to match theme
-                ui.style_mut().visuals.widgets.inactive.bg_fill = Theme::BG_TERTIARY;
-                ui.style_mut().visuals.widgets.inactive.weak_bg_fill = Theme::BG_TERTIARY;
-                ui.style_mut().visuals.widgets.hovered.bg_fill = Theme::CARD_BG_HOVER;
-                ui.style_mut().visuals.widgets.active.bg_fill = Theme::CARD_BG;
+                ui.style_mut().visuals.widgets.inactive.bg_fill = Theme::bg_tertiary();
+                ui.style_mut().visuals.widgets.inactive.weak_bg_fill = Theme::bg_tertiary();
+                ui.style_mut().visuals.widgets.hovered.bg_fill = Theme::card_bg_hover();
+                ui.style_mut().visuals.widgets.active.bg_fill = Theme::card_bg();
                 ui.style_mut().visuals.widgets.inactive.rounding = Rounding::same(Radius::SM);
                 ui.style_mut().visuals.widgets.hovered.rounding = Rounding::same(Radius::SM);
                 ui.style_mut().visuals.widgets.active.rounding = Rounding::same(Radius::SM);
@@ -3797,7 +4495,10 @@ fn render_advanced_tab(ui: &mut egui::Ui, shared_state: &Arc<Mutex<PreferencesSh
                     .width(90.0)
                     .show_ui(ui, |ui| {
                         for (value, label) in intervals {
-                            if ui.selectable_label(current_interval == value, label).clicked() {
+                            if ui
+                                .selectable_label(current_interval == value, label)
+                                .clicked()
+                            {
                                 if let Ok(mut state) = shared_state.lock() {
                                     state.settings.refresh_interval_secs = value;
                                     state.settings_changed = true;
@@ -3816,11 +4517,7 @@ fn render_about_tab(ui: &mut egui::Ui) {
         ui.add_space(Spacing::XL);
 
         // App icon
-        ui.label(
-            RichText::new("◆")
-                .size(48.0)
-                .color(Theme::ACCENT_PRIMARY)
-        );
+        ui.label(RichText::new("◆").size(48.0).color(Theme::ACCENT_PRIMARY));
 
         ui.add_space(Spacing::MD);
 
@@ -3828,8 +4525,8 @@ fn render_about_tab(ui: &mut egui::Ui) {
         ui.label(
             RichText::new("CodexBar")
                 .size(FontSize::XXL)
-                .color(Theme::TEXT_PRIMARY)
-                .strong()
+                .color(Theme::text_primary())
+                .strong(),
         );
 
         ui.add_space(Spacing::SM);
@@ -3838,7 +4535,7 @@ fn render_about_tab(ui: &mut egui::Ui) {
         ui.label(
             RichText::new(format!("Version {}", env!("CARGO_PKG_VERSION")))
                 .size(FontSize::MD)
-                .color(Theme::TEXT_SECONDARY)
+                .color(Theme::text_secondary()),
         );
 
         ui.add_space(Spacing::SM);
@@ -3847,7 +4544,7 @@ fn render_about_tab(ui: &mut egui::Ui) {
         ui.label(
             RichText::new("Monitor your AI provider usage limits")
                 .size(FontSize::SM)
-                .color(Theme::TEXT_MUTED)
+                .color(Theme::text_muted()),
         );
 
         ui.add_space(Spacing::XL);
@@ -3860,13 +4557,13 @@ fn render_about_tab(ui: &mut egui::Ui) {
             ui.label(
                 RichText::new("Created by CodexBar Contributors")
                     .size(FontSize::SM)
-                    .color(Theme::TEXT_PRIMARY)
+                    .color(Theme::text_primary()),
             );
             ui.add_space(Spacing::XS);
             ui.label(
                 RichText::new("MIT License")
                     .size(FontSize::SM)
-                    .color(Theme::TEXT_MUTED)
+                    .color(Theme::text_muted()),
             );
         });
     });
@@ -3900,13 +4597,13 @@ fn render_about_tab(ui: &mut egui::Ui) {
                 ui.label(
                     RichText::new("Commit:")
                         .size(FontSize::SM)
-                        .color(Theme::TEXT_MUTED)
+                        .color(Theme::text_muted()),
                 );
                 ui.label(
                     RichText::new(git_commit)
                         .size(FontSize::SM)
-                        .color(Theme::TEXT_SECONDARY)
-                        .monospace()
+                        .color(Theme::text_secondary())
+                        .monospace(),
                 );
             });
 
@@ -3916,12 +4613,12 @@ fn render_about_tab(ui: &mut egui::Ui) {
                 ui.label(
                     RichText::new("Built:")
                         .size(FontSize::SM)
-                        .color(Theme::TEXT_MUTED)
+                        .color(Theme::text_muted()),
                 );
                 ui.label(
                     RichText::new(build_date)
                         .size(FontSize::SM)
-                        .color(Theme::TEXT_SECONDARY)
+                        .color(Theme::text_secondary()),
                 );
             });
         });
@@ -3929,15 +4626,24 @@ fn render_about_tab(ui: &mut egui::Ui) {
 }
 
 /// Render Providers tab for viewport
-fn render_providers_tab(ui: &mut egui::Ui, _available_height: f32, shared_state: &Arc<Mutex<PreferencesSharedState>>) {
+fn render_providers_tab(
+    ui: &mut egui::Ui,
+    _available_height: f32,
+    shared_state: &Arc<Mutex<PreferencesSharedState>>,
+) {
     section_header(ui, "Enabled Providers");
 
     let providers = ProviderId::all();
 
     for provider_id in providers {
         let is_enabled = if let Ok(state) = shared_state.lock() {
-            state.settings.enabled_providers.contains(provider_id.cli_name())
-        } else { true };
+            state
+                .settings
+                .enabled_providers
+                .contains(provider_id.cli_name())
+        } else {
+            true
+        };
 
         settings_card(ui, |ui| {
             ui.horizontal(|ui| {
@@ -3946,7 +4652,7 @@ fn render_providers_tab(ui: &mut egui::Ui, _available_height: f32, shared_state:
                 ui.label(
                     RichText::new(provider_icon(provider_id.cli_name()))
                         .size(FontSize::LG)
-                        .color(brand_color)
+                        .color(brand_color),
                 );
 
                 ui.add_space(8.0);
@@ -3954,12 +4660,16 @@ fn render_providers_tab(ui: &mut egui::Ui, _available_height: f32, shared_state:
                 ui.label(
                     RichText::new(provider_id.display_name())
                         .size(FontSize::MD)
-                        .color(Theme::TEXT_PRIMARY)
+                        .color(Theme::text_primary()),
                 );
 
                 ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
                     let mut enabled = is_enabled;
-                    if switch_toggle(ui, egui::Id::new(format!("provider_{}", provider_id.cli_name())), &mut enabled) {
+                    if switch_toggle(
+                        ui,
+                        egui::Id::new(format!("provider_{}", provider_id.cli_name())),
+                        &mut enabled,
+                    ) {
                         if let Ok(mut state) = shared_state.lock() {
                             let name = provider_id.cli_name().to_string();
                             if enabled {
@@ -3988,8 +4698,8 @@ fn section_header(ui: &mut egui::Ui, text: &str) {
     ui.label(
         RichText::new(text.to_uppercase())
             .size(FontSize::XS)
-            .color(Theme::TEXT_SECTION)
-            .strong()
+            .color(Theme::text_section())
+            .strong(),
     );
     ui.add_space(Spacing::MD);
 }
@@ -3997,8 +4707,8 @@ fn section_header(ui: &mut egui::Ui, text: &str) {
 /// Settings card container - grouped settings with rounded corners and border
 fn settings_card(ui: &mut egui::Ui, content: impl FnOnce(&mut egui::Ui)) {
     egui::Frame::none()
-        .fill(Theme::BG_SECONDARY)
-        .stroke(Stroke::new(1.0, Theme::CARD_BORDER))
+        .fill(Theme::bg_secondary())
+        .stroke(Stroke::new(1.0, Theme::card_border()))
         .rounding(Rounding::same(Radius::LG))
         .inner_margin(Spacing::SM)
         .show(ui, content);
@@ -4007,11 +4717,8 @@ fn settings_card(ui: &mut egui::Ui, content: impl FnOnce(&mut egui::Ui)) {
 /// Divider line between settings in a card
 fn setting_divider(ui: &mut egui::Ui) {
     ui.add_space(Spacing::SM);
-    let rect = Rect::from_min_size(
-        ui.cursor().min,
-        Vec2::new(ui.available_width(), 1.0),
-    );
-    ui.painter().rect_filled(rect, 0.0, Theme::SEPARATOR);
+    let rect = Rect::from_min_size(ui.cursor().min, Vec2::new(ui.available_width(), 1.0));
+    ui.painter().rect_filled(rect, 0.0, Theme::separator());
     ui.add_space(Spacing::SM + 1.0);
 }
 
@@ -4028,21 +4735,19 @@ fn switch_toggle(ui: &mut egui::Ui, id: impl std::hash::Hash, value: &mut bool) 
     }
 
     // Animate the knob position
-    let animation_progress = ui.ctx().animate_bool_responsive(
-        egui::Id::new(id),
-        *value,
-    );
+    let animation_progress = ui.ctx().animate_bool_responsive(egui::Id::new(id), *value);
 
     // Track colors
     let track_color = if animation_progress > 0.5 {
         Theme::ACCENT_PRIMARY
     } else {
-        Theme::BG_TERTIARY
+        Theme::bg_tertiary()
     };
 
     // Draw track (rounded rectangle)
     let track_rounding = rect.height() / 2.0;
-    ui.painter().rect_filled(rect, Rounding::same(track_rounding), track_color);
+    ui.painter()
+        .rect_filled(rect, Rounding::same(track_rounding), track_color);
 
     // Knob properties
     let knob_margin = 2.0;
@@ -4054,7 +4759,8 @@ fn switch_toggle(ui: &mut egui::Ui, id: impl std::hash::Hash, value: &mut bool) 
     let knob_center = egui::pos2(knob_x + knob_diameter / 2.0, rect.center().y);
 
     // Draw knob (white circle)
-    ui.painter().circle_filled(knob_center, knob_diameter / 2.0, Color32::WHITE);
+    ui.painter()
+        .circle_filled(knob_center, knob_diameter / 2.0, Color32::WHITE);
 
     changed
 }
@@ -4066,8 +4772,16 @@ fn setting_toggle(ui: &mut egui::Ui, title: &str, subtitle: &str, value: &mut bo
     ui.horizontal(|ui| {
         // Labels on the left
         ui.vertical(|ui| {
-            ui.label(RichText::new(title).size(FontSize::MD).color(Theme::TEXT_PRIMARY));
-            ui.label(RichText::new(subtitle).size(FontSize::SM).color(Theme::TEXT_MUTED));
+            ui.label(
+                RichText::new(title)
+                    .size(FontSize::MD)
+                    .color(Theme::text_primary()),
+            );
+            ui.label(
+                RichText::new(subtitle)
+                    .size(FontSize::SM)
+                    .color(Theme::text_muted()),
+            );
         });
 
         // Switch on the right
@@ -4084,9 +4798,17 @@ fn setting_toggle(ui: &mut egui::Ui, title: &str, subtitle: &str, value: &mut bo
 /// Status message banner
 fn status_message(ui: &mut egui::Ui, msg: &str, is_error: bool) {
     let (bg_color, text_color, icon) = if is_error {
-        (Color32::from_rgba_unmultiplied(239, 68, 68, 15), Theme::RED, "✕")
+        (
+            Color32::from_rgba_unmultiplied(239, 68, 68, 15),
+            Theme::RED,
+            "✕",
+        )
     } else {
-        (Color32::from_rgba_unmultiplied(34, 197, 94, 15), Theme::GREEN, "✓")
+        (
+            Color32::from_rgba_unmultiplied(34, 197, 94, 15),
+            Theme::GREEN,
+            "✓",
+        )
     };
 
     egui::Frame::none()
@@ -4109,49 +4831,36 @@ fn badge(ui: &mut egui::Ui, text: &str, color: Color32) {
         .rounding(Rounding::same(Radius::XS))
         .inner_margin(egui::Margin::symmetric(Spacing::XS, 2.0))
         .show(ui, |ui| {
-            ui.label(
-                RichText::new(text)
-                    .size(FontSize::XS)
-                    .color(color)
-            );
+            ui.label(RichText::new(text).size(FontSize::XS).color(color));
         });
 }
 
 /// Small text button
 fn small_button(ui: &mut egui::Ui, text: &str, color: Color32) -> bool {
     ui.add(
-        egui::Button::new(
-            RichText::new(text)
-                .size(FontSize::SM)
-                .color(color)
-        )
-        .fill(color.gamma_multiply(0.1))
-        .rounding(Rounding::same(Radius::SM))
-    ).clicked()
+        egui::Button::new(RichText::new(text).size(FontSize::SM).color(color))
+            .fill(color.gamma_multiply(0.1))
+            .rounding(Rounding::same(Radius::SM)),
+    )
+    .clicked()
 }
 
 /// Text-only button (no background)
 fn text_button(ui: &mut egui::Ui, text: &str, color: Color32) -> bool {
     ui.add(
-        egui::Button::new(
-            RichText::new(text)
-                .size(FontSize::SM)
-                .color(color)
-        )
-        .fill(Color32::TRANSPARENT)
-        .stroke(Stroke::NONE)
-    ).clicked()
+        egui::Button::new(RichText::new(text).size(FontSize::SM).color(color))
+            .fill(Color32::TRANSPARENT)
+            .stroke(Stroke::NONE),
+    )
+    .clicked()
 }
 
 /// Primary action button
 fn primary_button(ui: &mut egui::Ui, text: &str) -> bool {
     ui.add(
-        egui::Button::new(
-            RichText::new(text)
-                .size(FontSize::SM)
-                .color(Color32::WHITE)
-        )
-        .fill(Theme::ACCENT_PRIMARY)
-        .rounding(Rounding::same(Radius::SM))
-    ).clicked()
+        egui::Button::new(RichText::new(text).size(FontSize::SM).color(Color32::WHITE))
+            .fill(Theme::ACCENT_PRIMARY)
+            .rounding(Rounding::same(Radius::SM)),
+    )
+    .clicked()
 }

--- a/rust/src/native_ui/provider_icons.rs
+++ b/rust/src/native_ui/provider_icons.rs
@@ -12,23 +12,74 @@ static ICON_DATA: OnceLock<HashMap<&'static str, &'static [u8]>> = OnceLock::new
 fn get_icon_data() -> &'static HashMap<&'static str, &'static [u8]> {
     ICON_DATA.get_or_init(|| {
         let mut map = HashMap::new();
-        map.insert("amp", include_bytes!("../../assets/icons/ProviderIcon-amp.svg").as_slice());
-        map.insert("antigravity", include_bytes!("../../assets/icons/ProviderIcon-antigravity.svg").as_slice());
-        map.insert("augment", include_bytes!("../../assets/icons/ProviderIcon-augment.svg").as_slice());
-        map.insert("claude", include_bytes!("../../assets/icons/ProviderIcon-claude.svg").as_slice());
-        map.insert("codex", include_bytes!("../../assets/icons/ProviderIcon-codex.svg").as_slice());
-        map.insert("copilot", include_bytes!("../../assets/icons/ProviderIcon-copilot.svg").as_slice());
-        map.insert("cursor", include_bytes!("../../assets/icons/ProviderIcon-cursor.svg").as_slice());
-        map.insert("factory", include_bytes!("../../assets/icons/ProviderIcon-factory.svg").as_slice());
-        map.insert("gemini", include_bytes!("../../assets/icons/ProviderIcon-gemini.svg").as_slice());
-        map.insert("jetbrains", include_bytes!("../../assets/icons/ProviderIcon-jetbrains.svg").as_slice());
-        map.insert("kimi", include_bytes!("../../assets/icons/ProviderIcon-kimi.svg").as_slice());
-        map.insert("kiro", include_bytes!("../../assets/icons/ProviderIcon-kiro.svg").as_slice());
-        map.insert("minimax", include_bytes!("../../assets/icons/ProviderIcon-minimax.svg").as_slice());
-        map.insert("opencode", include_bytes!("../../assets/icons/ProviderIcon-opencode.svg").as_slice());
-        map.insert("synthetic", include_bytes!("../../assets/icons/ProviderIcon-synthetic.svg").as_slice());
-        map.insert("vertexai", include_bytes!("../../assets/icons/ProviderIcon-vertexai.svg").as_slice());
-        map.insert("zai", include_bytes!("../../assets/icons/ProviderIcon-zai.svg").as_slice());
+        map.insert(
+            "amp",
+            include_bytes!("../../assets/icons/ProviderIcon-amp.svg").as_slice(),
+        );
+        map.insert(
+            "antigravity",
+            include_bytes!("../../assets/icons/ProviderIcon-antigravity.svg").as_slice(),
+        );
+        map.insert(
+            "augment",
+            include_bytes!("../../assets/icons/ProviderIcon-augment.svg").as_slice(),
+        );
+        map.insert(
+            "claude",
+            include_bytes!("../../assets/icons/ProviderIcon-claude.svg").as_slice(),
+        );
+        map.insert(
+            "codex",
+            include_bytes!("../../assets/icons/ProviderIcon-codex.svg").as_slice(),
+        );
+        map.insert(
+            "copilot",
+            include_bytes!("../../assets/icons/ProviderIcon-copilot.svg").as_slice(),
+        );
+        map.insert(
+            "cursor",
+            include_bytes!("../../assets/icons/ProviderIcon-cursor.svg").as_slice(),
+        );
+        map.insert(
+            "factory",
+            include_bytes!("../../assets/icons/ProviderIcon-factory.svg").as_slice(),
+        );
+        map.insert(
+            "gemini",
+            include_bytes!("../../assets/icons/ProviderIcon-gemini.svg").as_slice(),
+        );
+        map.insert(
+            "jetbrains",
+            include_bytes!("../../assets/icons/ProviderIcon-jetbrains.svg").as_slice(),
+        );
+        map.insert(
+            "kimi",
+            include_bytes!("../../assets/icons/ProviderIcon-kimi.svg").as_slice(),
+        );
+        map.insert(
+            "kiro",
+            include_bytes!("../../assets/icons/ProviderIcon-kiro.svg").as_slice(),
+        );
+        map.insert(
+            "minimax",
+            include_bytes!("../../assets/icons/ProviderIcon-minimax.svg").as_slice(),
+        );
+        map.insert(
+            "opencode",
+            include_bytes!("../../assets/icons/ProviderIcon-opencode.svg").as_slice(),
+        );
+        map.insert(
+            "synthetic",
+            include_bytes!("../../assets/icons/ProviderIcon-synthetic.svg").as_slice(),
+        );
+        map.insert(
+            "vertexai",
+            include_bytes!("../../assets/icons/ProviderIcon-vertexai.svg").as_slice(),
+        );
+        map.insert(
+            "zai",
+            include_bytes!("../../assets/icons/ProviderIcon-zai.svg").as_slice(),
+        );
         map
     })
 }
@@ -46,7 +97,12 @@ impl ProviderIconCache {
     }
 
     /// Get or load a provider icon texture
-    pub fn get_icon(&mut self, ctx: &egui::Context, provider_name: &str, size: u32) -> Option<&TextureHandle> {
+    pub fn get_icon(
+        &mut self,
+        ctx: &egui::Context,
+        provider_name: &str,
+        size: u32,
+    ) -> Option<&TextureHandle> {
         let key = normalize_provider_name(provider_name);
         let cache_key = format!("{}_{}", key, size);
 
@@ -95,16 +151,13 @@ fn load_provider_icon(ctx: &egui::Context, provider_key: &str, size: u32) -> Opt
     let offset_x = (size as f32 - svg_size.width() * scale) / 2.0;
     let offset_y = (size as f32 - svg_size.height() * scale) / 2.0;
 
-    let transform = tiny_skia::Transform::from_scale(scale, scale)
-        .post_translate(offset_x, offset_y);
+    let transform =
+        tiny_skia::Transform::from_scale(scale, scale).post_translate(offset_x, offset_y);
 
     resvg::render(&tree, transform, &mut pixmap.as_mut());
 
     // Convert to egui texture
-    let image = ColorImage::from_rgba_unmultiplied(
-        [size as usize, size as usize],
-        pixmap.data(),
-    );
+    let image = ColorImage::from_rgba_unmultiplied([size as usize, size as usize], pixmap.data());
 
     let texture = ctx.load_texture(
         format!("provider_icon_{}", provider_key),

--- a/rust/src/native_ui/theme.rs
+++ b/rust/src/native_ui/theme.rs
@@ -1,43 +1,101 @@
-//! Theme: macOS-Style Dark
+//! Theme: Dark & Light Mode Support
 //!
-//! A clean dark theme matching macOS dark mode appearance.
-//! Uses colors that approximate NSColor system colors.
+//! A clean theme system supporting both dark and light modes.
+//! Dark mode uses macOS Monterey dark colors.
+//! Light mode uses macOS-inspired light colors.
+//! Mode is controlled at runtime via an atomic flag.
 
 #![allow(dead_code)]
 
 use egui::Color32;
+use std::sync::atomic::{AtomicBool, Ordering};
 
-/// macOS-Style Dark Theme
+/// Global dark mode flag (true = dark, false = light)
+static IS_DARK: AtomicBool = AtomicBool::new(true);
+
+/// macOS-Style Theme with dark and light mode support
 pub struct Theme;
 
 impl Theme {
+    /// Set the active theme mode
+    pub fn set_dark(dark: bool) {
+        IS_DARK.store(dark, Ordering::Relaxed);
+    }
+
+    /// Check if dark mode is active
+    pub fn is_dark() -> bool {
+        IS_DARK.load(Ordering::Relaxed)
+    }
+
     // ═══════════════════════════════════════════════════════════════════
-    // BACKGROUNDS - macOS dark mode style
+    // BACKGROUNDS
     // ═══════════════════════════════════════════════════════════════════
 
-    /// Window background - matches macOS windowBackgroundColor (dark)
-    pub const BG_PRIMARY: Color32 = Color32::from_rgb(30, 30, 30);
+    /// Window background
+    pub fn bg_primary() -> Color32 {
+        if Self::is_dark() {
+            Color32::from_rgb(30, 30, 30)
+        } else {
+            Color32::from_rgb(246, 246, 248)
+        }
+    }
 
     /// Secondary background - elevated layer
-    pub const BG_SECONDARY: Color32 = Color32::from_rgb(38, 38, 38);
+    pub fn bg_secondary() -> Color32 {
+        if Self::is_dark() {
+            Color32::from_rgb(38, 38, 38)
+        } else {
+            Color32::from_rgb(255, 255, 255)
+        }
+    }
 
     /// Tertiary background - for nested elements
-    pub const BG_TERTIARY: Color32 = Color32::from_rgb(48, 48, 48);
+    pub fn bg_tertiary() -> Color32 {
+        if Self::is_dark() {
+            Color32::from_rgb(48, 48, 48)
+        } else {
+            Color32::from_rgb(238, 238, 240)
+        }
+    }
 
     /// Card/panel background - slightly elevated
-    pub const CARD_BG: Color32 = Color32::from_rgb(44, 44, 46);
+    pub fn card_bg() -> Color32 {
+        if Self::is_dark() {
+            Color32::from_rgb(44, 44, 46)
+        } else {
+            Color32::from_rgb(255, 255, 255)
+        }
+    }
 
     /// Card background on hover
-    pub const CARD_BG_HOVER: Color32 = Color32::from_rgb(54, 54, 56);
+    pub fn card_bg_hover() -> Color32 {
+        if Self::is_dark() {
+            Color32::from_rgb(54, 54, 56)
+        } else {
+            Color32::from_rgb(242, 242, 247)
+        }
+    }
 
     /// Elevated surface (modals, popovers)
-    pub const SURFACE_ELEVATED: Color32 = Color32::from_rgb(50, 50, 52);
+    pub fn surface_elevated() -> Color32 {
+        if Self::is_dark() {
+            Color32::from_rgb(50, 50, 52)
+        } else {
+            Color32::from_rgb(255, 255, 255)
+        }
+    }
 
     /// Input field background
-    pub const INPUT_BG: Color32 = Color32::from_rgb(28, 28, 30);
+    pub fn input_bg() -> Color32 {
+        if Self::is_dark() {
+            Color32::from_rgb(28, 28, 30)
+        } else {
+            Color32::from_rgb(239, 239, 244)
+        }
+    }
 
     // ═══════════════════════════════════════════════════════════════════
-    // ACCENT COLORS - macOS blue accent
+    // ACCENT COLORS - same in both modes
     // ═══════════════════════════════════════════════════════════════════
 
     /// Primary accent - macOS systemBlue
@@ -60,57 +118,123 @@ impl Theme {
     // ═══════════════════════════════════════════════════════════════════
 
     /// Tab container background
-    pub const TAB_CONTAINER: Color32 = Color32::from_rgb(28, 28, 30);
+    pub fn tab_container() -> Color32 {
+        if Self::is_dark() {
+            Color32::from_rgb(28, 28, 30)
+        } else {
+            Color32::from_rgb(229, 229, 234)
+        }
+    }
 
     /// Tab inactive state
-    pub const TAB_INACTIVE: Color32 = Color32::from_rgb(44, 44, 46);
+    pub fn tab_inactive() -> Color32 {
+        if Self::is_dark() {
+            Color32::from_rgb(44, 44, 46)
+        } else {
+            Color32::from_rgb(242, 242, 247)
+        }
+    }
 
     /// Tab active state
     pub const TAB_ACTIVE: Color32 = Color32::from_rgb(10, 132, 255);
 
-    /// Tab text when inactive - secondaryLabelColor
-    pub const TAB_TEXT_INACTIVE: Color32 = Color32::from_rgb(142, 142, 147);
+    /// Tab text when inactive
+    pub fn tab_text_inactive() -> Color32 {
+        if Self::is_dark() {
+            Color32::from_rgb(142, 142, 147)
+        } else {
+            Color32::from_rgb(108, 108, 112)
+        }
+    }
 
     /// Tab text when active
     pub const TAB_TEXT_ACTIVE: Color32 = Color32::WHITE;
 
     // ═══════════════════════════════════════════════════════════════════
-    // TEXT COLORS - macOS label colors
+    // TEXT COLORS
     // ═══════════════════════════════════════════════════════════════════
 
-    /// Primary text - labelColor (white in dark mode)
-    pub const TEXT_PRIMARY: Color32 = Color32::from_rgb(255, 255, 255);
+    /// Primary text
+    pub fn text_primary() -> Color32 {
+        if Self::is_dark() {
+            Color32::from_rgb(255, 255, 255)
+        } else {
+            Color32::from_rgb(0, 0, 0)
+        }
+    }
 
-    /// Secondary text - secondaryLabelColor
-    pub const TEXT_SECONDARY: Color32 = Color32::from_rgb(142, 142, 147);
+    /// Secondary text
+    pub fn text_secondary() -> Color32 {
+        if Self::is_dark() {
+            Color32::from_rgb(142, 142, 147)
+        } else {
+            Color32::from_rgb(108, 108, 112)
+        }
+    }
 
-    /// Muted text - tertiaryLabelColor
-    pub const TEXT_MUTED: Color32 = Color32::from_rgb(84, 84, 88);
+    /// Muted text
+    pub fn text_muted() -> Color32 {
+        if Self::is_dark() {
+            Color32::from_rgb(84, 84, 88)
+        } else {
+            Color32::from_rgb(142, 142, 147)
+        }
+    }
 
-    /// Dimmed text - quaternaryLabelColor
-    pub const TEXT_DIM: Color32 = Color32::from_rgb(60, 60, 67);
+    /// Dimmed text
+    pub fn text_dim() -> Color32 {
+        if Self::is_dark() {
+            Color32::from_rgb(60, 60, 67)
+        } else {
+            Color32::from_rgb(174, 174, 178)
+        }
+    }
 
     /// Section header text
-    pub const TEXT_SECTION: Color32 = Color32::from_rgb(142, 142, 147);
+    pub fn text_section() -> Color32 {
+        if Self::is_dark() {
+            Color32::from_rgb(142, 142, 147)
+        } else {
+            Color32::from_rgb(108, 108, 112)
+        }
+    }
 
     // ═══════════════════════════════════════════════════════════════════
-    // BORDERS & SEPARATORS - macOS separatorColor
+    // BORDERS & SEPARATORS
     // ═══════════════════════════════════════════════════════════════════
 
-    /// Separator line - separatorColor
-    pub const SEPARATOR: Color32 = Color32::from_rgb(56, 56, 58);
+    /// Separator line
+    pub fn separator() -> Color32 {
+        if Self::is_dark() {
+            Color32::from_rgb(56, 56, 58)
+        } else {
+            Color32::from_rgb(216, 216, 220)
+        }
+    }
 
     /// Card/panel border
-    pub const CARD_BORDER: Color32 = Color32::from_rgb(56, 56, 58);
+    pub fn card_border() -> Color32 {
+        if Self::is_dark() {
+            Color32::from_rgb(56, 56, 58)
+        } else {
+            Color32::from_rgb(216, 216, 220)
+        }
+    }
 
     /// Focused/accent border
     pub const CARD_BORDER_ACCENT: Color32 = Color32::from_rgb(10, 132, 255);
 
     /// Subtle border for inputs
-    pub const BORDER_SUBTLE: Color32 = Color32::from_rgb(68, 68, 70);
+    pub fn border_subtle() -> Color32 {
+        if Self::is_dark() {
+            Color32::from_rgb(68, 68, 70)
+        } else {
+            Color32::from_rgb(209, 209, 214)
+        }
+    }
 
     // ═══════════════════════════════════════════════════════════════════
-    // USAGE/STATUS COLORS - macOS system colors
+    // USAGE/STATUS COLORS - same in both modes
     // ═══════════════════════════════════════════════════════════════════
 
     /// Green - systemGreen (0-50% usage)
@@ -133,13 +257,17 @@ impl Theme {
     /// Cyan - systemCyan
     pub const CYAN: Color32 = Color32::from_rgb(100, 210, 255);
 
-    /// Progress bar track - tertiaryLabelColor with opacity
+    /// Progress bar track
     pub fn progress_track() -> Color32 {
-        Color32::from_rgba_unmultiplied(84, 84, 88, 56)
+        if Self::is_dark() {
+            Color32::from_rgba_unmultiplied(84, 84, 88, 56)
+        } else {
+            Color32::from_rgba_unmultiplied(120, 120, 128, 36)
+        }
     }
 
     // ═══════════════════════════════════════════════════════════════════
-    // BADGES - Status indicators
+    // BADGES - same in both modes
     // ═══════════════════════════════════════════════════════════════════
 
     /// Success badge - systemGreen
@@ -160,37 +288,65 @@ impl Theme {
 
     /// Shadow color
     pub fn shadow() -> Color32 {
-        Color32::from_rgba_unmultiplied(0, 0, 0, 60)
+        if Self::is_dark() {
+            Color32::from_rgba_unmultiplied(0, 0, 0, 60)
+        } else {
+            Color32::from_rgba_unmultiplied(0, 0, 0, 20)
+        }
     }
 
-    /// Selection overlay - selectedContentBackgroundColor with opacity
+    /// Selection overlay
     pub fn selection_overlay() -> Color32 {
-        Color32::from_rgba_unmultiplied(10, 132, 255, 30)
+        if Self::is_dark() {
+            Color32::from_rgba_unmultiplied(10, 132, 255, 30)
+        } else {
+            Color32::from_rgba_unmultiplied(10, 132, 255, 20)
+        }
     }
 
     /// Hover overlay
     pub fn hover_overlay() -> Color32 {
-        Color32::from_rgba_unmultiplied(255, 255, 255, 8)
+        if Self::is_dark() {
+            Color32::from_rgba_unmultiplied(255, 255, 255, 8)
+        } else {
+            Color32::from_rgba_unmultiplied(0, 0, 0, 6)
+        }
     }
 
     /// Glow overlay for active elements
     pub fn glow_overlay() -> Color32 {
-        Color32::from_rgba_unmultiplied(10, 132, 255, 25)
+        if Self::is_dark() {
+            Color32::from_rgba_unmultiplied(10, 132, 255, 25)
+        } else {
+            Color32::from_rgba_unmultiplied(10, 132, 255, 15)
+        }
     }
 
     /// Progress glow
     pub fn progress_glow() -> Color32 {
-        Color32::from_rgba_unmultiplied(10, 132, 255, 35)
+        if Self::is_dark() {
+            Color32::from_rgba_unmultiplied(10, 132, 255, 35)
+        } else {
+            Color32::from_rgba_unmultiplied(10, 132, 255, 20)
+        }
     }
 
     /// Gradient start (for backgrounds)
     pub fn gradient_start() -> Color32 {
-        Color32::from_rgba_unmultiplied(10, 132, 255, 10)
+        if Self::is_dark() {
+            Color32::from_rgba_unmultiplied(10, 132, 255, 10)
+        } else {
+            Color32::from_rgba_unmultiplied(10, 132, 255, 6)
+        }
     }
 
     /// Gradient end
     pub fn gradient_end() -> Color32 {
-        Color32::from_rgba_unmultiplied(94, 92, 230, 8)
+        if Self::is_dark() {
+            Color32::from_rgba_unmultiplied(94, 92, 230, 8)
+        } else {
+            Color32::from_rgba_unmultiplied(94, 92, 230, 5)
+        }
     }
 
     // ═══════════════════════════════════════════════════════════════════
@@ -223,7 +379,11 @@ impl Theme {
 
     /// Get menu item hover background
     pub fn menu_hover() -> Color32 {
-        Color32::from_rgba_unmultiplied(255, 255, 255, 8)
+        if Self::is_dark() {
+            Color32::from_rgba_unmultiplied(255, 255, 255, 8)
+        } else {
+            Color32::from_rgba_unmultiplied(0, 0, 0, 6)
+        }
     }
 
     /// Button gradient top
@@ -246,7 +406,7 @@ pub fn status_color(level: StatusLevel) -> Color32 {
         StatusLevel::Degraded => Theme::YELLOW,
         StatusLevel::Partial => Theme::ORANGE,
         StatusLevel::Major => Theme::RED,
-        StatusLevel::Unknown => Theme::TEXT_MUTED,
+        StatusLevel::Unknown => Theme::text_muted(),
     }
 }
 
@@ -283,25 +443,31 @@ pub fn provider_icon(name: &str) -> &'static str {
 /// Provider brand colors - matching original CodexBar
 pub fn provider_color(name: &str) -> Color32 {
     match name.to_lowercase().as_str() {
-        "claude" => Color32::from_rgb(204, 124, 94),        // #CC7C5E - Warm terracotta
-        "codex" => Color32::from_rgb(73, 163, 176),         // #49A3B0 - Teal
-        "gemini" => Color32::from_rgb(171, 135, 234),       // #AB87EA - Purple
-        "cursor" => Color32::from_rgb(0, 191, 165),         // #00BFA5 - Teal green
-        "copilot" => Color32::from_rgb(168, 85, 247),       // #A855F7 - Vibrant purple
+        "claude" => Color32::from_rgb(204, 124, 94), // #CC7C5E - Warm terracotta
+        "codex" => Color32::from_rgb(73, 163, 176),  // #49A3B0 - Teal
+        "gemini" => Color32::from_rgb(171, 135, 234), // #AB87EA - Purple
+        "cursor" => Color32::from_rgb(0, 191, 165),  // #00BFA5 - Teal green
+        "copilot" => Color32::from_rgb(168, 85, 247), // #A855F7 - Vibrant purple
         "jetbrains" | "jetbrains ai" => Color32::from_rgb(255, 51, 153), // #FF3399 - Hot pink
-        "antigravity" => Color32::from_rgb(96, 186, 126),   // #60BA7E - Soft green
-        "augment" => Color32::from_rgb(99, 102, 241),       // #6366F1 - Indigo
-        "amp" => Color32::from_rgb(220, 38, 38),            // #DC2626 - Red
+        "antigravity" => Color32::from_rgb(96, 186, 126), // #60BA7E - Soft green
+        "augment" => Color32::from_rgb(99, 102, 241), // #6366F1 - Indigo
+        "amp" => Color32::from_rgb(220, 38, 38),     // #DC2626 - Red
         "factory" | "droid" => Color32::from_rgb(255, 107, 53), // #FF6B35 - Orange
-        "kimi" => Color32::from_rgb(254, 96, 60),           // #FE603C - Coral
+        "kimi" => Color32::from_rgb(254, 96, 60),    // #FE603C - Coral
         "kimik2" | "kimi k2" => Color32::from_rgb(76, 0, 255), // #4C00FF - Electric blue
-        "kilo" => Color32::from_rgb(242, 112, 39),           // #F27027 - Kilo orange
-        "kiro" => Color32::from_rgb(255, 153, 0),           // #FF9900 - Amber
-        "opencode" => Color32::from_rgb(59, 130, 246),      // #3B82F6 - Blue
-        "minimax" => Color32::from_rgb(254, 96, 60),        // #FE603C - Coral (same as Kimi)
+        "kilo" => Color32::from_rgb(242, 112, 39),   // #F27027 - Kilo orange
+        "kiro" => Color32::from_rgb(255, 153, 0),    // #FF9900 - Amber
+        "opencode" => Color32::from_rgb(59, 130, 246), // #3B82F6 - Blue
+        "minimax" => Color32::from_rgb(254, 96, 60), // #FE603C - Coral (same as Kimi)
         "vertexai" | "vertex ai" => Color32::from_rgb(66, 133, 244), // #4285F4 - Google blue
-        "zai" | "z.ai" => Color32::from_rgb(232, 90, 106),  // #E85A6A - Rose
-        "synthetic" => Color32::from_rgb(20, 20, 20),       // #141414 - Near black
+        "zai" | "z.ai" => Color32::from_rgb(232, 90, 106), // #E85A6A - Rose
+        "synthetic" => {
+            if Theme::is_dark() {
+                Color32::from_rgb(20, 20, 20)
+            } else {
+                Color32::from_rgb(60, 60, 60)
+            }
+        }
         _ => Theme::ACCENT_PRIMARY,
     }
 }
@@ -346,4 +512,77 @@ impl FontSize {
     pub const LG: f32 = 17.0;
     pub const XL: f32 = 18.0;
     pub const XXL: f32 = 22.0;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_theme_dark_mode_default() {
+        // Default should be dark mode
+        Theme::set_dark(true);
+        assert!(Theme::is_dark());
+    }
+
+    #[test]
+    fn test_theme_light_mode_switch() {
+        Theme::set_dark(false);
+        assert!(!Theme::is_dark());
+        // Restore
+        Theme::set_dark(true);
+    }
+
+    #[test]
+    fn test_dark_mode_colors() {
+        Theme::set_dark(true);
+        assert_eq!(Theme::bg_primary(), Color32::from_rgb(30, 30, 30));
+        assert_eq!(Theme::text_primary(), Color32::from_rgb(255, 255, 255));
+        assert_eq!(Theme::card_bg(), Color32::from_rgb(44, 44, 46));
+    }
+
+    #[test]
+    fn test_light_mode_colors() {
+        Theme::set_dark(false);
+        assert_eq!(Theme::bg_primary(), Color32::from_rgb(246, 246, 248));
+        assert_eq!(Theme::text_primary(), Color32::from_rgb(0, 0, 0));
+        assert_eq!(Theme::card_bg(), Color32::from_rgb(255, 255, 255));
+        // Restore
+        Theme::set_dark(true);
+    }
+
+    #[test]
+    fn test_accent_colors_unchanged() {
+        // Accent colors should be the same in both modes
+        Theme::set_dark(true);
+        let dark_accent = Theme::ACCENT_PRIMARY;
+        Theme::set_dark(false);
+        let light_accent = Theme::ACCENT_PRIMARY;
+        assert_eq!(dark_accent, light_accent);
+        // Restore
+        Theme::set_dark(true);
+    }
+
+    #[test]
+    fn test_usage_colors() {
+        assert_eq!(Theme::usage_color(25.0), Theme::GREEN);
+        assert_eq!(Theme::usage_color(60.0), Theme::YELLOW);
+        assert_eq!(Theme::usage_color(80.0), Theme::ORANGE);
+        assert_eq!(Theme::usage_color(95.0), Theme::RED);
+    }
+
+    #[test]
+    fn test_provider_colors() {
+        assert_eq!(provider_color("claude"), Color32::from_rgb(204, 124, 94));
+        assert_eq!(provider_color("codex"), Color32::from_rgb(73, 163, 176));
+        // Unknown provider should return accent color
+        assert_eq!(provider_color("unknown"), Theme::ACCENT_PRIMARY);
+    }
+
+    #[test]
+    fn test_provider_icons() {
+        assert_eq!(provider_icon("claude"), "◈");
+        assert_eq!(provider_icon("codex"), "◆");
+        assert_eq!(provider_icon("unknown"), "●");
+    }
 }

--- a/rust/src/notifications.rs
+++ b/rust/src/notifications.rs
@@ -98,7 +98,12 @@ impl NotificationManager {
     }
 
     /// Send a notification for a status issue
-    pub fn notify_status_issue(&mut self, provider: ProviderId, description: &str, settings: &Settings) {
+    pub fn notify_status_issue(
+        &mut self,
+        provider: ProviderId,
+        description: &str,
+        settings: &Settings,
+    ) {
         let key = (provider, NotificationType::StatusIssue);
         if !self.sent_notifications.contains(&key) {
             self.send_status_notification(provider, description, settings);
@@ -108,7 +113,8 @@ impl NotificationManager {
 
     /// Clear status issue notification (when resolved)
     pub fn clear_status_issue(&mut self, provider: ProviderId) {
-        self.sent_notifications.remove(&(provider, NotificationType::StatusIssue));
+        self.sent_notifications
+            .remove(&(provider, NotificationType::StatusIssue));
     }
 
     /// Check session quota transitions (depleted/restored)
@@ -125,7 +131,11 @@ impl NotificationManager {
 
         const DEPLETED_THRESHOLD: f64 = 99.99; // Consider depleted at 99.99%+
 
-        let previous_percent = self.previous_session_percent.get(&provider).copied().unwrap_or(0.0);
+        let previous_percent = self
+            .previous_session_percent
+            .get(&provider)
+            .copied()
+            .unwrap_or(0.0);
 
         // Check for depleted transition: was not depleted, now is
         if previous_percent < DEPLETED_THRESHOLD && current_percent >= DEPLETED_THRESHOLD {
@@ -136,12 +146,16 @@ impl NotificationManager {
             );
             self.show_toast(title, &body);
             play_alert(AlertSound::Error, settings);
-            self.sent_notifications.insert((provider, NotificationType::SessionDepleted));
+            self.sent_notifications
+                .insert((provider, NotificationType::SessionDepleted));
         }
         // Check for restored transition: was depleted, now is not
         else if previous_percent >= DEPLETED_THRESHOLD && current_percent < DEPLETED_THRESHOLD {
             // Only notify restored if we previously sent a depleted notification
-            if self.sent_notifications.contains(&(provider, NotificationType::SessionDepleted)) {
+            if self
+                .sent_notifications
+                .contains(&(provider, NotificationType::SessionDepleted))
+            {
                 let title = NotificationType::SessionRestored.title();
                 let body = format!(
                     "{} session restored. Session quota is available again.",
@@ -149,26 +163,46 @@ impl NotificationManager {
                 );
                 self.show_toast(title, &body);
                 play_alert(AlertSound::Success, settings);
-                self.sent_notifications.remove(&(provider, NotificationType::SessionDepleted));
+                self.sent_notifications
+                    .remove(&(provider, NotificationType::SessionDepleted));
             }
         }
 
         // Update the tracked previous percent
-        self.previous_session_percent.insert(provider, current_percent);
+        self.previous_session_percent
+            .insert(provider, current_percent);
     }
 
     /// Send a Windows toast notification with sound
-    fn send_notification(&self, provider: ProviderId, used_percent: f64, notif_type: NotificationType, settings: &Settings) {
+    fn send_notification(
+        &self,
+        provider: ProviderId,
+        used_percent: f64,
+        notif_type: NotificationType,
+        settings: &Settings,
+    ) {
         let title = notif_type.title();
         let body = match notif_type {
             NotificationType::HighUsage => {
-                format!("{} usage at {:.0}% - approaching limit", provider.display_name(), used_percent)
+                format!(
+                    "{} usage at {:.0}% - approaching limit",
+                    provider.display_name(),
+                    used_percent
+                )
             }
             NotificationType::CriticalUsage => {
-                format!("{} usage at {:.0}% - critically high!", provider.display_name(), used_percent)
+                format!(
+                    "{} usage at {:.0}% - critically high!",
+                    provider.display_name(),
+                    used_percent
+                )
             }
             NotificationType::Exhausted => {
-                format!("{} usage limit exhausted ({:.0}%)", provider.display_name(), used_percent)
+                format!(
+                    "{} usage limit exhausted ({:.0}%)",
+                    provider.display_name(),
+                    used_percent
+                )
             }
             NotificationType::StatusIssue => {
                 format!("{} is experiencing issues", provider.display_name())
@@ -177,7 +211,10 @@ impl NotificationManager {
                 format!("{} session depleted. 0% left.", provider.display_name())
             }
             NotificationType::SessionRestored => {
-                format!("{} session restored. Quota available again.", provider.display_name())
+                format!(
+                    "{} session restored. Quota available again.",
+                    provider.display_name()
+                )
             }
         };
 
@@ -195,7 +232,12 @@ impl NotificationManager {
         play_alert(alert_sound, settings);
     }
 
-    fn send_status_notification(&self, provider: ProviderId, description: &str, settings: &Settings) {
+    fn send_status_notification(
+        &self,
+        provider: ProviderId,
+        description: &str,
+        settings: &Settings,
+    ) {
         let title = NotificationType::StatusIssue.title();
         let body = format!("{}: {}", provider.display_name(), description);
         self.show_toast(title, &body);
@@ -241,8 +283,7 @@ impl NotificationManager {
             $toast = [Windows.UI.Notifications.ToastNotification]::new($xml)
             [Windows.UI.Notifications.ToastNotificationManager]::CreateToastNotifier("CodexBar").Show($toast)
             "#,
-            safe_title,
-            safe_body
+            safe_title, safe_body
         );
 
         let _ = Command::new("powershell")

--- a/rust/src/providers/amp/mod.rs
+++ b/rust/src/providers/amp/mod.rs
@@ -7,8 +7,8 @@ use async_trait::async_trait;
 use std::path::PathBuf;
 
 use crate::core::{
-    FetchContext, Provider, ProviderId, ProviderError, ProviderFetchResult,
-    ProviderMetadata, RateWindow, SourceMode, UsageSnapshot,
+    FetchContext, Provider, ProviderError, ProviderFetchResult, ProviderId, ProviderMetadata,
+    RateWindow, SourceMode, UsageSnapshot,
 };
 
 /// Amp provider (Sourcegraph)
@@ -126,20 +126,27 @@ impl AmpProvider {
             return Err(ProviderError::AuthRequired);
         }
 
-        let json: serde_json::Value = resp.json().await
+        let json: serde_json::Value = resp
+            .json()
+            .await
             .map_err(|e| ProviderError::Parse(e.to_string()))?;
 
         self.parse_usage_response(&json)
     }
 
-    fn parse_usage_response(&self, json: &serde_json::Value) -> Result<UsageSnapshot, ProviderError> {
+    fn parse_usage_response(
+        &self,
+        json: &serde_json::Value,
+    ) -> Result<UsageSnapshot, ProviderError> {
         // Parse Sourcegraph/Amp usage response
-        let used = json.get("completionsUsed")
+        let used = json
+            .get("completionsUsed")
             .or_else(|| json.get("used"))
             .and_then(|v| v.as_f64())
             .unwrap_or(0.0);
 
-        let limit = json.get("completionsLimit")
+        let limit = json
+            .get("completionsLimit")
             .or_else(|| json.get("limit"))
             .and_then(|v| v.as_f64())
             .unwrap_or(500.0);
@@ -150,19 +157,20 @@ impl AmpProvider {
             0.0
         };
 
-        let plan = json.get("plan")
+        let plan = json
+            .get("plan")
             .or_else(|| json.get("tier"))
             .and_then(|v| v.as_str())
             .unwrap_or("Pro");
 
-        let reset_time = json.get("resetAt")
+        let reset_time = json
+            .get("resetAt")
             .or_else(|| json.get("periodEnd"))
             .and_then(|v| v.as_str())
             .map(|s| s.to_string());
 
         let primary_window = RateWindow::with_details(used_percent, None, None, reset_time);
-        let usage = UsageSnapshot::new(primary_window)
-            .with_login_method(plan);
+        let usage = UsageSnapshot::new(primary_window).with_login_method(plan);
 
         Ok(usage)
     }
@@ -172,8 +180,8 @@ impl AmpProvider {
         // Check ctx.api_key first
         let has_api_key = ctx.api_key.as_ref().map(|k| !k.is_empty()).unwrap_or(false);
 
-        let has_env = std::env::var("SRC_ACCESS_TOKEN").is_ok()
-            || std::env::var("AMP_ACCESS_TOKEN").is_ok();
+        let has_env =
+            std::env::var("SRC_ACCESS_TOKEN").is_ok() || std::env::var("AMP_ACCESS_TOKEN").is_ok();
 
         let has_amp_config = Self::get_amp_config_path()
             .map(|p| p.join("config.json").exists())
@@ -184,12 +192,13 @@ impl AmpProvider {
             .unwrap_or(false);
 
         if has_api_key || has_env || has_amp_config || has_cody_config {
-            let usage = UsageSnapshot::new(RateWindow::new(0.0))
-                .with_login_method("Amp (configured)");
+            let usage =
+                UsageSnapshot::new(RateWindow::new(0.0)).with_login_method("Amp (configured)");
             Ok(usage)
         } else {
             Err(ProviderError::NotInstalled(
-                "Amp not configured. Set SRC_ACCESS_TOKEN environment variable or configure Amp.".to_string()
+                "Amp not configured. Set SRC_ACCESS_TOKEN environment variable or configure Amp."
+                    .to_string(),
             ))
         }
     }
@@ -230,9 +239,7 @@ impl Provider for AmpProvider {
                 let usage = self.probe_cli(ctx).await?;
                 Ok(ProviderFetchResult::new(usage, "cli"))
             }
-            SourceMode::OAuth => {
-                Err(ProviderError::UnsupportedSource(SourceMode::OAuth))
-            }
+            SourceMode::OAuth => Err(ProviderError::UnsupportedSource(SourceMode::OAuth)),
         }
     }
 

--- a/rust/src/providers/antigravity/mod.rs
+++ b/rust/src/providers/antigravity/mod.rs
@@ -4,15 +4,15 @@
 //! Uses Windows process detection to find CSRF token
 
 use async_trait::async_trait;
+use regex_lite::Regex;
 use serde::Deserialize;
-use std::process::Command;
 #[cfg(windows)]
 use std::os::windows::process::CommandExt;
-use regex_lite::Regex;
+use std::process::Command;
 
 use crate::core::{
-    FetchContext, Provider, ProviderId, ProviderError, ProviderFetchResult,
-    ProviderMetadata, RateWindow, SourceMode, UsageSnapshot,
+    FetchContext, Provider, ProviderError, ProviderFetchResult, ProviderId, ProviderMetadata,
+    RateWindow, SourceMode, UsageSnapshot,
 };
 
 /// Antigravity provider
@@ -53,12 +53,13 @@ impl AntigravityProvider {
         #[cfg(windows)]
         cmd.creation_flags(CREATE_NO_WINDOW);
 
-        let output = cmd.output()
+        let output = cmd
+            .output()
             .map_err(|e| ProviderError::Other(format!("Failed to run PowerShell: {}", e)))?;
 
         if !output.status.success() {
             return Err(ProviderError::NotInstalled(
-                "Failed to detect Antigravity process".to_string()
+                "Failed to detect Antigravity process".to_string(),
             ));
         }
 
@@ -90,7 +91,7 @@ impl AntigravityProvider {
         }
 
         Err(ProviderError::NotInstalled(
-            "Antigravity language server not running".to_string()
+            "Antigravity language server not running".to_string(),
         ))
     }
 
@@ -110,10 +111,14 @@ impl AntigravityProvider {
 
         for offset in 0..20 {
             let port = extension_port + offset;
-            let url = format!("https://127.0.0.1:{}/exa.language_server_pb.LanguageServerService/GetUnleashData", port);
+            let url = format!(
+                "https://127.0.0.1:{}/exa.language_server_pb.LanguageServerService/GetUnleashData",
+                port
+            );
 
             // Just check if the port responds (even with error)
-            if let Ok(resp) = client.post(&url)
+            if let Ok(resp) = client
+                .post(&url)
                 .header("Content-Type", "application/json")
                 .header("Connect-Protocol-Version", "1")
                 .body("{}")
@@ -129,8 +134,12 @@ impl AntigravityProvider {
 
         // Fallback: try common ports
         for port in [53835, 53836, 53837, 53838, 53845, 53849] {
-            let url = format!("https://127.0.0.1:{}/exa.language_server_pb.LanguageServerService/GetUnleashData", port);
-            if let Ok(resp) = client.post(&url)
+            let url = format!(
+                "https://127.0.0.1:{}/exa.language_server_pb.LanguageServerService/GetUnleashData",
+                port
+            );
+            if let Ok(resp) = client
+                .post(&url)
                 .header("Content-Type", "application/json")
                 .header("Connect-Protocol-Version", "1")
                 .body("{}")
@@ -143,7 +152,9 @@ impl AntigravityProvider {
             }
         }
 
-        Err(ProviderError::Other("Could not find Antigravity API port".to_string()))
+        Err(ProviderError::Other(
+            "Could not find Antigravity API port".to_string(),
+        ))
     }
 
     /// Fetch user status from Antigravity API
@@ -173,7 +184,8 @@ impl AntigravityProvider {
             }
         });
 
-        let resp = client.post(&url)
+        let resp = client
+            .post(&url)
             .header("Content-Type", "application/json")
             .header("Connect-Protocol-Version", "1")
             .header("X-Codeium-Csrf-Token", &process_info.csrf_token)
@@ -185,20 +197,30 @@ impl AntigravityProvider {
         if !resp.status().is_success() {
             let status = resp.status();
             let text = resp.text().await.unwrap_or_default();
-            return Err(ProviderError::Other(format!("API error {}: {}", status, text)));
+            return Err(ProviderError::Other(format!(
+                "API error {}: {}",
+                status, text
+            )));
         }
 
-        let json: UserStatusResponse = resp.json().await
+        let json: UserStatusResponse = resp
+            .json()
+            .await
             .map_err(|e| ProviderError::Other(format!("Failed to parse response: {}", e)))?;
 
         self.parse_user_status(json)
     }
 
-    fn parse_user_status(&self, response: UserStatusResponse) -> Result<UsageSnapshot, ProviderError> {
-        let user_status = response.user_status
+    fn parse_user_status(
+        &self,
+        response: UserStatusResponse,
+    ) -> Result<UsageSnapshot, ProviderError> {
+        let user_status = response
+            .user_status
             .ok_or_else(|| ProviderError::Other("Missing userStatus".to_string()))?;
 
-        let model_configs = user_status.cascade_model_config_data
+        let model_configs = user_status
+            .cascade_model_config_data
             .and_then(|d| d.client_model_configs)
             .unwrap_or_default();
 
@@ -210,7 +232,10 @@ impl AntigravityProvider {
         for config in &model_configs {
             let label_lower = config.label.to_lowercase();
 
-            if primary.is_none() && label_lower.contains("claude") && !label_lower.contains("thinking") {
+            if primary.is_none()
+                && label_lower.contains("claude")
+                && !label_lower.contains("thinking")
+            {
                 if let Some(quota) = &config.quota_info {
                     let remaining = quota.remaining_fraction.unwrap_or(1.0);
                     let used_percent = (1.0 - remaining) * 100.0;
@@ -221,7 +246,10 @@ impl AntigravityProvider {
                         quota.reset_time.clone(),
                     ));
                 }
-            } else if secondary.is_none() && label_lower.contains("pro") && label_lower.contains("low") {
+            } else if secondary.is_none()
+                && label_lower.contains("pro")
+                && label_lower.contains("low")
+            {
                 if let Some(quota) = &config.quota_info {
                     let remaining = quota.remaining_fraction.unwrap_or(1.0);
                     let used_percent = (1.0 - remaining) * 100.0;
@@ -273,7 +301,8 @@ impl AntigravityProvider {
         }
 
         // Add plan info
-        let plan_name = user_status.plan_status
+        let plan_name = user_status
+            .plan_status
             .and_then(|ps| ps.plan_info)
             .and_then(|pi| pi.plan_display_name.or(pi.plan_name));
 

--- a/rust/src/providers/augment/keepalive.rs
+++ b/rust/src/providers/augment/keepalive.rs
@@ -4,11 +4,11 @@
 //! Monitors cookie expiration and proactively refreshes the session before
 //! cookies expire, ensuring uninterrupted access to Augment APIs.
 
+use chrono::{DateTime, Utc};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::RwLock;
-use chrono::{DateTime, Utc};
 
 /// Configuration for the keepalive service
 pub struct KeepaliveConfig {
@@ -99,7 +99,8 @@ impl AugmentSessionKeepalive {
                     &config,
                     &last_refresh_attempt,
                     &last_successful_refresh,
-                ).await;
+                )
+                .await;
 
                 if should_refresh {
                     Self::perform_refresh(
@@ -108,7 +109,8 @@ impl AugmentSessionKeepalive {
                         &last_successful_refresh,
                         &is_refreshing,
                         false,
-                    ).await;
+                    )
+                    .await;
                 }
             }
             tracing::info!("[AugmentKeepalive] Keepalive stopped");
@@ -135,7 +137,8 @@ impl AugmentSessionKeepalive {
             &self.last_successful_refresh,
             &self.is_refreshing,
             true,
-        ).await;
+        )
+        .await;
     }
 
     /// Check if we should refresh the session
@@ -147,7 +150,8 @@ impl AugmentSessionKeepalive {
         // Rate limit check
         if let Some(last_attempt) = *last_refresh_attempt.read().await {
             let elapsed = Utc::now().signed_duration_since(last_attempt);
-            if elapsed < chrono::Duration::from_std(config.min_refresh_interval).unwrap_or_default() {
+            if elapsed < chrono::Duration::from_std(config.min_refresh_interval).unwrap_or_default()
+            {
                 tracing::debug!(
                     "[AugmentKeepalive] Skipping refresh (last attempt {:?} ago)",
                     elapsed
@@ -191,7 +195,10 @@ impl AugmentSessionKeepalive {
         *last_refresh_attempt.write().await = Some(Utc::now());
 
         let action = if forced { "forced" } else { "automatic" };
-        tracing::info!("[AugmentKeepalive] Performing {} session refresh...", action);
+        tracing::info!(
+            "[AugmentKeepalive] Performing {} session refresh...",
+            action
+        );
 
         // Try to ping session endpoints
         match Self::ping_session_endpoint(config).await {
@@ -228,7 +235,8 @@ impl AugmentSessionKeepalive {
         for endpoint in endpoints {
             tracing::debug!("[AugmentKeepalive] Trying endpoint: {}", endpoint);
 
-            match client.get(endpoint)
+            match client
+                .get(endpoint)
                 .header("Accept", "application/json")
                 .header("Origin", "https://app.augmentcode.com")
                 .header("Referer", "https://app.augmentcode.com")

--- a/rust/src/providers/augment/mod.rs
+++ b/rust/src/providers/augment/mod.rs
@@ -13,8 +13,8 @@ use async_trait::async_trait;
 use std::path::PathBuf;
 
 use crate::core::{
-    FetchContext, Provider, ProviderId, ProviderError, ProviderFetchResult,
-    ProviderMetadata, RateWindow, SourceMode, UsageSnapshot,
+    FetchContext, Provider, ProviderError, ProviderFetchResult, ProviderId, ProviderMetadata,
+    RateWindow, SourceMode, UsageSnapshot,
 };
 
 /// Augment provider
@@ -73,11 +73,12 @@ impl AugmentProvider {
         // Check for token file
         let token_file = config_path.join("auth.json");
         if token_file.exists() {
-            let content = tokio::fs::read_to_string(&token_file).await
+            let content = tokio::fs::read_to_string(&token_file)
+                .await
                 .map_err(|e| ProviderError::Other(e.to_string()))?;
 
-            let json: serde_json::Value = serde_json::from_str(&content)
-                .map_err(|e| ProviderError::Parse(e.to_string()))?;
+            let json: serde_json::Value =
+                serde_json::from_str(&content).map_err(|e| ProviderError::Parse(e.to_string()))?;
 
             if let Some(token) = json.get("access_token").and_then(|v| v.as_str()) {
                 return Ok(token.to_string());
@@ -95,11 +96,21 @@ impl AugmentProvider {
 
     async fn get_vscode_augment_settings() -> Option<String> {
         #[cfg(target_os = "windows")]
-        let settings_path = dirs::config_dir()
-            .map(|p| p.join("Code").join("User").join("globalStorage").join("augment.augment-vscode").join("auth.json"));
+        let settings_path = dirs::config_dir().map(|p| {
+            p.join("Code")
+                .join("User")
+                .join("globalStorage")
+                .join("augment.augment-vscode")
+                .join("auth.json")
+        });
         #[cfg(not(target_os = "windows"))]
-        let settings_path = dirs::config_dir()
-            .map(|p| p.join("Code").join("User").join("globalStorage").join("augment.augment-vscode").join("auth.json"));
+        let settings_path = dirs::config_dir().map(|p| {
+            p.join("Code")
+                .join("User")
+                .join("globalStorage")
+                .join("augment.augment-vscode")
+                .join("auth.json")
+        });
 
         if let Some(path) = settings_path {
             if path.exists() {
@@ -135,19 +146,26 @@ impl AugmentProvider {
             return Err(ProviderError::AuthRequired);
         }
 
-        let json: serde_json::Value = resp.json().await
+        let json: serde_json::Value = resp
+            .json()
+            .await
             .map_err(|e| ProviderError::Parse(e.to_string()))?;
 
         self.parse_usage_response(&json)
     }
 
-    fn parse_usage_response(&self, json: &serde_json::Value) -> Result<UsageSnapshot, ProviderError> {
-        let used = json.get("used_credits")
+    fn parse_usage_response(
+        &self,
+        json: &serde_json::Value,
+    ) -> Result<UsageSnapshot, ProviderError> {
+        let used = json
+            .get("used_credits")
             .or_else(|| json.get("usage"))
             .and_then(|v| v.as_f64())
             .unwrap_or(0.0);
 
-        let limit = json.get("credit_limit")
+        let limit = json
+            .get("credit_limit")
             .or_else(|| json.get("limit"))
             .and_then(|v| v.as_f64())
             .unwrap_or(100.0);
@@ -158,17 +176,18 @@ impl AugmentProvider {
             0.0
         };
 
-        let email = json.get("email")
+        let email = json
+            .get("email")
             .and_then(|v| v.as_str())
             .map(|s| s.to_string());
 
-        let plan = json.get("plan")
+        let plan = json
+            .get("plan")
             .or_else(|| json.get("subscription"))
             .and_then(|v| v.as_str())
             .unwrap_or("Augment");
 
-        let mut usage = UsageSnapshot::new(RateWindow::new(used_percent))
-            .with_login_method(plan);
+        let mut usage = UsageSnapshot::new(RateWindow::new(used_percent)).with_login_method(plan);
 
         if let Some(email) = email {
             usage = usage.with_email(email);
@@ -183,13 +202,15 @@ impl AugmentProvider {
         let augment_path = Self::which_augment();
         let config_path = Self::get_augment_config_path();
 
-        if augment_path.map(|p| p.exists()).unwrap_or(false) || config_path.map(|p| p.exists()).unwrap_or(false) {
-            let usage = UsageSnapshot::new(RateWindow::new(0.0))
-                .with_login_method("Augment (installed)");
+        if augment_path.map(|p| p.exists()).unwrap_or(false)
+            || config_path.map(|p| p.exists()).unwrap_or(false)
+        {
+            let usage =
+                UsageSnapshot::new(RateWindow::new(0.0)).with_login_method("Augment (installed)");
             Ok(usage)
         } else {
             Err(ProviderError::NotInstalled(
-                "Augment not found. Install from https://www.augmentcode.com".to_string()
+                "Augment not found. Install from https://www.augmentcode.com".to_string(),
             ))
         }
     }
@@ -230,9 +251,7 @@ impl Provider for AugmentProvider {
                 let usage = self.probe_cli().await?;
                 Ok(ProviderFetchResult::new(usage, "cli"))
             }
-            SourceMode::OAuth => {
-                Err(ProviderError::UnsupportedSource(SourceMode::OAuth))
-            }
+            SourceMode::OAuth => Err(ProviderError::UnsupportedSource(SourceMode::OAuth)),
         }
     }
 

--- a/rust/src/providers/claude/mod.rs
+++ b/rust/src/providers/claude/mod.rs
@@ -4,18 +4,18 @@ mod oauth;
 mod web_api;
 
 use async_trait::async_trait;
-use std::process::Stdio;
-use tokio::process::Command;
-use tokio::io::AsyncWriteExt;
 use regex_lite::Regex;
+use std::process::Stdio;
+use tokio::io::AsyncWriteExt;
+use tokio::process::Command;
 
 use crate::core::{
     FetchContext, Provider, ProviderError, ProviderFetchResult, ProviderId, ProviderMetadata,
     RateWindow, SourceMode, UsageSnapshot,
 };
 
-pub use web_api::ClaudeWebApiFetcher;
 pub use oauth::ClaudeOAuthFetcher;
+pub use web_api::ClaudeWebApiFetcher;
 
 /// Claude provider implementation
 pub struct ClaudeProvider {
@@ -106,25 +106,37 @@ impl Provider for ClaudeProvider {
 }
 
 impl ClaudeProvider {
-    async fn fetch_via_oauth(&self, _ctx: &FetchContext) -> Result<ProviderFetchResult, ProviderError> {
+    async fn fetch_via_oauth(
+        &self,
+        _ctx: &FetchContext,
+    ) -> Result<ProviderFetchResult, ProviderError> {
         tracing::debug!("Attempting OAuth fetch for Claude");
         self.oauth_fetcher.fetch().await
     }
 
-    async fn fetch_via_web(&self, ctx: &FetchContext) -> Result<ProviderFetchResult, ProviderError> {
+    async fn fetch_via_web(
+        &self,
+        ctx: &FetchContext,
+    ) -> Result<ProviderFetchResult, ProviderError> {
         tracing::debug!("Attempting Web API fetch for Claude");
 
         // Check for manual cookie header first
         if let Some(ref cookie_header) = ctx.manual_cookie_header {
             tracing::debug!("Using manual cookie header");
-            return self.web_fetcher.fetch_with_cookie_header(cookie_header).await;
+            return self
+                .web_fetcher
+                .fetch_with_cookie_header(cookie_header)
+                .await;
         }
 
         // Otherwise, try to extract cookies from browser
         self.web_fetcher.fetch_with_cookies().await
     }
 
-    async fn fetch_via_cli(&self, _ctx: &FetchContext) -> Result<ProviderFetchResult, ProviderError> {
+    async fn fetch_via_cli(
+        &self,
+        _ctx: &FetchContext,
+    ) -> Result<ProviderFetchResult, ProviderError> {
         tracing::debug!("Attempting CLI probe for Claude");
 
         // Check if claude CLI exists
@@ -153,13 +165,11 @@ impl ClaudeProvider {
         }
 
         // Wait for output with timeout
-        let output = tokio::time::timeout(
-            std::time::Duration::from_secs(30),
-            child.wait_with_output()
-        )
-        .await
-        .map_err(|_| ProviderError::Timeout)?
-        .map_err(|e| ProviderError::Other(format!("Claude CLI failed: {}", e)))?;
+        let output =
+            tokio::time::timeout(std::time::Duration::from_secs(30), child.wait_with_output())
+                .await
+                .map_err(|_| ProviderError::Timeout)?
+                .map_err(|e| ProviderError::Other(format!("Claude CLI failed: {}", e)))?;
 
         let stdout = String::from_utf8_lossy(&output.stdout);
         let stderr = String::from_utf8_lossy(&output.stderr);
@@ -171,10 +181,14 @@ impl ClaudeProvider {
             return Err(ProviderError::AuthRequired);
         }
         if lowered.contains("token expired") || lowered.contains("token_expired") {
-            return Err(ProviderError::OAuth("Token expired. Run `claude login` to refresh.".to_string()));
+            return Err(ProviderError::OAuth(
+                "Token expired. Run `claude login` to refresh.".to_string(),
+            ));
         }
         if lowered.contains("authentication_error") {
-            return Err(ProviderError::OAuth("Authentication error. Run `claude login`.".to_string()));
+            return Err(ProviderError::OAuth(
+                "Authentication error. Run `claude login`.".to_string(),
+            ));
         }
 
         // Parse the usage output
@@ -186,7 +200,9 @@ impl ClaudeProvider {
         let clean = strip_ansi(output);
 
         if clean.trim().is_empty() {
-            return Err(ProviderError::Parse("Empty output from Claude CLI".to_string()));
+            return Err(ProviderError::Parse(
+                "Empty output from Claude CLI".to_string(),
+            ));
         }
 
         // Parse session percent: "X% used" or "X% left"
@@ -238,7 +254,7 @@ impl ClaudeProvider {
         let primary = RateWindow::with_details(
             session_used,
             Some(300), // 5 hour session window
-            None, // Could parse reset time
+            None,      // Could parse reset time
             session_reset,
         );
 
@@ -255,12 +271,7 @@ impl ClaudeProvider {
         }
 
         if let Some(opus_used) = opus_percent {
-            let model_specific = RateWindow::with_details(
-                opus_used,
-                Some(10080),
-                None,
-                None,
-            );
+            let model_specific = RateWindow::with_details(opus_used, Some(10080), None, None);
             usage = usage.with_model_specific(model_specific);
         }
 

--- a/rust/src/providers/claude/oauth.rs
+++ b/rust/src/providers/claude/oauth.rs
@@ -7,7 +7,7 @@ use reqwest::Client;
 use serde::Deserialize;
 use std::path::PathBuf;
 
-use crate::core::{ProviderError, RateWindow, UsageSnapshot, ProviderFetchResult};
+use crate::core::{ProviderError, ProviderFetchResult, RateWindow, UsageSnapshot};
 
 /// OAuth credentials from Claude CLI
 #[derive(Debug, Clone)]
@@ -173,13 +173,11 @@ impl ClaudeOAuthFetcher {
             ));
         }
 
-        let content = std::fs::read_to_string(&path).map_err(|e| {
-            ProviderError::OAuth(format!("Failed to read credentials file: {}", e))
-        })?;
+        let content = std::fs::read_to_string(&path)
+            .map_err(|e| ProviderError::OAuth(format!("Failed to read credentials file: {}", e)))?;
 
-        let file: CredentialsFile = serde_json::from_str(&content).map_err(|e| {
-            ProviderError::OAuth(format!("Invalid credentials format: {}", e))
-        })?;
+        let file: CredentialsFile = serde_json::from_str(&content)
+            .map_err(|e| ProviderError::OAuth(format!("Invalid credentials format: {}", e)))?;
 
         let oauth = file.claude_ai_oauth.ok_or_else(|| {
             ProviderError::OAuth(
@@ -244,7 +242,10 @@ impl ClaudeOAuthFetcher {
         let response = self
             .client
             .get(Self::USAGE_URL)
-            .header("Authorization", format!("Bearer {}", credentials.access_token))
+            .header(
+                "Authorization",
+                format!("Bearer {}", credentials.access_token),
+            )
             .timeout(std::time::Duration::from_secs(10))
             .send()
             .await?;
@@ -272,9 +273,10 @@ impl ClaudeOAuthFetcher {
             )));
         }
 
-        let usage: OAuthUsageResponse = response.json().await.map_err(|e| {
-            ProviderError::Parse(format!("Failed to parse OAuth response: {}", e))
-        })?;
+        let usage: OAuthUsageResponse = response
+            .json()
+            .await
+            .map_err(|e| ProviderError::Parse(format!("Failed to parse OAuth response: {}", e)))?;
 
         Ok(usage)
     }
@@ -295,14 +297,26 @@ impl ClaudeOAuthFetcher {
         let mut usage = UsageSnapshot::new(primary);
 
         // Secondary: 7-day window
-        if let Some(weekly) = response.seven_day.as_ref().and_then(|w| Self::to_rate_window(w, Some(10080))) {
+        if let Some(weekly) = response
+            .seven_day
+            .as_ref()
+            .and_then(|w| Self::to_rate_window(w, Some(10080)))
+        {
             usage = usage.with_secondary(weekly);
         }
 
         // Model-specific: Opus or Sonnet
-        if let Some(opus) = response.seven_day_opus.as_ref().and_then(|w| Self::to_rate_window(w, Some(10080))) {
+        if let Some(opus) = response
+            .seven_day_opus
+            .as_ref()
+            .and_then(|w| Self::to_rate_window(w, Some(10080)))
+        {
             usage = usage.with_model_specific(opus);
-        } else if let Some(sonnet) = response.seven_day_sonnet.as_ref().and_then(|w| Self::to_rate_window(w, Some(10080))) {
+        } else if let Some(sonnet) = response
+            .seven_day_sonnet
+            .as_ref()
+            .and_then(|w| Self::to_rate_window(w, Some(10080)))
+        {
             usage = usage.with_model_specific(sonnet);
         }
 

--- a/rust/src/providers/claude/web_api.rs
+++ b/rust/src/providers/claude/web_api.rs
@@ -1,13 +1,11 @@
 //! Claude Web API fetcher - uses browser cookies to fetch usage from claude.ai
 
 use chrono::{DateTime, Utc};
-use reqwest::{Client, header};
+use reqwest::{header, Client};
 use serde::Deserialize;
 
 use crate::browser::cookies::get_cookie_header;
-use crate::core::{
-    CostSnapshot, ProviderError, ProviderFetchResult, RateWindow, UsageSnapshot,
-};
+use crate::core::{CostSnapshot, ProviderError, ProviderFetchResult, RateWindow, UsageSnapshot};
 
 /// Claude Web API fetcher
 pub struct ClaudeWebApiFetcher {
@@ -88,7 +86,12 @@ impl ClaudeWebApiFetcher {
     pub async fn fetch_with_cookies(&self) -> Result<ProviderFetchResult, ProviderError> {
         // Try multiple domains - Claude uses different domains for different services
         // console.anthropic.com has the sessionKey for API access
-        let domains = ["claude.ai", "claude.com", "console.anthropic.com", "anthropic.com"];
+        let domains = [
+            "claude.ai",
+            "claude.com",
+            "console.anthropic.com",
+            "anthropic.com",
+        ];
 
         for domain in domains {
             match get_cookie_header(domain) {
@@ -209,9 +212,10 @@ impl ClaudeWebApiFetcher {
             )));
         }
 
-        let orgs: Vec<Organization> = response.json().await.map_err(|e| {
-            ProviderError::Parse(format!("Failed to parse organizations: {}", e))
-        })?;
+        let orgs: Vec<Organization> = response
+            .json()
+            .await
+            .map_err(|e| ProviderError::Parse(format!("Failed to parse organizations: {}", e)))?;
 
         orgs.into_iter()
             .next()
@@ -242,9 +246,10 @@ impl ClaudeWebApiFetcher {
             )));
         }
 
-        response.json().await.map_err(|e| {
-            ProviderError::Parse(format!("Failed to parse usage: {}", e))
-        })
+        response
+            .json()
+            .await
+            .map_err(|e| ProviderError::Parse(format!("Failed to parse usage: {}", e)))
     }
 
     /// Get extra usage (credits)
@@ -255,7 +260,8 @@ impl ClaudeWebApiFetcher {
     ) -> Result<ExtraUsageResponse, ProviderError> {
         let url = format!(
             "{}/organizations/{}/overage_spend_limit",
-            Self::BASE_URL, org_id
+            Self::BASE_URL,
+            org_id
         );
 
         let response = self
@@ -273,13 +279,17 @@ impl ClaudeWebApiFetcher {
             )));
         }
 
-        response.json().await.map_err(|e| {
-            ProviderError::Parse(format!("Failed to parse extra usage: {}", e))
-        })
+        response
+            .json()
+            .await
+            .map_err(|e| ProviderError::Parse(format!("Failed to parse extra usage: {}", e)))
     }
 
     /// Get account info
-    async fn get_account_info(&self, cookie_header: &str) -> Result<AccountResponse, ProviderError> {
+    async fn get_account_info(
+        &self,
+        cookie_header: &str,
+    ) -> Result<AccountResponse, ProviderError> {
         let url = format!("{}/account", Self::BASE_URL);
 
         let response = self
@@ -297,9 +307,10 @@ impl ClaudeWebApiFetcher {
             )));
         }
 
-        response.json().await.map_err(|e| {
-            ProviderError::Parse(format!("Failed to parse account: {}", e))
-        })
+        response
+            .json()
+            .await
+            .map_err(|e| ProviderError::Parse(format!("Failed to parse account: {}", e)))
     }
 
     /// Convert a usage window to a RateWindow

--- a/rust/src/providers/codex/api.rs
+++ b/rust/src/providers/codex/api.rs
@@ -33,7 +33,9 @@ impl CodexApi {
 
     /// Fetch usage information from Codex API
     /// Returns (UsageSnapshot, optional CostSnapshot)
-    pub async fn fetch_usage(&self) -> Result<(UsageSnapshot, Option<CostSnapshot>), ProviderError> {
+    pub async fn fetch_usage(
+        &self,
+    ) -> Result<(UsageSnapshot, Option<CostSnapshot>), ProviderError> {
         // Load credentials
         let creds = self.load_credentials()?;
 
@@ -42,7 +44,8 @@ impl CodexApi {
         let url = format!("{}{}", base_url, USAGE_PATH);
 
         // Build request
-        let mut request = self.client
+        let mut request = self
+            .client
             .get(&url)
             .header("Authorization", format!("Bearer {}", creds.access_token))
             .header("User-Agent", "CodexBar")
@@ -86,8 +89,9 @@ impl CodexApi {
             ));
         }
 
-        let content = std::fs::read_to_string(&auth_path)
-            .map_err(|e| ProviderError::Other(format!("Failed to read Codex credentials: {}", e)))?;
+        let content = std::fs::read_to_string(&auth_path).map_err(|e| {
+            ProviderError::Other(format!("Failed to read Codex credentials: {}", e))
+        })?;
 
         let json: serde_json::Value = serde_json::from_str(&content)
             .map_err(|e| ProviderError::Parse(format!("Invalid Codex credentials JSON: {}", e)))?;
@@ -109,18 +113,23 @@ impl CodexApi {
             ProviderError::Parse("Codex auth.json exists but contains no tokens.".to_string())
         })?;
 
-        let access_token = tokens.get("access_token")
+        let access_token = tokens
+            .get("access_token")
             .and_then(|v| v.as_str())
             .filter(|s| !s.is_empty())
-            .ok_or_else(|| ProviderError::Parse("Missing access_token in Codex credentials".to_string()))?
+            .ok_or_else(|| {
+                ProviderError::Parse("Missing access_token in Codex credentials".to_string())
+            })?
             .to_string();
 
-        let refresh_token = tokens.get("refresh_token")
+        let refresh_token = tokens
+            .get("refresh_token")
             .and_then(|v| v.as_str())
             .filter(|s| !s.is_empty())
             .map(|s| s.to_string());
 
-        let account_id = tokens.get("account_id")
+        let account_id = tokens
+            .get("account_id")
             .and_then(|v| v.as_str())
             .filter(|s| !s.is_empty())
             .map(|s| s.to_string());
@@ -161,19 +170,29 @@ impl CodexApi {
             if let Some(base_url) = parse_chatgpt_base_url(&content) {
                 let normalized = normalize_base_url(&base_url);
                 // Only allow HTTPS URLs for custom base URLs to prevent token exfiltration
-                if normalized.starts_with("https://") || normalized.starts_with("http://127.0.0.1") || normalized.starts_with("http://localhost") {
+                if normalized.starts_with("https://")
+                    || normalized.starts_with("http://127.0.0.1")
+                    || normalized.starts_with("http://localhost")
+                {
                     return normalized;
                 }
-                tracing::warn!("Ignoring insecure custom chatgpt_base_url (must be HTTPS): {}", normalized);
+                tracing::warn!(
+                    "Ignoring insecure custom chatgpt_base_url (must be HTTPS): {}",
+                    normalized
+                );
             }
         }
 
         DEFAULT_BASE_URL.to_string()
     }
 
-    fn build_result_from_json(&self, json: &serde_json::Value) -> Result<(UsageSnapshot, Option<CostSnapshot>), ProviderError> {
+    fn build_result_from_json(
+        &self,
+        json: &serde_json::Value,
+    ) -> Result<(UsageSnapshot, Option<CostSnapshot>), ProviderError> {
         // Extract plan type
-        let plan_type = json.get("plan_type")
+        let plan_type = json
+            .get("plan_type")
             .and_then(|v| v.as_str())
             .map(|s| s.to_string());
 
@@ -181,19 +200,17 @@ impl CodexApi {
         let (primary, secondary) = self.extract_rate_limits(json);
 
         // Build login method string
-        let login_method = plan_type.as_ref().map(|pt| {
-            match pt.as_str() {
-                "guest" => "Guest".to_string(),
-                "free" => "ChatGPT Free".to_string(),
-                "go" => "ChatGPT Go".to_string(),
-                "plus" => "ChatGPT Plus".to_string(),
-                "pro" => "ChatGPT Pro".to_string(),
-                "team" => "ChatGPT Team".to_string(),
-                "business" => "ChatGPT Business".to_string(),
-                "enterprise" => "ChatGPT Enterprise".to_string(),
-                "education" | "edu" => "ChatGPT Education".to_string(),
-                other => format!("ChatGPT {}", capitalize(other)),
-            }
+        let login_method = plan_type.as_ref().map(|pt| match pt.as_str() {
+            "guest" => "Guest".to_string(),
+            "free" => "ChatGPT Free".to_string(),
+            "go" => "ChatGPT Go".to_string(),
+            "plus" => "ChatGPT Plus".to_string(),
+            "pro" => "ChatGPT Pro".to_string(),
+            "team" => "ChatGPT Team".to_string(),
+            "business" => "ChatGPT Business".to_string(),
+            "enterprise" => "ChatGPT Enterprise".to_string(),
+            "education" | "edu" => "ChatGPT Education".to_string(),
+            other => format!("ChatGPT {}", capitalize(other)),
         });
 
         let mut usage = UsageSnapshot::new(primary);
@@ -213,11 +230,13 @@ impl CodexApi {
     fn extract_rate_limits(&self, json: &serde_json::Value) -> (RateWindow, Option<RateWindow>) {
         // Try rate_limit object
         if let Some(rate_limit) = json.get("rate_limit") {
-            let primary = rate_limit.get("primary_window")
+            let primary = rate_limit
+                .get("primary_window")
                 .map(|w| self.parse_window(w))
                 .unwrap_or_else(|| RateWindow::new(0.0));
 
-            let secondary = rate_limit.get("secondary_window")
+            let secondary = rate_limit
+                .get("secondary_window")
                 .map(|w| self.parse_window(w));
 
             return (primary, secondary);
@@ -233,7 +252,8 @@ impl CodexApi {
         }
 
         // Try direct fields
-        let used_percent = json.get("used_percent")
+        let used_percent = json
+            .get("used_percent")
             .or_else(|| json.get("usage_percent"))
             .and_then(|v| v.as_f64())
             .unwrap_or(0.0);
@@ -242,17 +262,25 @@ impl CodexApi {
     }
 
     fn parse_window(&self, window: &serde_json::Value) -> RateWindow {
-        let used_percent = window.get("used_percent")
+        let used_percent = window
+            .get("used_percent")
             .or_else(|| window.get("usage_percent"))
             .and_then(|v| v.as_f64())
-            .or_else(|| window.get("used_percent").and_then(|v| v.as_i64()).map(|i| i as f64))
+            .or_else(|| {
+                window
+                    .get("used_percent")
+                    .and_then(|v| v.as_i64())
+                    .map(|i| i as f64)
+            })
             .unwrap_or(0.0);
 
-        let window_minutes = window.get("limit_window_seconds")
+        let window_minutes = window
+            .get("limit_window_seconds")
             .and_then(|v| v.as_i64())
             .map(|s| (s / 60) as u32);
 
-        let reset_at = window.get("reset_at")
+        let reset_at = window
+            .get("reset_at")
             .and_then(|v| v.as_i64())
             .and_then(|ts| Utc.timestamp_opt(ts, 0).single());
 
@@ -262,7 +290,8 @@ impl CodexApi {
     fn extract_credits(&self, json: &serde_json::Value) -> Option<CostSnapshot> {
         let credits = json.get("credits")?;
 
-        let has_credits = credits.get("has_credits")
+        let has_credits = credits
+            .get("has_credits")
             .and_then(|v| v.as_bool())
             .unwrap_or(false);
 
@@ -270,7 +299,8 @@ impl CodexApi {
             return None;
         }
 
-        let unlimited = credits.get("unlimited")
+        let unlimited = credits
+            .get("unlimited")
             .and_then(|v| v.as_bool())
             .unwrap_or(false);
 
@@ -278,14 +308,18 @@ impl CodexApi {
             return None;
         }
 
-        let balance = credits.get("balance")
+        let balance = credits
+            .get("balance")
             .and_then(|v| v.as_f64())
             .unwrap_or(0.0);
 
         Some(CostSnapshot::new(balance, "USD", "Credits"))
     }
 
-    fn build_result(&self, response: UsageResponse) -> Result<(UsageSnapshot, Option<CostSnapshot>), ProviderError> {
+    fn build_result(
+        &self,
+        response: UsageResponse,
+    ) -> Result<(UsageSnapshot, Option<CostSnapshot>), ProviderError> {
         // Extract primary rate window
         let primary = if let Some(ref rate_limit) = response.rate_limit {
             if let Some(ref primary_window) = rate_limit.primary_window {
@@ -303,7 +337,9 @@ impl CodexApi {
         };
 
         // Extract secondary rate window
-        let secondary = response.rate_limit.as_ref()
+        let secondary = response
+            .rate_limit
+            .as_ref()
             .and_then(|rl| rl.secondary_window.as_ref())
             .map(|window| {
                 RateWindow::with_details(
@@ -315,19 +351,17 @@ impl CodexApi {
             });
 
         // Build usage snapshot
-        let login_method = response.plan_type.as_ref().map(|pt| {
-            match pt.as_str() {
-                "guest" => "Guest".to_string(),
-                "free" => "ChatGPT Free".to_string(),
-                "go" => "ChatGPT Go".to_string(),
-                "plus" => "ChatGPT Plus".to_string(),
-                "pro" => "ChatGPT Pro".to_string(),
-                "team" => "ChatGPT Team".to_string(),
-                "business" => "ChatGPT Business".to_string(),
-                "enterprise" => "ChatGPT Enterprise".to_string(),
-                "education" | "edu" => "ChatGPT Education".to_string(),
-                other => format!("ChatGPT {}", capitalize(other)),
-            }
+        let login_method = response.plan_type.as_ref().map(|pt| match pt.as_str() {
+            "guest" => "Guest".to_string(),
+            "free" => "ChatGPT Free".to_string(),
+            "go" => "ChatGPT Go".to_string(),
+            "plus" => "ChatGPT Plus".to_string(),
+            "pro" => "ChatGPT Pro".to_string(),
+            "team" => "ChatGPT Team".to_string(),
+            "business" => "ChatGPT Business".to_string(),
+            "enterprise" => "ChatGPT Enterprise".to_string(),
+            "education" | "edu" => "ChatGPT Education".to_string(),
+            other => format!("ChatGPT {}", capitalize(other)),
         });
 
         let mut usage = UsageSnapshot::new(primary);
@@ -428,9 +462,10 @@ fn parse_chatgpt_base_url(config_content: &str) -> Option<String> {
             if key == "chatgpt_base_url" {
                 let mut value = value.trim();
                 // Remove quotes
-                if (value.starts_with('"') && value.ends_with('"')) ||
-                   (value.starts_with('\'') && value.ends_with('\'')) {
-                    value = &value[1..value.len()-1];
+                if (value.starts_with('"') && value.ends_with('"'))
+                    || (value.starts_with('\'') && value.ends_with('\''))
+                {
+                    value = &value[1..value.len() - 1];
                 }
                 return Some(value.trim().to_string());
             }
@@ -451,7 +486,8 @@ fn normalize_base_url(url: &str) -> String {
     }
 
     // Add /backend-api if needed
-    if (trimmed.starts_with("https://chatgpt.com") || trimmed.starts_with("https://chat.openai.com"))
+    if (trimmed.starts_with("https://chatgpt.com")
+        || trimmed.starts_with("https://chat.openai.com"))
         && !trimmed.contains("/backend-api")
     {
         trimmed.push_str("/backend-api");

--- a/rust/src/providers/codex/mod.rs
+++ b/rust/src/providers/codex/mod.rs
@@ -8,8 +8,8 @@ mod api;
 use async_trait::async_trait;
 
 use crate::core::{
-    FetchContext, Provider, ProviderId, ProviderError, ProviderFetchResult,
-    ProviderMetadata, SourceMode,
+    FetchContext, Provider, ProviderError, ProviderFetchResult, ProviderId, ProviderMetadata,
+    SourceMode,
 };
 
 pub use api::CodexApi;

--- a/rust/src/providers/copilot/api.rs
+++ b/rust/src/providers/copilot/api.rs
@@ -10,9 +10,9 @@ const API_URL: &str = "https://api.github.com/copilot_internal/user";
 
 // Credential Manager targets to try
 const CREDENTIAL_TARGETS: &[&str] = &[
-    "codexbar-copilot",          // Our own storage
-    "git:https://github.com",    // GitHub CLI / Git Credential Manager
-    "github.com",                // Alternative format
+    "codexbar-copilot",       // Our own storage
+    "git:https://github.com", // GitHub CLI / Git Credential Manager
+    "github.com",             // Alternative format
 ];
 
 /// Copilot API client
@@ -38,7 +38,8 @@ impl CopilotApi {
         let token = self.load_token(api_key)?;
 
         // Build request with required headers
-        let response = self.client
+        let response = self
+            .client
             .get(API_URL)
             .header("Authorization", format!("token {}", token))
             .header("Accept", "application/json")
@@ -111,7 +112,7 @@ impl CopilotApi {
         use std::os::windows::ffi::OsStrExt;
         use windows::core::PCWSTR;
         use windows::Win32::Security::Credentials::{
-            CredReadW, CredFree, CREDENTIALW, CRED_TYPE_GENERIC,
+            CredFree, CredReadW, CREDENTIALW, CRED_TYPE_GENERIC,
         };
 
         let target_wide: Vec<u16> = OsStr::new(target)
@@ -122,7 +123,12 @@ impl CopilotApi {
         let mut credential: *mut CREDENTIALW = std::ptr::null_mut();
 
         let result = unsafe {
-            CredReadW(PCWSTR(target_wide.as_ptr()), CRED_TYPE_GENERIC, 0, &mut credential)
+            CredReadW(
+                PCWSTR(target_wide.as_ptr()),
+                CRED_TYPE_GENERIC,
+                0,
+                &mut credential,
+            )
         };
 
         if result.is_err() {
@@ -136,10 +142,8 @@ impl CopilotApi {
                 return None;
             }
 
-            let blob = std::slice::from_raw_parts(
-                cred.CredentialBlob,
-                cred.CredentialBlobSize as usize,
-            );
+            let blob =
+                std::slice::from_raw_parts(cred.CredentialBlob, cred.CredentialBlobSize as usize);
 
             let token = String::from_utf8_lossy(blob).to_string();
             let _ = CredFree(credential as *mut std::ffi::c_void);
@@ -159,9 +163,14 @@ impl CopilotApi {
         None
     }
 
-    fn build_snapshot(&self, response: CopilotUsageResponse) -> Result<UsageSnapshot, ProviderError> {
+    fn build_snapshot(
+        &self,
+        response: CopilotUsageResponse,
+    ) -> Result<UsageSnapshot, ProviderError> {
         // Build primary rate window from premium_interactions
-        let primary = response.quota_snapshots.premium_interactions
+        let primary = response
+            .quota_snapshots
+            .premium_interactions
             .as_ref()
             .map(|snapshot| {
                 let used_percent = (100.0 - snapshot.percent_remaining).max(0.0);
@@ -175,17 +184,15 @@ impl CopilotApi {
             .unwrap_or_else(|| RateWindow::new(0.0));
 
         // Build secondary rate window from chat
-        let secondary = response.quota_snapshots.chat
-            .as_ref()
-            .map(|snapshot| {
-                let used_percent = (100.0 - snapshot.percent_remaining).max(0.0);
-                RateWindow::with_details(
-                    used_percent,
-                    None,
-                    parse_iso_date(&response.quota_reset_date),
-                    None,
-                )
-            });
+        let secondary = response.quota_snapshots.chat.as_ref().map(|snapshot| {
+            let used_percent = (100.0 - snapshot.percent_remaining).max(0.0);
+            RateWindow::with_details(
+                used_percent,
+                None,
+                parse_iso_date(&response.quota_reset_date),
+                None,
+            )
+        });
 
         // Format plan type
         let plan_type = format!("Copilot {}", capitalize(&response.copilot_plan));

--- a/rust/src/providers/copilot/mod.rs
+++ b/rust/src/providers/copilot/mod.rs
@@ -8,8 +8,8 @@ pub mod device_flow;
 use async_trait::async_trait;
 
 use crate::core::{
-    FetchContext, Provider, ProviderId, ProviderError, ProviderFetchResult,
-    ProviderMetadata, SourceMode,
+    FetchContext, Provider, ProviderError, ProviderFetchResult, ProviderId, ProviderMetadata,
+    SourceMode,
 };
 
 pub use api::CopilotApi;

--- a/rust/src/providers/cursor/api.rs
+++ b/rust/src/providers/cursor/api.rs
@@ -24,7 +24,17 @@ impl CursorApi {
 
     /// Fetch usage information from Cursor API
     /// Returns (primary RateWindow, optional CostSnapshot, optional email, optional plan_type)
-    pub async fn fetch_usage(&self) -> Result<(RateWindow, Option<CostSnapshot>, Option<String>, Option<String>), ProviderError> {
+    pub async fn fetch_usage(
+        &self,
+    ) -> Result<
+        (
+            RateWindow,
+            Option<CostSnapshot>,
+            Option<String>,
+            Option<String>,
+        ),
+        ProviderError,
+    > {
         // Try to get cookies from browser
         let cookie_header = self.get_cookie_header()?;
 
@@ -104,7 +114,9 @@ impl CursorApi {
             .await?;
 
         if !response.status().is_success() {
-            return Err(ProviderError::Other("Failed to fetch user info".to_string()));
+            return Err(ProviderError::Other(
+                "Failed to fetch user info".to_string(),
+            ));
         }
 
         response
@@ -117,9 +129,20 @@ impl CursorApi {
         &self,
         summary: UsageSummary,
         user_info: Option<UserInfo>,
-    ) -> Result<(RateWindow, Option<CostSnapshot>, Option<String>, Option<String>), ProviderError> {
+    ) -> Result<
+        (
+            RateWindow,
+            Option<CostSnapshot>,
+            Option<String>,
+            Option<String>,
+        ),
+        ProviderError,
+    > {
         // Parse billing cycle end date
-        let billing_end = summary.billing_cycle_end.as_ref().and_then(|s| parse_iso_date(s));
+        let billing_end = summary
+            .billing_cycle_end
+            .as_ref()
+            .and_then(|s| parse_iso_date(s));
 
         // Extract plan usage for primary rate window
         let (percent_used, cost_snapshot) = if let Some(individual) = &summary.individual_usage {
@@ -160,15 +183,16 @@ impl CursorApi {
         );
 
         // Format plan type
-        let plan_type = summary.membership_type.as_ref().map(|t| {
-            match t.to_lowercase().as_str() {
+        let plan_type = summary
+            .membership_type
+            .as_ref()
+            .map(|t| match t.to_lowercase().as_str() {
                 "enterprise" => "Cursor Enterprise".to_string(),
                 "pro" => "Cursor Pro".to_string(),
                 "hobby" => "Cursor Hobby".to_string(),
                 "team" => "Cursor Team".to_string(),
                 other => format!("Cursor {}", capitalize(other)),
-            }
-        });
+            });
 
         let email = user_info.as_ref().and_then(|u| u.email.clone());
 

--- a/rust/src/providers/cursor/mod.rs
+++ b/rust/src/providers/cursor/mod.rs
@@ -7,8 +7,8 @@ mod api;
 use async_trait::async_trait;
 
 use crate::core::{
-    FetchContext, Provider, ProviderId, ProviderError, ProviderFetchResult,
-    ProviderMetadata, SourceMode, UsageSnapshot,
+    FetchContext, Provider, ProviderError, ProviderFetchResult, ProviderId, ProviderMetadata,
+    SourceMode, UsageSnapshot,
 };
 
 pub use api::CursorApi;

--- a/rust/src/providers/factory/mod.rs
+++ b/rust/src/providers/factory/mod.rs
@@ -9,8 +9,8 @@ use serde::Deserialize;
 use crate::browser::cookies::CookieExtractor;
 use crate::browser::detection::BrowserDetector;
 use crate::core::{
-    FetchContext, Provider, ProviderId, ProviderError, ProviderFetchResult,
-    ProviderMetadata, RateWindow, SourceMode, UsageSnapshot,
+    FetchContext, Provider, ProviderError, ProviderFetchResult, ProviderId, ProviderMetadata,
+    RateWindow, SourceMode, UsageSnapshot,
 };
 
 /// Factory.ai API endpoints
@@ -88,7 +88,8 @@ impl FactoryProvider {
             if let Ok(cookies) = CookieExtractor::extract_for_domain(browser, "app.factory.ai") {
                 if !cookies.is_empty() {
                     // Convert to cookie header string
-                    let cookie_str = cookies.iter()
+                    let cookie_str = cookies
+                        .iter()
                         .map(|c| c.to_header_value())
                         .collect::<Vec<_>>()
                         .join("; ");
@@ -125,7 +126,8 @@ impl FactoryProvider {
             )));
         }
 
-        resp.json().await
+        resp.json()
+            .await
             .map_err(|e| ProviderError::Parse(e.to_string()))
     }
 
@@ -154,7 +156,8 @@ impl FactoryProvider {
             )));
         }
 
-        resp.json().await
+        resp.json()
+            .await
             .map_err(|e| ProviderError::Parse(e.to_string()))
     }
 

--- a/rust/src/providers/gemini/api.rs
+++ b/rust/src/providers/gemini/api.rs
@@ -27,7 +27,10 @@ impl GeminiApi {
     /// Fetch quota information from the Gemini API
     /// Returns (primary RateWindow, optional model-specific RateWindow, optional email)
     /// Note: Gemini quota API requires OAuth tokens, not API keys
-    pub async fn fetch_quota(&self, _ctx: &FetchContext) -> Result<(RateWindow, Option<RateWindow>, Option<String>), ProviderError> {
+    pub async fn fetch_quota(
+        &self,
+        _ctx: &FetchContext,
+    ) -> Result<(RateWindow, Option<RateWindow>, Option<String>), ProviderError> {
         // Gemini quota endpoint requires OAuth credentials (not API keys)
         // Always load OAuth credentials from ~/.gemini/oauth_creds.json
         let mut creds = self.load_credentials()?;
@@ -38,11 +41,14 @@ impl GeminiApi {
             creds = self.refresh_token(&creds).await?;
         }
 
-        let access_token = creds.access_token.clone()
+        let access_token = creds
+            .access_token
+            .clone()
             .ok_or_else(|| ProviderError::AuthRequired)?;
 
         // Fetch quota
-        let response = self.client
+        let response = self
+            .client
             .post(QUOTA_ENDPOINT)
             .header("Authorization", format!("Bearer {}", access_token))
             .header("Content-Type", "application/json")
@@ -80,15 +86,21 @@ impl GeminiApi {
             ));
         }
 
-        let content = std::fs::read_to_string(&creds_path)
-            .map_err(|e| ProviderError::Other(format!("Failed to read Gemini credentials: {}", e)))?;
+        let content = std::fs::read_to_string(&creds_path).map_err(|e| {
+            ProviderError::Other(format!("Failed to read Gemini credentials: {}", e))
+        })?;
 
         serde_json::from_str(&content)
             .map_err(|e| ProviderError::Parse(format!("Invalid Gemini credentials: {}", e)))
     }
 
-    async fn refresh_token(&self, creds: &OAuthCredentials) -> Result<OAuthCredentials, ProviderError> {
-        let refresh_token = creds.refresh_token.as_ref()
+    async fn refresh_token(
+        &self,
+        creds: &OAuthCredentials,
+    ) -> Result<OAuthCredentials, ProviderError> {
+        let refresh_token = creds
+            .refresh_token
+            .as_ref()
             .ok_or_else(|| ProviderError::AuthRequired)?;
 
         // Get OAuth client credentials from Gemini CLI
@@ -101,7 +113,8 @@ impl GeminiApi {
             ("grant_type", "refresh_token"),
         ];
 
-        let response = self.client
+        let response = self
+            .client
             .post(TOKEN_REFRESH_ENDPOINT)
             .form(&params)
             .timeout(std::time::Duration::from_secs(10))
@@ -137,8 +150,8 @@ impl GeminiApi {
 
     fn save_credentials(&self, creds: &OAuthCredentials) -> Result<(), ProviderError> {
         let creds_path = self.home_dir.join(".gemini").join("oauth_creds.json");
-        let content = serde_json::to_string_pretty(creds)
-            .map_err(|e| ProviderError::Parse(e.to_string()))?;
+        let content =
+            serde_json::to_string_pretty(creds).map_err(|e| ProviderError::Parse(e.to_string()))?;
         std::fs::write(&creds_path, content)
             .map_err(|e| ProviderError::Other(format!("Failed to save credentials: {}", e)))?;
         Ok(())
@@ -184,9 +197,9 @@ impl GeminiApi {
         response: QuotaResponse,
         creds: Option<&OAuthCredentials>,
     ) -> Result<(RateWindow, Option<RateWindow>, Option<String>), ProviderError> {
-        let buckets = response.buckets.ok_or_else(|| {
-            ProviderError::Parse("No quota buckets in response".to_string())
-        })?;
+        let buckets = response
+            .buckets
+            .ok_or_else(|| ProviderError::Parse("No quota buckets in response".to_string()))?;
 
         if buckets.is_empty() {
             return Err(ProviderError::Parse("Empty quota buckets".to_string()));
@@ -206,13 +219,23 @@ impl GeminiApi {
         }
 
         // Find Flash and Pro quotas
-        let flash_quota = model_quotas.iter()
+        let flash_quota = model_quotas
+            .iter()
             .filter(|(k, _)| k.to_lowercase().contains("flash"))
-            .min_by(|a, b| a.1.0.partial_cmp(&b.1.0).unwrap_or(std::cmp::Ordering::Equal));
+            .min_by(|a, b| {
+                a.1 .0
+                    .partial_cmp(&b.1 .0)
+                    .unwrap_or(std::cmp::Ordering::Equal)
+            });
 
-        let pro_quota = model_quotas.iter()
+        let pro_quota = model_quotas
+            .iter()
             .filter(|(k, _)| k.to_lowercase().contains("pro"))
-            .min_by(|a, b| a.1.0.partial_cmp(&b.1.0).unwrap_or(std::cmp::Ordering::Equal));
+            .min_by(|a, b| {
+                a.1 .0
+                    .partial_cmp(&b.1 .0)
+                    .unwrap_or(std::cmp::Ordering::Equal)
+            });
 
         // Build primary RateWindow from the most constrained quota
         let (primary_fraction, primary_reset) = if let Some((_, (frac, reset))) = pro_quota {
@@ -341,11 +364,11 @@ fn extract_email_from_jwt(token: &str) -> Option<String> {
         payload.push_str(&"=".repeat(4 - remainder));
     }
 
-    let decoded = base64::Engine::decode(
-        &base64::engine::general_purpose::STANDARD,
-        &payload,
-    ).ok()?;
+    let decoded =
+        base64::Engine::decode(&base64::engine::general_purpose::STANDARD, &payload).ok()?;
 
     let json: serde_json::Value = serde_json::from_slice(&decoded).ok()?;
-    json.get("email").and_then(|v| v.as_str()).map(|s| s.to_string())
+    json.get("email")
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string())
 }

--- a/rust/src/providers/gemini/mod.rs
+++ b/rust/src/providers/gemini/mod.rs
@@ -8,8 +8,8 @@ mod api;
 use async_trait::async_trait;
 
 use crate::core::{
-    FetchContext, Provider, ProviderId, ProviderError, ProviderFetchResult,
-    ProviderMetadata, SourceMode, UsageSnapshot,
+    FetchContext, Provider, ProviderError, ProviderFetchResult, ProviderId, ProviderMetadata,
+    SourceMode, UsageSnapshot,
 };
 
 pub use api::GeminiApi;

--- a/rust/src/providers/jetbrains/mod.rs
+++ b/rust/src/providers/jetbrains/mod.rs
@@ -9,8 +9,8 @@ use async_trait::async_trait;
 use std::path::PathBuf;
 
 use crate::core::{
-    FetchContext, Provider, ProviderId, ProviderError, ProviderFetchResult,
-    ProviderMetadata, RateWindow, SourceMode, UsageSnapshot,
+    FetchContext, Provider, ProviderError, ProviderFetchResult, ProviderId, ProviderMetadata,
+    RateWindow, SourceMode, UsageSnapshot,
 };
 
 /// JetBrains AI provider
@@ -87,7 +87,9 @@ impl JetBrainsProvider {
                 config_dir.join("options").join("ai-assistant.xml"),
                 config_dir.join("options").join("aiAssistant.xml"),
                 config_dir.join("options").join("ai.xml"),
-                config_dir.join("options").join("AIAssistantQuotaManager2.xml"),
+                config_dir
+                    .join("options")
+                    .join("AIAssistantQuotaManager2.xml"),
             ];
 
             for path in possible_paths {
@@ -104,11 +106,13 @@ impl JetBrainsProvider {
     async fn read_local_config(&self) -> Result<UsageSnapshot, ProviderError> {
         let config_file = Self::find_ai_config_file().ok_or_else(|| {
             ProviderError::NotInstalled(
-                "JetBrains AI Assistant not found. Install from JetBrains IDE Marketplace.".to_string()
+                "JetBrains AI Assistant not found. Install from JetBrains IDE Marketplace."
+                    .to_string(),
             )
         })?;
 
-        let content = tokio::fs::read_to_string(&config_file).await
+        let content = tokio::fs::read_to_string(&config_file)
+            .await
             .map_err(|e| ProviderError::Other(format!("Failed to read config: {}", e)))?;
 
         self.parse_xml_config(&content)
@@ -130,13 +134,20 @@ impl JetBrainsProvider {
         for line in content.lines() {
             let line = line.trim();
 
-            if line.contains("usedCredits") || line.contains("used_credits") || line.contains("creditsUsed") {
+            if line.contains("usedCredits")
+                || line.contains("used_credits")
+                || line.contains("creditsUsed")
+            {
                 if let Some(value) = Self::extract_xml_value(line) {
                     used_credits = value;
                 }
             }
 
-            if line.contains("creditLimit") || line.contains("credit_limit") || line.contains("creditsLimit") || line.contains("monthlyLimit") {
+            if line.contains("creditLimit")
+                || line.contains("credit_limit")
+                || line.contains("creditsLimit")
+                || line.contains("monthlyLimit")
+            {
                 if let Some(value) = Self::extract_xml_value(line) {
                     credit_limit = value;
                 }
@@ -149,8 +160,8 @@ impl JetBrainsProvider {
             0.0
         };
 
-        let usage = UsageSnapshot::new(RateWindow::new(used_percent))
-            .with_login_method("JetBrains AI");
+        let usage =
+            UsageSnapshot::new(RateWindow::new(used_percent)).with_login_method("JetBrains AI");
 
         Ok(usage)
     }

--- a/rust/src/providers/kimi/mod.rs
+++ b/rust/src/providers/kimi/mod.rs
@@ -8,8 +8,8 @@ use async_trait::async_trait;
 
 use crate::browser::cookies::get_cookie_header;
 use crate::core::{
-    FetchContext, Provider, ProviderId, ProviderError, ProviderFetchResult,
-    ProviderMetadata, RateWindow, SourceMode, UsageSnapshot,
+    FetchContext, Provider, ProviderError, ProviderFetchResult, ProviderId, ProviderMetadata,
+    RateWindow, SourceMode, UsageSnapshot,
 };
 
 const KIMI_API_BASE: &str = "https://kimi.moonshot.cn";
@@ -88,7 +88,10 @@ impl KimiProvider {
             .header("Authorization", format!("Bearer {}", token))
             .header("Cookie", format!("kimi-auth={}", token))
             .header("Accept", "application/json")
-            .header("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36")
+            .header(
+                "User-Agent",
+                "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36",
+            )
             .send()
             .await?;
 
@@ -100,14 +103,19 @@ impl KimiProvider {
             return Err(ProviderError::Other(format!("API error: {}", status)));
         }
 
-        let json: serde_json::Value = resp.json().await
+        let json: serde_json::Value = resp
+            .json()
+            .await
             .map_err(|e| ProviderError::Parse(e.to_string()))?;
 
         self.parse_usage_response(&json)
     }
 
     /// Parse Kimi usage response
-    fn parse_usage_response(&self, json: &serde_json::Value) -> Result<UsageSnapshot, ProviderError> {
+    fn parse_usage_response(
+        &self,
+        json: &serde_json::Value,
+    ) -> Result<UsageSnapshot, ProviderError> {
         // Extract quota information
         // Kimi typically has: daily/weekly limits and 5-hour rate limits
 
@@ -120,7 +128,10 @@ impl KimiProvider {
             .unwrap_or(0.0);
 
         let five_hour_limit = quota
-            .and_then(|q| q.get("rate_limit_total").or_else(|| q.get("five_hour_limit")))
+            .and_then(|q| {
+                q.get("rate_limit_total")
+                    .or_else(|| q.get("five_hour_limit"))
+            })
             .and_then(|v| v.as_f64())
             .unwrap_or(100.0);
 
@@ -148,11 +159,13 @@ impl KimiProvider {
         };
 
         // Get user info
-        let nickname = json.get("nickname")
+        let nickname = json
+            .get("nickname")
             .or_else(|| json.get("name"))
             .and_then(|v| v.as_str());
 
-        let plan = json.get("vip_type")
+        let plan = json
+            .get("vip_type")
             .or_else(|| json.get("plan"))
             .and_then(|v| v.as_str())
             .unwrap_or("Kimi");
@@ -168,8 +181,7 @@ impl KimiProvider {
         rate_limit.resets_at = Some(five_hours_from_now);
         rate_limit.window_minutes = Some(300); // 5 hours = 300 minutes
 
-        let mut usage = UsageSnapshot::new(primary)
-            .with_login_method(plan);
+        let mut usage = UsageSnapshot::new(primary).with_login_method(plan);
 
         // Only add rate limit as secondary if we actually have rate limit data
         if five_hour_limit > 0.0 {
@@ -208,12 +220,8 @@ impl Provider for KimiProvider {
                 let usage = self.fetch_via_web().await?;
                 Ok(ProviderFetchResult::new(usage, "web"))
             }
-            SourceMode::Cli => {
-                Err(ProviderError::UnsupportedSource(SourceMode::Cli))
-            }
-            SourceMode::OAuth => {
-                Err(ProviderError::UnsupportedSource(SourceMode::OAuth))
-            }
+            SourceMode::Cli => Err(ProviderError::UnsupportedSource(SourceMode::Cli)),
+            SourceMode::OAuth => Err(ProviderError::UnsupportedSource(SourceMode::OAuth)),
         }
     }
 

--- a/rust/src/providers/kimik2/mod.rs
+++ b/rust/src/providers/kimik2/mod.rs
@@ -6,8 +6,8 @@
 use async_trait::async_trait;
 
 use crate::core::{
-    FetchContext, Provider, ProviderId, ProviderError, ProviderFetchResult,
-    ProviderMetadata, RateWindow, SourceMode, UsageSnapshot,
+    FetchContext, Provider, ProviderError, ProviderFetchResult, ProviderId, ProviderMetadata,
+    RateWindow, SourceMode, UsageSnapshot,
 };
 
 const KIMIK2_API_BASE: &str = "https://api.moonshot.cn";
@@ -72,7 +72,8 @@ impl KimiK2Provider {
     async fn fetch_via_api(&self) -> Result<UsageSnapshot, ProviderError> {
         let api_key = Self::get_api_key().ok_or_else(|| {
             ProviderError::NotInstalled(
-                "Moonshot API key not found. Set MOONSHOT_API_KEY environment variable.".to_string()
+                "Moonshot API key not found. Set MOONSHOT_API_KEY environment variable."
+                    .to_string(),
             )
         })?;
 
@@ -97,31 +98,39 @@ impl KimiK2Provider {
             return Err(ProviderError::Other(format!("API error: {}", status)));
         }
 
-        let json: serde_json::Value = resp.json().await
+        let json: serde_json::Value = resp
+            .json()
+            .await
             .map_err(|e| ProviderError::Parse(e.to_string()))?;
 
         self.parse_usage_response(&json)
     }
 
     /// Parse Kimi K2 usage response
-    fn parse_usage_response(&self, json: &serde_json::Value) -> Result<UsageSnapshot, ProviderError> {
+    fn parse_usage_response(
+        &self,
+        json: &serde_json::Value,
+    ) -> Result<UsageSnapshot, ProviderError> {
         // Extract balance/credit information
         let data = json.get("data").unwrap_or(json);
 
         // Available balance (credits remaining)
-        let available_balance = data.get("available_balance")
+        let available_balance = data
+            .get("available_balance")
             .or_else(|| data.get("balance"))
             .and_then(|v| v.as_f64())
             .unwrap_or(0.0);
 
         // Total credits (used + available)
-        let total_credits = data.get("total_balance")
+        let total_credits = data
+            .get("total_balance")
             .or_else(|| data.get("total"))
             .and_then(|v| v.as_f64())
             .unwrap_or(100.0);
 
         // Used credits
-        let used_credits = data.get("used_balance")
+        let used_credits = data
+            .get("used_balance")
             .or_else(|| data.get("used"))
             .and_then(|v| v.as_f64())
             .unwrap_or(total_credits - available_balance);
@@ -134,14 +143,12 @@ impl KimiK2Provider {
         };
 
         // Cash balance (if any)
-        let cash_balance = data.get("cash_balance")
-            .and_then(|v| v.as_f64());
+        let cash_balance = data.get("cash_balance").and_then(|v| v.as_f64());
 
         // Create primary rate window (credits used)
         let primary = RateWindow::new(used_percent);
 
-        let mut usage = UsageSnapshot::new(primary)
-            .with_login_method("API Key");
+        let mut usage = UsageSnapshot::new(primary).with_login_method("API Key");
 
         // Add secondary window for cash balance if available
         if let Some(cash) = cash_balance {
@@ -180,9 +187,7 @@ impl Provider for KimiK2Provider {
                 let usage = self.fetch_via_api().await?;
                 Ok(ProviderFetchResult::new(usage, "api"))
             }
-            SourceMode::Cli => {
-                Err(ProviderError::UnsupportedSource(SourceMode::Cli))
-            }
+            SourceMode::Cli => Err(ProviderError::UnsupportedSource(SourceMode::Cli)),
         }
     }
 

--- a/rust/src/providers/kiro/mod.rs
+++ b/rust/src/providers/kiro/mod.rs
@@ -13,16 +13,16 @@ pub use version::{
 
 use async_trait::async_trait;
 use chrono::Datelike;
-use std::path::PathBuf;
-use std::process::Stdio;
-use tokio::process::Command;
 use regex_lite::Regex;
 #[cfg(windows)]
 use std::os::windows::process::CommandExt;
+use std::path::PathBuf;
+use std::process::Stdio;
+use tokio::process::Command;
 
 use crate::core::{
-    FetchContext, Provider, ProviderId, ProviderError, ProviderFetchResult,
-    ProviderMetadata, RateWindow, SourceMode, UsageSnapshot,
+    FetchContext, Provider, ProviderError, ProviderFetchResult, ProviderId, ProviderMetadata,
+    RateWindow, SourceMode, UsageSnapshot,
 };
 
 /// Kiro provider (AWS AI assistant)
@@ -74,7 +74,8 @@ impl KiroProvider {
         #[cfg(target_os = "windows")]
         {
             let possible_paths = [
-                dirs::data_local_dir().map(|p| p.join("Programs").join("Kiro").join("kiro-cli.exe")),
+                dirs::data_local_dir()
+                    .map(|p| p.join("Programs").join("Kiro").join("kiro-cli.exe")),
                 Some(PathBuf::from("C:\\Program Files\\Kiro\\kiro-cli.exe")),
             ];
             for path in possible_paths.into_iter().flatten() {
@@ -90,7 +91,9 @@ impl KiroProvider {
     /// Check if user is logged in by running `kiro-cli whoami`
     async fn ensure_logged_in(&self) -> Result<(), ProviderError> {
         let cli_path = Self::which_kiro().ok_or_else(|| {
-            ProviderError::NotInstalled("kiro-cli not found. Install from https://kiro.dev".to_string())
+            ProviderError::NotInstalled(
+                "kiro-cli not found. Install from https://kiro.dev".to_string(),
+            )
         })?;
 
         #[cfg(windows)]
@@ -103,7 +106,8 @@ impl KiroProvider {
         #[cfg(windows)]
         cmd.creation_flags(CREATE_NO_WINDOW);
 
-        let output = cmd.output()
+        let output = cmd
+            .output()
             .await
             .map_err(|e| ProviderError::Other(format!("Failed to run kiro-cli: {}", e)))?;
 
@@ -130,9 +134,8 @@ impl KiroProvider {
         // First ensure we're logged in
         self.ensure_logged_in().await?;
 
-        let cli_path = Self::which_kiro().ok_or_else(|| {
-            ProviderError::NotInstalled("kiro-cli not found".to_string())
-        })?;
+        let cli_path = Self::which_kiro()
+            .ok_or_else(|| ProviderError::NotInstalled("kiro-cli not found".to_string()))?;
 
         // Run the usage command
         #[cfg(windows)]
@@ -146,13 +149,18 @@ impl KiroProvider {
         #[cfg(windows)]
         cmd.creation_flags(CREATE_NO_WINDOW);
 
-        let output = cmd.output()
+        let output = cmd
+            .output()
             .await
             .map_err(|e| ProviderError::Other(format!("Failed to run kiro-cli: {}", e)))?;
 
         let stdout = String::from_utf8_lossy(&output.stdout);
         let stderr = String::from_utf8_lossy(&output.stderr);
-        let combined = if stdout.trim().is_empty() { &stderr } else { &stdout };
+        let combined = if stdout.trim().is_empty() {
+            &stderr
+        } else {
+            &stdout
+        };
 
         // Check for login errors
         let lowered = combined.to_lowercase();
@@ -174,12 +182,16 @@ impl KiroProvider {
         let trimmed = stripped.trim();
 
         if trimmed.is_empty() {
-            return Err(ProviderError::Parse("Empty output from kiro-cli".to_string()));
+            return Err(ProviderError::Parse(
+                "Empty output from kiro-cli".to_string(),
+            ));
         }
 
         let lowered = stripped.to_lowercase();
         if lowered.contains("could not retrieve usage information") {
-            return Err(ProviderError::Parse("Kiro CLI could not retrieve usage information".to_string()));
+            return Err(ProviderError::Parse(
+                "Kiro CLI could not retrieve usage information".to_string(),
+            ));
         }
 
         // Parse plan name from "| KIRO FREE" or similar (legacy format)
@@ -207,8 +219,8 @@ impl KiroProvider {
         }
 
         // Check if this is a managed plan with no usage data
-        let is_managed_plan = lowered.contains("managed by admin")
-            || lowered.contains("managed by organization");
+        let is_managed_plan =
+            lowered.contains("managed by admin") || lowered.contains("managed by organization");
 
         // Parse reset date from "resets on 01/01"
         let mut reset_date: Option<chrono::DateTime<chrono::Utc>> = None;
@@ -284,8 +296,7 @@ impl KiroProvider {
 
         // Managed plans in new format may omit usage metrics
         if matched_new_format && is_managed_plan && !matched_percent && !matched_credits {
-            let usage = UsageSnapshot::new(RateWindow::new(0.0))
-                .with_login_method(&plan_name);
+            let usage = UsageSnapshot::new(RateWindow::new(0.0)).with_login_method(&plan_name);
             return Ok(usage);
         }
 
@@ -293,13 +304,12 @@ impl KiroProvider {
         if !matched_percent && !matched_credits {
             if matched_new_format || plan_name != "Kiro" {
                 // We got a plan name but no usage data
-                let usage = UsageSnapshot::new(RateWindow::new(0.0))
-                    .with_login_method(&plan_name);
+                let usage = UsageSnapshot::new(RateWindow::new(0.0)).with_login_method(&plan_name);
                 return Ok(usage);
             }
             // If we have the CLI but can't parse, at least report it's installed
-            let usage = UsageSnapshot::new(RateWindow::new(0.0))
-                .with_login_method("Kiro (installed)");
+            let usage =
+                UsageSnapshot::new(RateWindow::new(0.0)).with_login_method("Kiro (installed)");
             return Ok(usage);
         }
 
@@ -310,8 +320,7 @@ impl KiroProvider {
             None,
         );
 
-        let mut usage = UsageSnapshot::new(primary)
-            .with_login_method(&plan_name);
+        let mut usage = UsageSnapshot::new(primary).with_login_method(&plan_name);
 
         if let Some(bonus) = bonus_window {
             usage = usage.with_secondary(bonus);
@@ -331,7 +340,7 @@ impl KiroProvider {
                 // Skip escape sequence
                 if chars.peek() == Some(&'[') {
                     chars.next(); // consume '['
-                    // Skip until we hit a letter
+                                  // Skip until we hit a letter
                     while let Some(&next) = chars.peek() {
                         chars.next();
                         if next.is_ascii_alphabetic() {
@@ -370,7 +379,8 @@ impl KiroProvider {
         // Try current year first
         if let Some(date) = chrono::NaiveDate::from_ymd_opt(current_year, month, day) {
             let datetime = date.and_hms_opt(0, 0, 0)?;
-            let utc = chrono::DateTime::<chrono::Utc>::from_naive_utc_and_offset(datetime, chrono::Utc);
+            let utc =
+                chrono::DateTime::<chrono::Utc>::from_naive_utc_and_offset(datetime, chrono::Utc);
             if utc > now {
                 return Some(utc);
             }
@@ -379,7 +389,10 @@ impl KiroProvider {
         // If in the past, use next year
         if let Some(date) = chrono::NaiveDate::from_ymd_opt(current_year + 1, month, day) {
             let datetime = date.and_hms_opt(0, 0, 0)?;
-            return Some(chrono::DateTime::<chrono::Utc>::from_naive_utc_and_offset(datetime, chrono::Utc));
+            return Some(chrono::DateTime::<chrono::Utc>::from_naive_utc_and_offset(
+                datetime,
+                chrono::Utc,
+            ));
         }
 
         None
@@ -415,9 +428,7 @@ impl Provider for KiroProvider {
                 let usage = self.fetch_via_cli().await?;
                 Ok(ProviderFetchResult::new(usage, "cli"))
             }
-            SourceMode::OAuth => {
-                Err(ProviderError::UnsupportedSource(SourceMode::OAuth))
-            }
+            SourceMode::OAuth => Err(ProviderError::UnsupportedSource(SourceMode::OAuth)),
         }
     }
 

--- a/rust/src/providers/kiro/mod.rs
+++ b/rust/src/providers/kiro/mod.rs
@@ -14,8 +14,6 @@ pub use version::{
 use async_trait::async_trait;
 use chrono::Datelike;
 use regex_lite::Regex;
-#[cfg(windows)]
-use std::os::windows::process::CommandExt;
 use std::path::PathBuf;
 use std::process::Stdio;
 use tokio::process::Command;

--- a/rust/src/providers/kiro/version.rs
+++ b/rust/src/providers/kiro/version.rs
@@ -183,10 +183,7 @@ pub fn detect_version() -> Option<String> {
         .get_or_init(|| {
             let cli_path = find_kiro_cli()?;
 
-            let output = Command::new(&cli_path)
-                .arg("--version")
-                .output()
-                .ok()?;
+            let output = Command::new(&cli_path).arg("--version").output().ok()?;
 
             if !output.status.success() {
                 return None;

--- a/rust/src/providers/minimax/local_storage.rs
+++ b/rust/src/providers/minimax/local_storage.rs
@@ -137,10 +137,13 @@ impl MiniMaxLocalStorageImporter {
     }
 
     /// Extract session from a localStorage path
-    fn extract_from_path(path: &PathBuf, browser_name: &str) -> Result<MiniMaxSession, ImportError> {
+    fn extract_from_path(
+        path: &PathBuf,
+        browser_name: &str,
+    ) -> Result<MiniMaxSession, ImportError> {
         // Look for .ldb or .log files
-        let entries = std::fs::read_dir(path)
-            .map_err(|e| ImportError::AccessDenied(e.to_string()))?;
+        let entries =
+            std::fs::read_dir(path).map_err(|e| ImportError::AccessDenied(e.to_string()))?;
 
         let mut minimax_data: Option<serde_json::Value> = None;
 
@@ -220,34 +223,49 @@ impl MiniMaxLocalStorageImporter {
     }
 
     /// Parse session from extracted JSON
-    fn parse_session_from_json(json: &serde_json::Value, browser_name: &str) -> Result<MiniMaxSession, ImportError> {
-        let access_token = json.get("access_token")
+    fn parse_session_from_json(
+        json: &serde_json::Value,
+        browser_name: &str,
+    ) -> Result<MiniMaxSession, ImportError> {
+        let access_token = json
+            .get("access_token")
             .or_else(|| json.get("token"))
             .or_else(|| json.get("mm_token"))
             .and_then(|v| v.as_str())
             .map(|s| s.to_string());
 
-        let user_id = json.get("user_id")
+        let user_id = json
+            .get("user_id")
             .or_else(|| json.get("userId"))
             .or_else(|| json.get("id"))
-            .and_then(|v| v.as_str().map(|s| s.to_string())
-                .or_else(|| v.as_i64().map(|n| n.to_string())));
+            .and_then(|v| {
+                v.as_str()
+                    .map(|s| s.to_string())
+                    .or_else(|| v.as_i64().map(|n| n.to_string()))
+            });
 
-        let group_id = json.get("group_id")
+        let group_id = json
+            .get("group_id")
             .or_else(|| json.get("groupId"))
-            .and_then(|v| v.as_str().map(|s| s.to_string())
-                .or_else(|| v.as_i64().map(|n| n.to_string())));
+            .and_then(|v| {
+                v.as_str()
+                    .map(|s| s.to_string())
+                    .or_else(|| v.as_i64().map(|n| n.to_string()))
+            });
 
-        let email = json.get("email")
+        let email = json
+            .get("email")
             .and_then(|v| v.as_str())
             .map(|s| s.to_string());
 
-        let phone = json.get("phone")
+        let phone = json
+            .get("phone")
             .or_else(|| json.get("mobile"))
             .and_then(|v| v.as_str())
             .map(|s| s.to_string());
 
-        let plan_type = json.get("plan_type")
+        let plan_type = json
+            .get("plan_type")
             .or_else(|| json.get("planType"))
             .or_else(|| json.get("plan"))
             .and_then(|v| v.as_str())
@@ -255,7 +273,9 @@ impl MiniMaxLocalStorageImporter {
 
         // Need at least access_token or user_id
         if access_token.is_none() && user_id.is_none() {
-            return Err(ImportError::ParseError("No valid session data found".to_string()));
+            return Err(ImportError::ParseError(
+                "No valid session data found".to_string(),
+            ));
         }
 
         Ok(MiniMaxSession {

--- a/rust/src/providers/minimax/mod.rs
+++ b/rust/src/providers/minimax/mod.rs
@@ -7,14 +7,14 @@ mod local_storage;
 
 // Re-exports for local storage import
 #[allow(unused_imports)]
-pub use local_storage::{MiniMaxLocalStorageImporter, MiniMaxSession, ImportError};
+pub use local_storage::{ImportError, MiniMaxLocalStorageImporter, MiniMaxSession};
 
 use async_trait::async_trait;
 use std::path::PathBuf;
 
 use crate::core::{
-    FetchContext, Provider, ProviderId, ProviderError, ProviderFetchResult,
-    ProviderMetadata, RateWindow, SourceMode, UsageSnapshot,
+    FetchContext, Provider, ProviderError, ProviderFetchResult, ProviderId, ProviderMetadata,
+    RateWindow, SourceMode, UsageSnapshot,
 };
 
 /// MiniMax API region
@@ -64,7 +64,7 @@ impl MiniMaxProvider {
         // Check environment variables first
         if let (Ok(group_id), Ok(api_key)) = (
             std::env::var("MINIMAX_GROUP_ID"),
-            std::env::var("MINIMAX_API_KEY")
+            std::env::var("MINIMAX_API_KEY"),
         ) {
             return Ok((group_id, api_key));
         }
@@ -75,17 +75,20 @@ impl MiniMaxProvider {
 
         let config_file = config_path.join("config.json");
         if config_file.exists() {
-            let content = tokio::fs::read_to_string(&config_file).await
+            let content = tokio::fs::read_to_string(&config_file)
+                .await
                 .map_err(|e| ProviderError::Other(e.to_string()))?;
 
-            let json: serde_json::Value = serde_json::from_str(&content)
-                .map_err(|e| ProviderError::Parse(e.to_string()))?;
+            let json: serde_json::Value =
+                serde_json::from_str(&content).map_err(|e| ProviderError::Parse(e.to_string()))?;
 
-            let group_id = json.get("group_id")
+            let group_id = json
+                .get("group_id")
                 .and_then(|v| v.as_str())
                 .map(|s| s.to_string());
 
-            let api_key = json.get("api_key")
+            let api_key = json
+                .get("api_key")
                 .and_then(|v| v.as_str())
                 .map(|s| s.to_string());
 
@@ -110,11 +113,15 @@ impl MiniMaxProvider {
         let (group_id, api_key) = self.read_api_key().await?;
 
         // Try global endpoint first, fall back to China mainland on 401/403
-        match self.fetch_from_region(&group_id, &api_key, MiniMaxRegion::Global).await {
+        match self
+            .fetch_from_region(&group_id, &api_key, MiniMaxRegion::Global)
+            .await
+        {
             Ok(usage) => Ok(usage),
             Err(ProviderError::AuthRequired) => {
                 // Retry with China mainland endpoint
-                self.fetch_from_region(&group_id, &api_key, MiniMaxRegion::ChinaMainland).await
+                self.fetch_from_region(&group_id, &api_key, MiniMaxRegion::ChinaMainland)
+                    .await
             }
             Err(e) => Err(e),
         }
@@ -156,33 +163,43 @@ impl MiniMaxProvider {
             )));
         }
 
-        let json: serde_json::Value = resp.json().await
+        let json: serde_json::Value = resp
+            .json()
+            .await
             .map_err(|e| ProviderError::Parse(e.to_string()))?;
 
         self.parse_usage_response(&json)
     }
 
-    fn parse_usage_response(&self, json: &serde_json::Value) -> Result<UsageSnapshot, ProviderError> {
+    fn parse_usage_response(
+        &self,
+        json: &serde_json::Value,
+    ) -> Result<UsageSnapshot, ProviderError> {
         // Parse MiniMax billing response
         let base_resp = json.get("base_resp");
         if let Some(base) = base_resp {
-            let status_code = base.get("status_code").and_then(|v| v.as_i64()).unwrap_or(-1);
+            let status_code = base
+                .get("status_code")
+                .and_then(|v| v.as_i64())
+                .unwrap_or(-1);
             if status_code != 0 {
                 return Err(ProviderError::Parse(
                     base.get("status_msg")
                         .and_then(|v| v.as_str())
                         .unwrap_or("Unknown error")
-                        .to_string()
+                        .to_string(),
                 ));
             }
         }
 
-        let used_credits = json.get("used_amount")
+        let used_credits = json
+            .get("used_amount")
             .or_else(|| json.get("total_amount"))
             .and_then(|v| v.as_f64())
             .unwrap_or(0.0);
 
-        let credit_limit = json.get("total_quota")
+        let credit_limit = json
+            .get("total_quota")
             .or_else(|| json.get("quota"))
             .and_then(|v| v.as_f64())
             .unwrap_or(100.0);
@@ -193,13 +210,13 @@ impl MiniMaxProvider {
             0.0
         };
 
-        let plan = json.get("plan_type")
+        let plan = json
+            .get("plan_type")
             .or_else(|| json.get("type"))
             .and_then(|v| v.as_str())
             .unwrap_or("MiniMax");
 
-        let usage = UsageSnapshot::new(RateWindow::new(used_percent))
-            .with_login_method(plan);
+        let usage = UsageSnapshot::new(RateWindow::new(used_percent)).with_login_method(plan);
 
         Ok(usage)
     }
@@ -213,8 +230,8 @@ impl MiniMaxProvider {
             .unwrap_or(false);
 
         if has_env_vars || has_config {
-            let usage = UsageSnapshot::new(RateWindow::new(0.0))
-                .with_login_method("MiniMax (configured)");
+            let usage =
+                UsageSnapshot::new(RateWindow::new(0.0)).with_login_method("MiniMax (configured)");
             Ok(usage)
         } else {
             Err(ProviderError::NotInstalled(
@@ -259,9 +276,7 @@ impl Provider for MiniMaxProvider {
                 let usage = self.probe_cli().await?;
                 Ok(ProviderFetchResult::new(usage, "cli"))
             }
-            SourceMode::OAuth => {
-                Err(ProviderError::UnsupportedSource(SourceMode::OAuth))
-            }
+            SourceMode::OAuth => Err(ProviderError::UnsupportedSource(SourceMode::OAuth)),
         }
     }
 

--- a/rust/src/providers/ollama/mod.rs
+++ b/rust/src/providers/ollama/mod.rs
@@ -7,8 +7,8 @@ use async_trait::async_trait;
 use regex_lite::Regex;
 
 use crate::core::{
-    FetchContext, Provider, ProviderId, ProviderError, ProviderFetchResult,
-    ProviderMetadata, RateWindow, SourceMode, UsageSnapshot,
+    FetchContext, Provider, ProviderError, ProviderFetchResult, ProviderId, ProviderMetadata,
+    RateWindow, SourceMode, UsageSnapshot,
 };
 
 /// Ollama settings page URL
@@ -108,7 +108,10 @@ impl OllamaProvider {
     /// Parse usage data from the Ollama settings HTML page
     fn parse_usage_html(&self, html: &str) -> Result<UsageSnapshot, ProviderError> {
         // Check if we're signed out
-        if html.contains("Sign in") && !html.contains("Cloud Usage") && !html.contains("Session usage") {
+        if html.contains("Sign in")
+            && !html.contains("Cloud Usage")
+            && !html.contains("Session usage")
+        {
             return Err(ProviderError::AuthRequired);
         }
 

--- a/rust/src/providers/openai/friendly_errors.rs
+++ b/rust/src/providers/openai/friendly_errors.rs
@@ -4,11 +4,8 @@
 //! into human-readable error messages with actionable guidance.
 
 /// Indicators that suggest the page is a public landing page
-const LANDING_PAGE_INDICATORS: &[&str] = &[
-    "skip to content",
-    "about openai",
-    "learn about chatgpt",
-];
+const LANDING_PAGE_INDICATORS: &[&str] =
+    &["skip to content", "about openai", "learn about chatgpt"];
 
 /// Indicators that suggest the user is logged out
 const LOGGED_OUT_INDICATORS: &[&str] = &[
@@ -34,12 +31,7 @@ const CLOUDFLARE_INDICATORS: &[&str] = &[
 ];
 
 /// Rate limit indicators
-const RATE_LIMIT_INDICATORS: &[&str] = &[
-    "rate limit",
-    "too many requests",
-    "429",
-    "slow down",
-];
+const RATE_LIMIT_INDICATORS: &[&str] = &["rate limit", "too many requests", "429", "slow down"];
 
 /// Server error indicators
 const SERVER_ERROR_INDICATORS: &[&str] = &[
@@ -68,7 +60,10 @@ pub enum OpenAIWebErrorKind {
     /// Empty response
     EmptyResponse,
     /// Cookie mismatch with expected account
-    CookieMismatch { expected: String, got: Option<String> },
+    CookieMismatch {
+        expected: String,
+        got: Option<String>,
+    },
     /// Unknown error (page doesn't match known patterns)
     Unknown,
 }
@@ -111,9 +106,7 @@ impl OpenAIWebErrorKind {
             && (lower.contains("about") || lower.contains("openai") || lower.contains("chatgpt"));
 
         // Check if it looks logged out
-        let looks_logged_out = LOGGED_OUT_INDICATORS
-            .iter()
-            .any(|ind| lower.contains(ind));
+        let looks_logged_out = LOGGED_OUT_INDICATORS.iter().any(|ind| lower.contains(ind));
 
         if looks_like_landing {
             return Some(OpenAIWebErrorKind::PublicLanding);
@@ -208,7 +201,10 @@ pub fn friendly_error(
             ))
         }
 
-        OpenAIWebErrorKind::CookieMismatch { ref expected, ref got } => {
+        OpenAIWebErrorKind::CookieMismatch {
+            ref expected,
+            ref got,
+        } => {
             let got_label = got.as_deref().unwrap_or("a different account");
             Some(format!(
                 "Cookie mismatch: expected {} but got {}. \
@@ -278,7 +274,12 @@ pub fn is_logged_out(html: &str) -> bool {
 
     // Fall back to content detection
     OpenAIWebErrorKind::detect(html)
-        .map(|k| matches!(k, OpenAIWebErrorKind::NotLoggedIn | OpenAIWebErrorKind::PublicLanding))
+        .map(|k| {
+            matches!(
+                k,
+                OpenAIWebErrorKind::NotLoggedIn | OpenAIWebErrorKind::PublicLanding
+            )
+        })
         .unwrap_or(false)
 }
 

--- a/rust/src/providers/openai/mod.rs
+++ b/rust/src/providers/openai/mod.rs
@@ -8,11 +8,10 @@ pub mod scraper;
 // Re-exports for error handling and dashboard scraping
 #[allow(unused_imports)]
 pub use friendly_errors::{
-    extract_auth_status, extract_signed_in_email, friendly_error, is_logged_out,
-    OpenAIWebErrorKind,
+    extract_auth_status, extract_signed_in_email, friendly_error, is_logged_out, OpenAIWebErrorKind,
 };
 #[allow(unused_imports)]
 pub use scraper::{
-    CreditsHistoryEntry, OpenAIDashboardData, UsageBreakdown, parse_dashboard_json,
+    parse_dashboard_json, CreditsHistoryEntry, OpenAIDashboardData, UsageBreakdown,
     OPENAI_DASHBOARD_SCRAPE_SCRIPT,
 };

--- a/rust/src/providers/opencode/mod.rs
+++ b/rust/src/providers/opencode/mod.rs
@@ -16,14 +16,16 @@ use serde_json::Value;
 use uuid::Uuid;
 
 use crate::core::{
-    FetchContext, Provider, ProviderId, ProviderError, ProviderFetchResult,
-    ProviderMetadata, RateWindow, SourceMode, UsageSnapshot,
+    FetchContext, Provider, ProviderError, ProviderFetchResult, ProviderId, ProviderMetadata,
+    RateWindow, SourceMode, UsageSnapshot,
 };
 
 const BASE_URL: &str = "https://opencode.ai";
 const SERVER_URL: &str = "https://opencode.ai/_server";
-const WORKSPACES_SERVER_ID: &str = "def39973159c7f0483d8793a822b8dbb10d067e12c65455fcb4608459ba0234f";
-const SUBSCRIPTION_SERVER_ID: &str = "7abeebee372f304e050aaaf92be863f4a86490e382f8c79db68fd94040d691b4";
+const WORKSPACES_SERVER_ID: &str =
+    "def39973159c7f0483d8793a822b8dbb10d067e12c65455fcb4608459ba0234f";
+const SUBSCRIPTION_SERVER_ID: &str =
+    "7abeebee372f304e050aaaf92be863f4a86490e382f8c79db68fd94040d691b4";
 
 /// OpenCode provider
 pub struct OpenCodeProvider {
@@ -54,12 +56,17 @@ impl OpenCodeProvider {
     }
 
     /// Fetch usage with cookie header
-    async fn fetch_with_cookies(&self, cookie_header: &str) -> Result<UsageSnapshot, ProviderError> {
+    async fn fetch_with_cookies(
+        &self,
+        cookie_header: &str,
+    ) -> Result<UsageSnapshot, ProviderError> {
         // First get workspace ID
         let workspace_id = self.fetch_workspace_id(cookie_header).await?;
 
         // Then fetch subscription info
-        let subscription = self.fetch_subscription(&workspace_id, cookie_header).await?;
+        let subscription = self
+            .fetch_subscription(&workspace_id, cookie_header)
+            .await?;
 
         // Parse the response
         self.parse_subscription(&subscription)
@@ -69,15 +76,22 @@ impl OpenCodeProvider {
     async fn fetch_workspace_id(&self, cookie_header: &str) -> Result<String, ProviderError> {
         let url = format!("{}?id={}", SERVER_URL, WORKSPACES_SERVER_ID);
 
-        let response = self.client
+        let response = self
+            .client
             .get(&url)
             .header("Cookie", cookie_header)
             .header("X-Server-Id", WORKSPACES_SERVER_ID)
             .header("X-Server-Instance", format!("server-fn:{}", Uuid::new_v4()))
-            .header("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36")
+            .header(
+                "User-Agent",
+                "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36",
+            )
             .header("Origin", BASE_URL)
             .header("Referer", BASE_URL)
-            .header("Accept", "text/javascript, application/json;q=0.9, */*;q=0.8")
+            .header(
+                "Accept",
+                "text/javascript, application/json;q=0.9, */*;q=0.8",
+            )
             .send()
             .await?;
 
@@ -108,21 +122,35 @@ impl OpenCodeProvider {
     }
 
     /// Fetch subscription info for a workspace
-    async fn fetch_subscription(&self, workspace_id: &str, cookie_header: &str) -> Result<String, ProviderError> {
+    async fn fetch_subscription(
+        &self,
+        workspace_id: &str,
+        cookie_header: &str,
+    ) -> Result<String, ProviderError> {
         let referer = format!("https://opencode.ai/workspace/{}/billing", workspace_id);
         let args = serde_json::json!([workspace_id]);
         let encoded_args = Self::url_encode(&args.to_string());
-        let url = format!("{}?id={}&args={}", SERVER_URL, SUBSCRIPTION_SERVER_ID, encoded_args);
+        let url = format!(
+            "{}?id={}&args={}",
+            SERVER_URL, SUBSCRIPTION_SERVER_ID, encoded_args
+        );
 
-        let response = self.client
+        let response = self
+            .client
             .get(&url)
             .header("Cookie", cookie_header)
             .header("X-Server-Id", SUBSCRIPTION_SERVER_ID)
             .header("X-Server-Instance", format!("server-fn:{}", Uuid::new_v4()))
-            .header("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36")
+            .header(
+                "User-Agent",
+                "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36",
+            )
             .header("Origin", BASE_URL)
             .header("Referer", referer)
-            .header("Accept", "text/javascript, application/json;q=0.9, */*;q=0.8")
+            .header(
+                "Accept",
+                "text/javascript, application/json;q=0.9, */*;q=0.8",
+            )
             .send()
             .await?;
 
@@ -184,7 +212,8 @@ impl OpenCodeProvider {
     /// Parse usage from JSON response
     fn parse_usage_json(&self, json: &Value, now: DateTime<Utc>) -> Option<UsageSnapshot> {
         // Look for rollingUsage and weeklyUsage
-        let rolling = self.find_usage_window(json, &["rollingUsage", "rolling", "rolling_usage"])?;
+        let rolling =
+            self.find_usage_window(json, &["rollingUsage", "rolling", "rolling_usage"])?;
         let weekly = self.find_usage_window(json, &["weeklyUsage", "weekly", "weekly_usage"])?;
 
         let primary = RateWindow::with_details(
@@ -232,8 +261,19 @@ impl OpenCodeProvider {
 
     /// Parse a usage window object
     fn parse_window(&self, obj: &Value) -> Option<(f64, i64)> {
-        let percent_keys = ["usagePercent", "usedPercent", "percentUsed", "percent", "utilization"];
-        let reset_keys = ["resetInSec", "resetInSeconds", "resetSeconds", "resetsInSec"];
+        let percent_keys = [
+            "usagePercent",
+            "usedPercent",
+            "percentUsed",
+            "percent",
+            "utilization",
+        ];
+        let reset_keys = [
+            "resetInSec",
+            "resetInSeconds",
+            "resetSeconds",
+            "resetsInSec",
+        ];
 
         let mut percent: Option<f64> = None;
         for key in percent_keys {
@@ -245,8 +285,14 @@ impl OpenCodeProvider {
 
         // Try computing from used/limit
         if percent.is_none() {
-            let used = obj.get("used").or(obj.get("usage")).and_then(|v| v.as_f64());
-            let limit = obj.get("limit").or(obj.get("total")).and_then(|v| v.as_f64());
+            let used = obj
+                .get("used")
+                .or(obj.get("usage"))
+                .and_then(|v| v.as_f64());
+            let limit = obj
+                .get("limit")
+                .or(obj.get("total"))
+                .and_then(|v| v.as_f64());
             if let (Some(u), Some(l)) = (used, limit) {
                 if l > 0.0 {
                     percent = Some((u / l) * 100.0);
@@ -274,10 +320,12 @@ impl OpenCodeProvider {
         let percent_pattern = format!(r"{}[^}}]*?usagePercent\s*:\s*([0-9]+(?:\.[0-9]+)?)", prefix);
         let reset_pattern = format!(r"{}[^}}]*?resetInSec\s*:\s*([0-9]+)", prefix);
 
-        let percent = self.extract_number(&percent_pattern, text)
+        let percent = self
+            .extract_number(&percent_pattern, text)
             .ok_or_else(|| ProviderError::Parse(format!("Missing {} percent", prefix)))?;
 
-        let reset = self.extract_number(&reset_pattern, text)
+        let reset = self
+            .extract_number(&reset_pattern, text)
             .map(|n| n as i64)
             .unwrap_or(0);
 
@@ -359,15 +407,18 @@ impl Provider for OpenCodeProvider {
                 // Try to get cookies from browser
                 #[cfg(windows)]
                 {
-                    use crate::browser::detection::BrowserDetector;
                     use crate::browser::cookies::{Cookie, CookieExtractor};
+                    use crate::browser::detection::BrowserDetector;
 
                     let browsers = BrowserDetector::detect_all();
 
                     for browser in browsers {
-                        if let Ok(cookies) = CookieExtractor::extract_for_domain(&browser, "opencode.ai") {
+                        if let Ok(cookies) =
+                            CookieExtractor::extract_for_domain(&browser, "opencode.ai")
+                        {
                             // Build cookie header
-                            let cookie_header: String = cookies.iter()
+                            let cookie_header: String = cookies
+                                .iter()
                                 .map(|c: &Cookie| format!("{}={}", c.name, c.value))
                                 .collect::<Vec<_>>()
                                 .join("; ");
@@ -385,12 +436,8 @@ impl Provider for OpenCodeProvider {
 
                 Err(ProviderError::AuthRequired)
             }
-            SourceMode::Cli => {
-                Err(ProviderError::UnsupportedSource(SourceMode::Cli))
-            }
-            SourceMode::OAuth => {
-                Err(ProviderError::UnsupportedSource(SourceMode::OAuth))
-            }
+            SourceMode::Cli => Err(ProviderError::UnsupportedSource(SourceMode::Cli)),
+            SourceMode::OAuth => Err(ProviderError::UnsupportedSource(SourceMode::OAuth)),
         }
     }
 

--- a/rust/src/providers/opencode/scraper.rs
+++ b/rust/src/providers/opencode/scraper.rs
@@ -11,8 +11,10 @@ use serde::{Deserialize, Serialize};
 use std::sync::OnceLock;
 
 /// OpenCode server IDs for API endpoints
-const WORKSPACES_SERVER_ID: &str = "def39973159c7f0483d8793a822b8dbb10d067e12c65455fcb4608459ba0234f";
-const SUBSCRIPTION_SERVER_ID: &str = "7abeebee372f304e050aaaf92be863f4a86490e382f8c79db68fd94040d691b4";
+const WORKSPACES_SERVER_ID: &str =
+    "def39973159c7f0483d8793a822b8dbb10d067e12c65455fcb4608459ba0234f";
+const SUBSCRIPTION_SERVER_ID: &str =
+    "7abeebee372f304e050aaaf92be863f4a86490e382f8c79db68fd94040d691b4";
 const BASE_URL: &str = "https://opencode.ai";
 const SERVER_URL: &str = "https://opencode.ai/_server";
 
@@ -192,7 +194,9 @@ impl OpenCodeUsageFetcher {
             }
 
             if ids.is_empty() {
-                return Err(OpenCodeError::ParseFailed("Missing workspace id".to_string()));
+                return Err(OpenCodeError::ParseFailed(
+                    "Missing workspace id".to_string(),
+                ));
             }
         }
 
@@ -306,9 +310,7 @@ impl OpenCodeUsageFetcher {
 
         if request.method != "GET" {
             if let Some(args) = &request.args {
-                req = req
-                    .header("Content-Type", "application/json")
-                    .json(args);
+                req = req.header("Content-Type", "application/json").json(args);
             }
         }
 
@@ -350,10 +352,7 @@ impl OpenCodeUsageFetcher {
         if let Some(args) = args {
             if !args.is_empty() {
                 if let Ok(json_str) = serde_json::to_string(args) {
-                    url.push_str(&format!(
-                        "&args={}",
-                        Self::url_encode(&json_str)
-                    ));
+                    url.push_str(&format!("&args={}", Self::url_encode(&json_str)));
                 }
             }
         }
@@ -393,18 +392,13 @@ impl OpenCodeUsageFetcher {
             r#"rollingUsage[^}]*?usagePercent\s*:\s*([0-9]+(?:\.[0-9]+)?)"#,
             text,
         );
-        let rolling_reset = Self::extract_int(
-            r#"rollingUsage[^}]*?resetInSec\s*:\s*([0-9]+)"#,
-            text,
-        );
+        let rolling_reset =
+            Self::extract_int(r#"rollingUsage[^}]*?resetInSec\s*:\s*([0-9]+)"#, text);
         let weekly_percent = Self::extract_double(
             r#"weeklyUsage[^}]*?usagePercent\s*:\s*([0-9]+(?:\.[0-9]+)?)"#,
             text,
         );
-        let weekly_reset = Self::extract_int(
-            r#"weeklyUsage[^}]*?resetInSec\s*:\s*([0-9]+)"#,
-            text,
-        );
+        let weekly_reset = Self::extract_int(r#"weeklyUsage[^}]*?resetInSec\s*:\s*([0-9]+)"#, text);
 
         match (rolling_percent, rolling_reset, weekly_percent, weekly_reset) {
             (Some(rp), Some(rr), Some(wp), Some(wr)) => Ok(OpenCodeUsageSnapshot {
@@ -414,7 +408,9 @@ impl OpenCodeUsageFetcher {
                 weekly_reset_in_sec: wr,
                 updated_at: now,
             }),
-            _ => Err(OpenCodeError::ParseFailed("Missing usage fields".to_string())),
+            _ => Err(OpenCodeError::ParseFailed(
+                "Missing usage fields".to_string(),
+            )),
         }
     }
 
@@ -440,16 +436,15 @@ impl OpenCodeUsageFetcher {
     }
 
     /// Parse usage from a JSON object
-    fn parse_usage_dict(json: &serde_json::Value, now: DateTime<Utc>) -> Option<OpenCodeUsageSnapshot> {
+    fn parse_usage_dict(
+        json: &serde_json::Value,
+        now: DateTime<Utc>,
+    ) -> Option<OpenCodeUsageSnapshot> {
         let rolling_keys = ["rollingUsage", "rolling", "rolling_usage"];
         let weekly_keys = ["weeklyUsage", "weekly", "weekly_usage"];
 
-        let rolling = rolling_keys
-            .iter()
-            .find_map(|k| json.get(k));
-        let weekly = weekly_keys
-            .iter()
-            .find_map(|k| json.get(k));
+        let rolling = rolling_keys.iter().find_map(|k| json.get(k));
+        let weekly = weekly_keys.iter().find_map(|k| json.get(k));
 
         if let (Some(rolling), Some(weekly)) = (rolling, weekly) {
             let rolling_window = Self::parse_window(rolling, now)?;
@@ -500,8 +495,9 @@ impl OpenCodeUsageFetcher {
 
         // Fall back to regex for JavaScript object notation (unquoted keys)
         static WRK_ID_REGEX: OnceLock<Regex> = OnceLock::new();
-        let regex =
-            WRK_ID_REGEX.get_or_init(|| Regex::new(r#""id"\s*:\s*"(wrk_[^"]+)"|id\s*:\s*"(wrk_[^"]+)""#).unwrap());
+        let regex = WRK_ID_REGEX.get_or_init(|| {
+            Regex::new(r#""id"\s*:\s*"(wrk_[^"]+)"|id\s*:\s*"(wrk_[^"]+)""#).unwrap()
+        });
 
         regex
             .captures_iter(text)
@@ -550,9 +546,7 @@ impl OpenCodeUsageFetcher {
     /// Check if response indicates signed out
     fn looks_signed_out(text: &str) -> bool {
         let lower = text.to_lowercase();
-        lower.contains("login")
-            || lower.contains("sign in")
-            || lower.contains("auth/authorize")
+        lower.contains("login") || lower.contains("sign in") || lower.contains("auth/authorize")
     }
 
     /// Extract a double from text using regex
@@ -611,9 +605,13 @@ mod tests {
 
     #[test]
     fn test_looks_signed_out() {
-        assert!(OpenCodeUsageFetcher::looks_signed_out("Please login to continue"));
+        assert!(OpenCodeUsageFetcher::looks_signed_out(
+            "Please login to continue"
+        ));
         assert!(OpenCodeUsageFetcher::looks_signed_out("Sign in required"));
-        assert!(!OpenCodeUsageFetcher::looks_signed_out("Welcome to OpenCode"));
+        assert!(!OpenCodeUsageFetcher::looks_signed_out(
+            "Welcome to OpenCode"
+        ));
     }
 
     #[test]
@@ -623,8 +621,7 @@ mod tests {
             "weeklyUsage": {"usagePercent": 20.0, "resetInSec": 604800}
         }"#;
 
-        let snapshot =
-            OpenCodeUsageFetcher::parse_subscription(json, Utc::now()).unwrap();
+        let snapshot = OpenCodeUsageFetcher::parse_subscription(json, Utc::now()).unwrap();
         assert!((snapshot.rolling_usage_percent - 45.5).abs() < 0.01);
         assert!((snapshot.weekly_usage_percent - 20.0).abs() < 0.01);
         assert_eq!(snapshot.rolling_reset_in_sec, 3600);

--- a/rust/src/providers/openrouter/mod.rs
+++ b/rust/src/providers/openrouter/mod.rs
@@ -7,8 +7,8 @@ use async_trait::async_trait;
 use serde::Deserialize;
 
 use crate::core::{
-    FetchContext, Provider, ProviderId, ProviderError, ProviderFetchResult,
-    ProviderMetadata, RateWindow, SourceMode, UsageSnapshot,
+    FetchContext, Provider, ProviderError, ProviderFetchResult, ProviderId, ProviderMetadata,
+    RateWindow, SourceMode, UsageSnapshot,
 };
 
 /// OpenRouter API base URL
@@ -139,10 +139,9 @@ impl OpenRouterProvider {
             )));
         }
 
-        let credits: CreditsResponse = resp
-            .json()
-            .await
-            .map_err(|e| ProviderError::Parse(format!("Failed to parse credits response: {}", e)))?;
+        let credits: CreditsResponse = resp.json().await.map_err(|e| {
+            ProviderError::Parse(format!("Failed to parse credits response: {}", e))
+        })?;
 
         let balance = credits.data.balance();
         let used_percent = credits.data.used_percent();
@@ -150,8 +149,8 @@ impl OpenRouterProvider {
         let mut primary = RateWindow::new(used_percent);
         primary.reset_description = Some(format!("${:.2} remaining", balance));
 
-        let mut usage = UsageSnapshot::new(primary)
-            .with_login_method(&format!("${:.2} balance", balance));
+        let mut usage =
+            UsageSnapshot::new(primary).with_login_method(&format!("${:.2} balance", balance));
 
         // Try to enrich with /key endpoint data (optional, short timeout)
         let key_url = format!("{}/key", OPENROUTER_API_BASE);
@@ -174,10 +173,8 @@ impl OpenRouterProvider {
                         (key_data.data.limit, key_data.data.usage)
                     {
                         if limit > 0.0 {
-                            let key_percent =
-                                ((key_usage / limit) * 100.0).min(100.0).max(0.0);
-                            let key_desc =
-                                format!("${:.2}/${:.2} key quota", key_usage, limit);
+                            let key_percent = ((key_usage / limit) * 100.0).min(100.0).max(0.0);
+                            let key_desc = format!("${:.2}/${:.2} key quota", key_usage, limit);
                             let mut key_window = RateWindow::new(key_percent);
                             key_window.reset_description = Some(key_desc);
                             usage = usage.with_secondary(key_window);

--- a/rust/src/providers/synthetic/mod.rs
+++ b/rust/src/providers/synthetic/mod.rs
@@ -7,8 +7,8 @@ use async_trait::async_trait;
 use std::path::PathBuf;
 
 use crate::core::{
-    FetchContext, Provider, ProviderId, ProviderError, ProviderFetchResult,
-    ProviderMetadata, RateWindow, SourceMode, UsageSnapshot,
+    FetchContext, Provider, ProviderError, ProviderFetchResult, ProviderId, ProviderMetadata,
+    RateWindow, SourceMode, UsageSnapshot,
 };
 
 /// Synthetic provider
@@ -69,7 +69,8 @@ impl SyntheticProvider {
             if config_file.exists() {
                 if let Ok(content) = tokio::fs::read_to_string(&config_file).await {
                     if let Ok(json) = serde_json::from_str::<serde_json::Value>(&content) {
-                        if let Some(token) = json.get("apiKey")
+                        if let Some(token) = json
+                            .get("apiKey")
                             .or_else(|| json.get("accessToken"))
                             .and_then(|v| v.as_str())
                         {
@@ -84,7 +85,8 @@ impl SyntheticProvider {
             if creds_file.exists() {
                 if let Ok(content) = tokio::fs::read_to_string(&creds_file).await {
                     if let Ok(json) = serde_json::from_str::<serde_json::Value>(&content) {
-                        if let Some(token) = json.get("apiKey")
+                        if let Some(token) = json
+                            .get("apiKey")
                             .or_else(|| json.get("token"))
                             .and_then(|v| v.as_str())
                         {
@@ -118,21 +120,28 @@ impl SyntheticProvider {
             return Err(ProviderError::AuthRequired);
         }
 
-        let json: serde_json::Value = resp.json().await
+        let json: serde_json::Value = resp
+            .json()
+            .await
             .map_err(|e| ProviderError::Parse(e.to_string()))?;
 
         self.parse_usage_response(&json)
     }
 
-    fn parse_usage_response(&self, json: &serde_json::Value) -> Result<UsageSnapshot, ProviderError> {
+    fn parse_usage_response(
+        &self,
+        json: &serde_json::Value,
+    ) -> Result<UsageSnapshot, ProviderError> {
         // Parse Synthetic usage response
-        let used = json.get("usage")
+        let used = json
+            .get("usage")
             .or_else(|| json.get("used"))
             .or_else(|| json.get("tokensUsed"))
             .and_then(|v| v.as_f64())
             .unwrap_or(0.0);
 
-        let limit = json.get("limit")
+        let limit = json
+            .get("limit")
             .or_else(|| json.get("quota"))
             .or_else(|| json.get("tokensLimit"))
             .and_then(|v| v.as_f64())
@@ -144,21 +153,22 @@ impl SyntheticProvider {
             0.0
         };
 
-        let plan = json.get("plan")
+        let plan = json
+            .get("plan")
             .or_else(|| json.get("tier"))
             .or_else(|| json.get("subscription"))
             .and_then(|v| v.as_str())
             .unwrap_or("Synthetic");
 
-        let reset_time = json.get("resetAt")
+        let reset_time = json
+            .get("resetAt")
             .or_else(|| json.get("periodEnd"))
             .or_else(|| json.get("resetsAt"))
             .and_then(|v| v.as_str())
             .map(|s| s.to_string());
 
         let primary_window = RateWindow::with_details(used_percent, None, None, reset_time);
-        let usage = UsageSnapshot::new(primary_window)
-            .with_login_method(plan);
+        let usage = UsageSnapshot::new(primary_window).with_login_method(plan);
 
         Ok(usage)
     }
@@ -222,9 +232,7 @@ impl Provider for SyntheticProvider {
                 let usage = self.probe_cli(ctx).await?;
                 Ok(ProviderFetchResult::new(usage, "cli"))
             }
-            SourceMode::OAuth => {
-                Err(ProviderError::UnsupportedSource(SourceMode::OAuth))
-            }
+            SourceMode::OAuth => Err(ProviderError::UnsupportedSource(SourceMode::OAuth)),
         }
     }
 

--- a/rust/src/providers/vertexai/mod.rs
+++ b/rust/src/providers/vertexai/mod.rs
@@ -7,14 +7,14 @@ mod token_refresher;
 
 // Re-exports for OAuth token refresh
 #[allow(unused_imports)]
-pub use token_refresher::{VertexAIOAuthCredentials, VertexAITokenRefresher, RefreshError};
+pub use token_refresher::{RefreshError, VertexAIOAuthCredentials, VertexAITokenRefresher};
 
 use async_trait::async_trait;
 use std::path::PathBuf;
 
 use crate::core::{
-    FetchContext, Provider, ProviderId, ProviderError, ProviderFetchResult,
-    ProviderMetadata, RateWindow, SourceMode, UsageSnapshot,
+    FetchContext, Provider, ProviderError, ProviderFetchResult, ProviderId, ProviderMetadata,
+    RateWindow, SourceMode, UsageSnapshot,
 };
 
 /// Vertex AI provider
@@ -50,11 +50,18 @@ impl VertexAIProvider {
         // Default gcloud config location
         #[cfg(target_os = "windows")]
         {
-            dirs::config_dir().map(|p| p.join("gcloud").join("application_default_credentials.json"))
+            dirs::config_dir().map(|p| {
+                p.join("gcloud")
+                    .join("application_default_credentials.json")
+            })
         }
         #[cfg(not(target_os = "windows"))]
         {
-            dirs::home_dir().map(|p| p.join(".config").join("gcloud").join("application_default_credentials.json"))
+            dirs::home_dir().map(|p| {
+                p.join(".config")
+                    .join("gcloud")
+                    .join("application_default_credentials.json")
+            })
         }
     }
 
@@ -63,9 +70,13 @@ impl VertexAIProvider {
         let possible_paths = [
             which::which("gcloud").ok(),
             #[cfg(target_os = "windows")]
-            Some(PathBuf::from("C:\\Program Files (x86)\\Google\\Cloud SDK\\google-cloud-sdk\\bin\\gcloud.cmd")),
+            Some(PathBuf::from(
+                "C:\\Program Files (x86)\\Google\\Cloud SDK\\google-cloud-sdk\\bin\\gcloud.cmd",
+            )),
             #[cfg(target_os = "windows")]
-            Some(PathBuf::from("C:\\Users\\Public\\google-cloud-sdk\\bin\\gcloud.cmd")),
+            Some(PathBuf::from(
+                "C:\\Users\\Public\\google-cloud-sdk\\bin\\gcloud.cmd",
+            )),
             #[cfg(not(target_os = "windows"))]
             None,
         ];
@@ -75,22 +86,32 @@ impl VertexAIProvider {
 
     /// Read access token from gcloud config
     async fn get_access_token(&self) -> Result<String, ProviderError> {
-        let creds_path = Self::get_gcloud_config_path()
-            .ok_or_else(|| ProviderError::NotInstalled("Google Cloud credentials not found".to_string()))?;
+        let creds_path = Self::get_gcloud_config_path().ok_or_else(|| {
+            ProviderError::NotInstalled("Google Cloud credentials not found".to_string())
+        })?;
 
         if creds_path.exists() {
-            let content = tokio::fs::read_to_string(&creds_path).await
+            let content = tokio::fs::read_to_string(&creds_path)
+                .await
                 .map_err(|e| ProviderError::Other(e.to_string()))?;
 
-            let json: serde_json::Value = serde_json::from_str(&content)
-                .map_err(|e| ProviderError::Parse(e.to_string()))?;
+            let json: serde_json::Value =
+                serde_json::from_str(&content).map_err(|e| ProviderError::Parse(e.to_string()))?;
 
             // Check for refresh token flow
             if let Some(refresh_token) = json.get("refresh_token").and_then(|v| v.as_str()) {
-                let client_id = json.get("client_id").and_then(|v| v.as_str()).unwrap_or_default();
-                let client_secret = json.get("client_secret").and_then(|v| v.as_str()).unwrap_or_default();
+                let client_id = json
+                    .get("client_id")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or_default();
+                let client_secret = json
+                    .get("client_secret")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or_default();
 
-                return self.refresh_access_token(refresh_token, client_id, client_secret).await;
+                return self
+                    .refresh_access_token(refresh_token, client_id, client_secret)
+                    .await;
             }
         }
 
@@ -113,7 +134,12 @@ impl VertexAIProvider {
         Err(ProviderError::AuthRequired)
     }
 
-    async fn refresh_access_token(&self, refresh_token: &str, client_id: &str, client_secret: &str) -> Result<String, ProviderError> {
+    async fn refresh_access_token(
+        &self,
+        refresh_token: &str,
+        client_id: &str,
+        client_secret: &str,
+    ) -> Result<String, ProviderError> {
         let client = reqwest::Client::new();
 
         let resp = client
@@ -131,7 +157,9 @@ impl VertexAIProvider {
             return Err(ProviderError::AuthRequired);
         }
 
-        let json: serde_json::Value = resp.json().await
+        let json: serde_json::Value = resp
+            .json()
+            .await
             .map_err(|e| ProviderError::Parse(e.to_string()))?;
 
         json.get("access_token")
@@ -150,7 +178,10 @@ impl VertexAIProvider {
             .map_err(|e| ProviderError::Other(e.to_string()))?;
 
         // Get project ID from config
-        let project_id = self.get_project_id().await.unwrap_or_else(|_| "unknown".to_string());
+        let project_id = self
+            .get_project_id()
+            .await
+            .unwrap_or_else(|_| "unknown".to_string());
 
         // Vertex AI billing/quota API
         let resp = client
@@ -164,7 +195,9 @@ impl VertexAIProvider {
 
         match resp {
             Ok(r) if r.status().is_success() => {
-                let json: serde_json::Value = r.json().await
+                let json: serde_json::Value = r
+                    .json()
+                    .await
                     .map_err(|e| ProviderError::Parse(e.to_string()))?;
                 self.parse_usage_response(&json, &project_id)
             }
@@ -187,11 +220,13 @@ impl VertexAIProvider {
         #[cfg(target_os = "windows")]
         let config_path = dirs::config_dir().map(|p| p.join("gcloud").join("properties"));
         #[cfg(not(target_os = "windows"))]
-        let config_path = dirs::home_dir().map(|p| p.join(".config").join("gcloud").join("properties"));
+        let config_path =
+            dirs::home_dir().map(|p| p.join(".config").join("gcloud").join("properties"));
 
         if let Some(path) = config_path {
             if path.exists() {
-                let content = tokio::fs::read_to_string(&path).await
+                let content = tokio::fs::read_to_string(&path)
+                    .await
                     .map_err(|e| ProviderError::Other(e.to_string()))?;
 
                 for line in content.lines() {
@@ -207,9 +242,14 @@ impl VertexAIProvider {
         Err(ProviderError::Other("Project ID not found".to_string()))
     }
 
-    fn parse_usage_response(&self, json: &serde_json::Value, project_id: &str) -> Result<UsageSnapshot, ProviderError> {
+    fn parse_usage_response(
+        &self,
+        json: &serde_json::Value,
+        project_id: &str,
+    ) -> Result<UsageSnapshot, ProviderError> {
         // Parse project info - actual usage would require Cloud Billing API
-        let project_name = json.get("name")
+        let project_name = json
+            .get("name")
             .and_then(|v| v.as_str())
             .unwrap_or(project_id);
 
@@ -222,7 +262,9 @@ impl VertexAIProvider {
     /// Probe CLI for detection
     async fn probe_cli(&self) -> Result<UsageSnapshot, ProviderError> {
         let gcloud = Self::which_gcloud().ok_or_else(|| {
-            ProviderError::NotInstalled("gcloud CLI not found. Install from https://cloud.google.com/sdk".to_string())
+            ProviderError::NotInstalled(
+                "gcloud CLI not found. Install from https://cloud.google.com/sdk".to_string(),
+            )
         })?;
 
         if gcloud.exists() {
@@ -233,8 +275,7 @@ impl VertexAIProvider {
                 "Vertex AI (installed)".to_string()
             };
 
-            let usage = UsageSnapshot::new(RateWindow::new(0.0))
-                .with_login_method(&label);
+            let usage = UsageSnapshot::new(RateWindow::new(0.0)).with_login_method(&label);
             Ok(usage)
         } else {
             Err(ProviderError::NotInstalled("gcloud not found".to_string()))
@@ -277,9 +318,7 @@ impl Provider for VertexAIProvider {
                 let usage = self.probe_cli().await?;
                 Ok(ProviderFetchResult::new(usage, "cli"))
             }
-            SourceMode::OAuth => {
-                Err(ProviderError::UnsupportedSource(SourceMode::OAuth))
-            }
+            SourceMode::OAuth => Err(ProviderError::UnsupportedSource(SourceMode::OAuth)),
         }
     }
 

--- a/rust/src/providers/vertexai/token_refresher.rs
+++ b/rust/src/providers/vertexai/token_refresher.rs
@@ -55,8 +55,14 @@ pub enum RefreshError {
 impl std::fmt::Display for RefreshError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            RefreshError::Expired => write!(f, "Refresh token expired. Run `gcloud auth application-default login` again."),
-            RefreshError::Revoked => write!(f, "Refresh token was revoked. Run `gcloud auth application-default login` again."),
+            RefreshError::Expired => write!(
+                f,
+                "Refresh token expired. Run `gcloud auth application-default login` again."
+            ),
+            RefreshError::Revoked => write!(
+                f,
+                "Refresh token was revoked. Run `gcloud auth application-default login` again."
+            ),
             RefreshError::NetworkError(e) => write!(f, "Network error during token refresh: {}", e),
             RefreshError::InvalidResponse(e) => write!(f, "Invalid refresh response: {}", e),
         }
@@ -79,9 +85,14 @@ impl VertexAITokenRefresher {
     }
 
     /// Refresh the access token using the refresh token
-    pub async fn refresh(&self, credentials: VertexAIOAuthCredentials) -> Result<VertexAIOAuthCredentials, RefreshError> {
+    pub async fn refresh(
+        &self,
+        credentials: VertexAIOAuthCredentials,
+    ) -> Result<VertexAIOAuthCredentials, RefreshError> {
         if credentials.refresh_token.is_empty() {
-            return Err(RefreshError::InvalidResponse("No refresh token available".to_string()));
+            return Err(RefreshError::InvalidResponse(
+                "No refresh token available".to_string(),
+            ));
         }
 
         let client = reqwest::Client::builder()
@@ -120,22 +131,27 @@ impl VertexAITokenRefresher {
             return Err(RefreshError::InvalidResponse(format!("Status {}", status)));
         }
 
-        let json: serde_json::Value = resp.json().await
+        let json: serde_json::Value = resp
+            .json()
+            .await
             .map_err(|e| RefreshError::InvalidResponse(e.to_string()))?;
 
-        let new_access_token = json.get("access_token")
+        let new_access_token = json
+            .get("access_token")
             .and_then(|v| v.as_str())
             .unwrap_or(&credentials.access_token)
             .to_string();
 
-        let expires_in = json.get("expires_in")
+        let expires_in = json
+            .get("expires_in")
             .and_then(|v| v.as_f64())
             .unwrap_or(3600.0);
 
         let new_expiry_date = Utc::now() + chrono::Duration::seconds(expires_in as i64);
 
         // Extract email from new ID token if present
-        let email = json.get("id_token")
+        let email = json
+            .get("id_token")
             .and_then(|v| v.as_str())
             .and_then(|token| Self::extract_email_from_id_token(token))
             .or(credentials.email.clone());
@@ -157,7 +173,10 @@ impl VertexAITokenRefresher {
     }
 
     /// Get a valid access token, refreshing if necessary
-    pub async fn get_valid_token(&self, credentials: VertexAIOAuthCredentials) -> Result<String, RefreshError> {
+    pub async fn get_valid_token(
+        &self,
+        credentials: VertexAIOAuthCredentials,
+    ) -> Result<String, RefreshError> {
         // Check cache first
         if let Some(cached) = self.cached_credentials.read().await.clone() {
             if cached.is_valid() {
@@ -185,9 +204,7 @@ impl VertexAITokenRefresher {
 
         // Decode the payload (second part)
         let payload = parts[1];
-        let mut padded = payload
-            .replace('-', "+")
-            .replace('_', "/");
+        let mut padded = payload.replace('-', "+").replace('_', "/");
 
         // Add padding if needed
         let remainder = padded.len() % 4;
@@ -195,10 +212,8 @@ impl VertexAITokenRefresher {
             padded.push_str(&"=".repeat(4 - remainder));
         }
 
-        let decoded = base64::Engine::decode(
-            &base64::engine::general_purpose::STANDARD,
-            &padded,
-        ).ok()?;
+        let decoded =
+            base64::Engine::decode(&base64::engine::general_purpose::STANDARD, &padded).ok()?;
 
         let json: serde_json::Value = serde_json::from_slice(&decoded).ok()?;
         json.get("email")

--- a/rust/src/providers/warp/mod.rs
+++ b/rust/src/providers/warp/mod.rs
@@ -8,8 +8,8 @@ use serde::Deserialize;
 use serde_json::json;
 
 use crate::core::{
-    FetchContext, Provider, ProviderId, ProviderError, ProviderFetchResult,
-    ProviderMetadata, RateWindow, SourceMode, UsageSnapshot,
+    FetchContext, Provider, ProviderError, ProviderFetchResult, ProviderId, ProviderMetadata,
+    RateWindow, SourceMode, UsageSnapshot,
 };
 
 /// Warp GraphQL API endpoint
@@ -220,10 +220,8 @@ impl WarpProvider {
         // Check for GraphQL errors
         if let Some(errors) = &gql_response.errors {
             if !errors.is_empty() {
-                let messages: Vec<String> = errors
-                    .iter()
-                    .filter_map(|e| e.message.clone())
-                    .collect();
+                let messages: Vec<String> =
+                    errors.iter().filter_map(|e| e.message.clone()).collect();
                 let summary = if messages.is_empty() {
                     "GraphQL request failed".to_string()
                 } else {

--- a/rust/src/providers/zai/mcp_details.rs
+++ b/rust/src/providers/zai/mcp_details.rs
@@ -121,7 +121,10 @@ impl ZaiLimitEntry {
         }
 
         let used_from_remaining = limit - self.remaining;
-        let used = used_from_remaining.max(self.current_value).max(0).min(limit);
+        let used = used_from_remaining
+            .max(self.current_value)
+            .max(0)
+            .min(limit);
         let percent = (used as f64 / limit as f64) * 100.0;
         percent.clamp(0.0, 100.0)
     }
@@ -239,7 +242,11 @@ impl McpDetailsMenu {
 
         // Sort by model code
         let mut usage_details = time_limit.usage_details.clone();
-        usage_details.sort_by(|a, b| a.model_code.to_lowercase().cmp(&b.model_code.to_lowercase()));
+        usage_details.sort_by(|a, b| {
+            a.model_code
+                .to_lowercase()
+                .cmp(&b.model_code.to_lowercase())
+        });
 
         Some(Self {
             window_label,

--- a/rust/src/providers/zai/mod.rs
+++ b/rust/src/providers/zai/mod.rs
@@ -7,14 +7,16 @@ pub mod mcp_details;
 
 // Re-exports for MCP details menu
 #[allow(unused_imports)]
-pub use mcp_details::{McpDetailsMenu, ZaiLimitEntry, ZaiLimitType, ZaiLimitUnit, ZaiUsageDetail, ZaiUsageSnapshot};
+pub use mcp_details::{
+    McpDetailsMenu, ZaiLimitEntry, ZaiLimitType, ZaiLimitUnit, ZaiUsageDetail, ZaiUsageSnapshot,
+};
 
 use async_trait::async_trait;
 use serde::Deserialize;
 
 use crate::core::{
-    FetchContext, Provider, ProviderId, ProviderError, ProviderFetchResult,
-    ProviderMetadata, RateWindow, SourceMode, UsageSnapshot,
+    FetchContext, Provider, ProviderError, ProviderFetchResult, ProviderId, ProviderMetadata,
+    RateWindow, SourceMode, UsageSnapshot,
 };
 
 /// z.ai API endpoint for quota/usage
@@ -128,29 +130,38 @@ impl ZaiProvider {
             )));
         }
 
-        let resp_bytes = resp.bytes().await
+        let resp_bytes = resp
+            .bytes()
+            .await
             .map_err(|e| ProviderError::Other(e.to_string()))?;
 
         // Handle empty response body (can happen with wrong region/endpoint)
         if resp_bytes.is_empty() {
             return Err(ProviderError::Parse(
-                "Empty response body from z.ai API. Check API region and token.".to_string()
+                "Empty response body from z.ai API. Check API region and token.".to_string(),
             ));
         }
 
-        let quota: ZaiQuotaResponse = serde_json::from_slice(&resp_bytes)
-            .map_err(|e| ProviderError::Parse(e.to_string()))?;
+        let quota: ZaiQuotaResponse =
+            serde_json::from_slice(&resp_bytes).map_err(|e| ProviderError::Parse(e.to_string()))?;
 
         self.parse_quota_response(&quota)
     }
 
-    fn parse_quota_response(&self, quota: &ZaiQuotaResponse) -> Result<UsageSnapshot, ProviderError> {
+    fn parse_quota_response(
+        &self,
+        quota: &ZaiQuotaResponse,
+    ) -> Result<UsageSnapshot, ProviderError> {
         // Find tokens limit (primary/session)
-        let tokens_limit = quota.limits.iter()
+        let tokens_limit = quota
+            .limits
+            .iter()
             .find(|l| l.limit_type.as_deref() == Some("tokens"));
 
         // Find MCP limit (weekly/secondary)
-        let mcp_limit = quota.limits.iter()
+        let mcp_limit = quota
+            .limits
+            .iter()
             .find(|l| l.limit_type.as_deref() == Some("mcp"));
 
         // Calculate session (tokens) usage percentage
@@ -184,8 +195,8 @@ impl ZaiProvider {
             0.0
         };
 
-        let mut usage = UsageSnapshot::new(RateWindow::new(session_percent))
-            .with_login_method("z.ai");
+        let mut usage =
+            UsageSnapshot::new(RateWindow::new(session_percent)).with_login_method("z.ai");
 
         // Add secondary (MCP) usage if available
         if mcp_limit.is_some() {

--- a/rust/src/settings.rs
+++ b/rust/src/settings.rs
@@ -14,6 +14,78 @@ use std::path::PathBuf;
 
 use crate::core::ProviderId;
 
+/// Theme mode for UI appearance
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum ThemeMode {
+    /// Follow system setting (Windows dark/light mode)
+    #[default]
+    System,
+    /// Always use dark theme
+    Dark,
+    /// Always use light theme
+    Light,
+}
+
+impl ThemeMode {
+    /// Get the display name for this mode
+    pub fn display_name(&self) -> &'static str {
+        match self {
+            ThemeMode::System => "System",
+            ThemeMode::Dark => "Dark",
+            ThemeMode::Light => "Light",
+        }
+    }
+
+    /// Get a description for this mode
+    pub fn description(&self) -> &'static str {
+        match self {
+            ThemeMode::System => "Follow your Windows appearance setting",
+            ThemeMode::Dark => "Always use dark theme",
+            ThemeMode::Light => "Always use light theme",
+        }
+    }
+
+    /// Get all available theme modes
+    pub fn all() -> &'static [ThemeMode] {
+        &[ThemeMode::System, ThemeMode::Dark, ThemeMode::Light]
+    }
+
+    /// Resolve to concrete dark/light based on system preference
+    pub fn is_dark(&self) -> bool {
+        match self {
+            ThemeMode::Dark => true,
+            ThemeMode::Light => false,
+            ThemeMode::System => Self::system_is_dark(),
+        }
+    }
+
+    /// Detect whether the Windows system theme is dark
+    fn system_is_dark() -> bool {
+        #[cfg(target_os = "windows")]
+        {
+            use winreg::enums::*;
+            use winreg::RegKey;
+
+            let hkcu = RegKey::predef(HKEY_CURRENT_USER);
+            if let Ok(key) =
+                hkcu.open_subkey(r"Software\Microsoft\Windows\CurrentVersion\Themes\Personalize")
+            {
+                // AppsUseLightTheme: 0 = dark, 1 = light
+                if let Ok(val) = key.get_value::<u32, _>("AppsUseLightTheme") {
+                    return val == 0;
+                }
+            }
+            true // Default to dark if registry read fails
+        }
+
+        #[cfg(not(target_os = "windows"))]
+        {
+            true // Default to dark on non-Windows
+        }
+    }
+}
+
 /// Update channel for receiving updates
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "lowercase")]
@@ -128,6 +200,10 @@ pub struct Settings {
     /// Enabled provider IDs (by CLI name)
     pub enabled_providers: HashSet<String>,
 
+    /// Theme mode: Dark, Light, or System (follow OS setting)
+    #[serde(default)]
+    pub theme_mode: ThemeMode,
+
     /// Refresh interval in seconds (0 = manual only)
     pub refresh_interval_secs: u64,
 
@@ -225,7 +301,8 @@ impl Default for Settings {
 
         Self {
             enabled_providers: enabled,
-            refresh_interval_secs: 300, // 5 minutes
+            theme_mode: ThemeMode::default(), // Follow system theme by default
+            refresh_interval_secs: 300,       // 5 minutes
             start_minimized: false,
             start_at_login: false,
             show_notifications: true,
@@ -412,7 +489,8 @@ impl Settings {
 
     /// Set the metric preference for a provider
     pub fn set_provider_metric(&mut self, id: ProviderId, metric: MetricPreference) {
-        self.provider_metrics.insert(id.cli_name().to_string(), metric);
+        self.provider_metrics
+            .insert(id.cli_name().to_string(), metric);
     }
 
     /// Maximum number of providers shown in the Overview tab
@@ -426,14 +504,19 @@ impl Settings {
             return Vec::new();
         }
 
-        let mut resolved: Vec<ProviderId> = self.overview_providers.iter()
+        let mut resolved: Vec<ProviderId> = self
+            .overview_providers
+            .iter()
             .filter_map(|name| ProviderId::from_cli_name(name))
             .filter(|id| enabled.contains(id))
             .take(Self::MAX_OVERVIEW_PROVIDERS)
             .collect();
 
         if resolved.is_empty() {
-            resolved = enabled.into_iter().take(Self::MAX_OVERVIEW_PROVIDERS).collect();
+            resolved = enabled
+                .into_iter()
+                .take(Self::MAX_OVERVIEW_PROVIDERS)
+                .collect();
         }
 
         resolved
@@ -473,12 +556,30 @@ pub struct RefreshIntervalOption {
 /// Get available refresh interval options
 pub fn get_refresh_interval_options() -> Vec<RefreshIntervalOption> {
     vec![
-        RefreshIntervalOption { value: 60, label: "1 minute".to_string() },
-        RefreshIntervalOption { value: 120, label: "2 minutes".to_string() },
-        RefreshIntervalOption { value: 300, label: "5 minutes".to_string() },
-        RefreshIntervalOption { value: 600, label: "10 minutes".to_string() },
-        RefreshIntervalOption { value: 900, label: "15 minutes".to_string() },
-        RefreshIntervalOption { value: 1800, label: "30 minutes".to_string() },
+        RefreshIntervalOption {
+            value: 60,
+            label: "1 minute".to_string(),
+        },
+        RefreshIntervalOption {
+            value: 120,
+            label: "2 minutes".to_string(),
+        },
+        RefreshIntervalOption {
+            value: 300,
+            label: "5 minutes".to_string(),
+        },
+        RefreshIntervalOption {
+            value: 600,
+            label: "10 minutes".to_string(),
+        },
+        RefreshIntervalOption {
+            value: 900,
+            label: "15 minutes".to_string(),
+        },
+        RefreshIntervalOption {
+            value: 1800,
+            label: "30 minutes".to_string(),
+        },
     ]
 }
 
@@ -533,7 +634,9 @@ impl ManualCookies {
 
     /// Get cookie for a provider
     pub fn get(&self, provider_id: &str) -> Option<&str> {
-        self.cookies.get(provider_id).map(|e| e.cookie_header.as_str())
+        self.cookies
+            .get(provider_id)
+            .map(|e| e.cookie_header.as_str())
     }
 
     /// Set cookie for a provider
@@ -657,7 +760,10 @@ impl ApiKeys {
 
     /// Check if a provider has an API key configured
     pub fn has_key(&self, provider_id: &str) -> bool {
-        self.keys.get(provider_id).map(|e| !e.api_key.is_empty()).unwrap_or(false)
+        self.keys
+            .get(provider_id)
+            .map(|e| !e.api_key.is_empty())
+            .unwrap_or(false)
     }
 
     /// Get all saved API keys for UI display (with masked values)
@@ -873,5 +979,56 @@ mod tests {
         // Remove it
         cookies.remove("claude");
         assert_eq!(cookies.get("claude"), None);
+    }
+
+    #[test]
+    fn test_theme_mode_default() {
+        let settings = Settings::default();
+        assert_eq!(settings.theme_mode, ThemeMode::System);
+    }
+
+    #[test]
+    fn test_theme_mode_display_names() {
+        assert_eq!(ThemeMode::System.display_name(), "System");
+        assert_eq!(ThemeMode::Dark.display_name(), "Dark");
+        assert_eq!(ThemeMode::Light.display_name(), "Light");
+    }
+
+    #[test]
+    fn test_theme_mode_is_dark() {
+        assert!(ThemeMode::Dark.is_dark());
+        assert!(!ThemeMode::Light.is_dark());
+        // System depends on OS, but we can verify it returns a bool
+        let _ = ThemeMode::System.is_dark();
+    }
+
+    #[test]
+    fn test_theme_mode_all() {
+        let all = ThemeMode::all();
+        assert_eq!(all.len(), 3);
+        assert!(all.contains(&ThemeMode::System));
+        assert!(all.contains(&ThemeMode::Dark));
+        assert!(all.contains(&ThemeMode::Light));
+    }
+
+    #[test]
+    fn test_theme_mode_serialization() {
+        let settings = Settings {
+            theme_mode: ThemeMode::Light,
+            ..Settings::default()
+        };
+        let json = serde_json::to_string(&settings).unwrap();
+        assert!(json.contains("\"theme_mode\":\"light\""));
+
+        let deserialized: Settings = serde_json::from_str(&json).unwrap();
+        assert_eq!(deserialized.theme_mode, ThemeMode::Light);
+    }
+
+    #[test]
+    fn test_theme_mode_deserialization_missing_field() {
+        // When theme_mode is missing from JSON, it should default to System
+        let json = r#"{"enabled_providers":["claude"]}"#;
+        let settings: Settings = serde_json::from_str(json).unwrap();
+        assert_eq!(settings.theme_mode, ThemeMode::System);
     }
 }

--- a/rust/src/shortcuts.rs
+++ b/rust/src/shortcuts.rs
@@ -37,7 +37,11 @@ impl ShortcutManager {
     }
 
     /// Register a custom shortcut for opening the menu
-    pub fn set_open_menu_shortcut(&mut self, modifiers: Modifiers, key: Code) -> anyhow::Result<()> {
+    pub fn set_open_menu_shortcut(
+        &mut self,
+        modifiers: Modifiers,
+        key: Code,
+    ) -> anyhow::Result<()> {
         // Unregister old shortcut
         let old = HotKey::new(Some(Modifiers::CONTROL | Modifiers::SHIFT), Code::KeyU);
         let _ = self.manager.unregister(old);

--- a/rust/src/single_instance.rs
+++ b/rust/src/single_instance.rs
@@ -3,11 +3,11 @@
 //! Prevents multiple instances of the menubar app from running simultaneously.
 
 #[cfg(windows)]
+use windows::core::PCWSTR;
+#[cfg(windows)]
 use windows::Win32::Foundation::{CloseHandle, HANDLE};
 #[cfg(windows)]
 use windows::Win32::System::Threading::{CreateMutexW, ReleaseMutex};
-#[cfg(windows)]
-use windows::core::PCWSTR;
 
 /// Guard that holds the single instance mutex
 /// When dropped, the mutex is released
@@ -38,8 +38,8 @@ impl SingleInstanceGuard {
 
         unsafe {
             let handle = CreateMutexW(
-                None,           // default security attributes
-                true,           // initially owned
+                None, // default security attributes
+                true, // initially owned
                 PCWSTR(wide_name.as_ptr()),
             );
 

--- a/rust/src/status/indicators.rs
+++ b/rust/src/status/indicators.rs
@@ -8,7 +8,9 @@
 use serde::{Deserialize, Serialize};
 
 /// Provider status level
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize, Default)]
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize, Default,
+)]
 pub enum StatusLevel {
     /// All systems operational
     #[default]
@@ -78,11 +80,11 @@ impl StatusLevel {
     pub fn status_prefix(&self) -> &'static str {
         match self {
             StatusLevel::Operational => "",
-            StatusLevel::Minor => "\u{1F7E1} ",      // Yellow circle
-            StatusLevel::Major => "\u{1F7E0} ",      // Orange circle
-            StatusLevel::Critical => "\u{1F534} ",   // Red circle
+            StatusLevel::Minor => "\u{1F7E1} ", // Yellow circle
+            StatusLevel::Major => "\u{1F7E0} ", // Orange circle
+            StatusLevel::Critical => "\u{1F534} ", // Red circle
             StatusLevel::Maintenance => "\u{1F535} ", // Blue circle
-            StatusLevel::Unknown => "",              // No dot for unknown
+            StatusLevel::Unknown => "",         // No dot for unknown
         }
     }
 
@@ -187,7 +189,10 @@ impl OverlayPosition {
         match self {
             OverlayPosition::TopRight => (icon_size - dot_size - padding, padding),
             OverlayPosition::TopLeft => (padding, padding),
-            OverlayPosition::BottomRight => (icon_size - dot_size - padding, icon_size - dot_size - padding),
+            OverlayPosition::BottomRight => (
+                icon_size - dot_size - padding,
+                icon_size - dot_size - padding,
+            ),
             OverlayPosition::BottomLeft => (padding, icon_size - dot_size - padding),
         }
     }
@@ -271,10 +276,22 @@ mod tests {
 
     #[test]
     fn test_from_statuspage() {
-        assert_eq!(StatusLevel::from_statuspage("operational"), StatusLevel::Operational);
-        assert_eq!(StatusLevel::from_statuspage("degraded_performance"), StatusLevel::Minor);
-        assert_eq!(StatusLevel::from_statuspage("major_outage"), StatusLevel::Critical);
-        assert_eq!(StatusLevel::from_statuspage("under_maintenance"), StatusLevel::Maintenance);
+        assert_eq!(
+            StatusLevel::from_statuspage("operational"),
+            StatusLevel::Operational
+        );
+        assert_eq!(
+            StatusLevel::from_statuspage("degraded_performance"),
+            StatusLevel::Minor
+        );
+        assert_eq!(
+            StatusLevel::from_statuspage("major_outage"),
+            StatusLevel::Critical
+        );
+        assert_eq!(
+            StatusLevel::from_statuspage("under_maintenance"),
+            StatusLevel::Maintenance
+        );
     }
 
     #[test]

--- a/rust/src/status/mod.rs
+++ b/rust/src/status/mod.rs
@@ -12,10 +12,9 @@ use std::collections::HashMap;
 
 // Re-export indicator types for convenience
 pub use indicators::{
-    OverlayPosition, StatusOverlayConfig,
-    StatusLevel as IndicatorStatusLevel,
-    ProviderStatus as IndicatorProviderStatus,
-    StatuspageResponse, StatuspageStatus, StatuspageIncident,
+    OverlayPosition, ProviderStatus as IndicatorProviderStatus,
+    StatusLevel as IndicatorStatusLevel, StatusOverlayConfig, StatuspageIncident,
+    StatuspageResponse, StatuspageStatus,
 };
 
 /// Status level for a provider
@@ -89,7 +88,7 @@ pub fn get_status_page_url(provider: &str) -> Option<&'static str> {
         "copilot" | "github" => Some("https://www.githubstatus.com"),
         "cursor" => Some("https://status.cursor.com"),
         "factory" | "droid" => None, // Factory.ai doesn't have a public status page
-        "zai" | "z.ai" => None, // z.ai doesn't have a public status page
+        "zai" | "z.ai" => None,      // z.ai doesn't have a public status page
         _ => None,
     }
 }
@@ -174,8 +173,14 @@ pub async fn fetch_statuspage_io_components(url: &str) -> Result<ProviderStatus,
 
     if let Some(comps) = json.get("components").and_then(|c| c.as_array()) {
         for comp in comps {
-            let name = comp.get("name").and_then(|n| n.as_str()).unwrap_or("Unknown");
-            let status_str = comp.get("status").and_then(|s| s.as_str()).unwrap_or("unknown");
+            let name = comp
+                .get("name")
+                .and_then(|n| n.as_str())
+                .unwrap_or("Unknown");
+            let status_str = comp
+                .get("status")
+                .and_then(|s| s.as_str())
+                .unwrap_or("unknown");
             let status = StatusLevel::from_indicator(status_str);
 
             // Update overall status to worst component

--- a/rust/src/tray/blink.rs
+++ b/rust/src/tray/blink.rs
@@ -268,9 +268,7 @@ impl EyeBlinkSystem {
             state.effect = MotionEffect::random_for_provider(provider);
 
             // Maybe schedule a double-blink
-            if state.effect == MotionEffect::Blink
-                && rng.random_bool(config.double_blink_chance)
-            {
+            if state.effect == MotionEffect::Blink && rng.random_bool(config.double_blink_chance) {
                 state.pending_second_start = Some(now + BlinkState::double_blink_delay());
             }
 

--- a/rust/src/tray/icon.rs
+++ b/rust/src/tray/icon.rs
@@ -145,7 +145,8 @@ impl LoadingPattern {
         let idx = (std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap_or_default()
-            .as_millis() as usize) % patterns.len();
+            .as_millis() as usize)
+            % patterns.len();
         patterns[idx]
     }
 }

--- a/rust/src/tray/manager.rs
+++ b/rust/src/tray/manager.rs
@@ -9,7 +9,7 @@ use std::cell::{Cell, RefCell};
 use std::collections::{hash_map::DefaultHasher, HashMap};
 use std::hash::{Hash, Hasher};
 use tray_icon::{
-    menu::{Menu, MenuEvent, MenuItem, PredefinedMenuItem, Submenu, CheckMenuItem},
+    menu::{CheckMenuItem, Menu, MenuEvent, MenuItem, PredefinedMenuItem, Submenu},
     Icon, TrayIcon, TrayIconBuilder,
 };
 
@@ -56,11 +56,11 @@ impl SurpriseAnimation {
     pub fn duration_frames(&self) -> u32 {
         match self {
             SurpriseAnimation::None => 0,
-            SurpriseAnimation::Blink => 8,     // Quick flash
-            SurpriseAnimation::Wiggle => 20,   // Shake back and forth
-            SurpriseAnimation::Pulse => 30,    // Slow pulse
-            SurpriseAnimation::Rainbow => 40,  // Color sweep
-            SurpriseAnimation::Tilt => 24,     // Tilt and return
+            SurpriseAnimation::Blink => 8,    // Quick flash
+            SurpriseAnimation::Wiggle => 20,  // Shake back and forth
+            SurpriseAnimation::Pulse => 30,   // Slow pulse
+            SurpriseAnimation::Rainbow => 40, // Color sweep
+            SurpriseAnimation::Tilt => 24,    // Tilt and return
         }
     }
 }
@@ -173,13 +173,16 @@ impl TrayManager {
     pub fn update_usage(&self, session_percent: f64, weekly_percent: f64, provider_name: &str) {
         let tooltip = format!(
             "{}: Session {}% | Weekly {}%",
-            provider_name,
-            session_percent as i32,
-            weekly_percent as i32
+            provider_name, session_percent as i32, weekly_percent as i32
         );
         let _ = self.tray_icon.set_tooltip(Some(&tooltip));
 
-        if !self.should_update_usage(session_percent, weekly_percent, provider_name, IconOverlay::None) {
+        if !self.should_update_usage(
+            session_percent,
+            weekly_percent,
+            provider_name,
+            IconOverlay::None,
+        ) {
             return;
         }
 
@@ -188,7 +191,13 @@ impl TrayManager {
     }
 
     /// Update the tray icon with an overlay (error, stale, incident)
-    pub fn update_usage_with_overlay(&self, session_percent: f64, weekly_percent: f64, provider_name: &str, overlay: IconOverlay) {
+    pub fn update_usage_with_overlay(
+        &self,
+        session_percent: f64,
+        weekly_percent: f64,
+        provider_name: &str,
+        overlay: IconOverlay,
+    ) {
         let status_suffix = match overlay {
             IconOverlay::None => "",
             IconOverlay::Error => " (Error)",
@@ -199,10 +208,7 @@ impl TrayManager {
 
         let tooltip = format!(
             "{}: Session {}% | Weekly {}%{}",
-            provider_name,
-            session_percent as i32,
-            weekly_percent as i32,
-            status_suffix
+            provider_name, session_percent as i32, weekly_percent as i32, status_suffix
         );
         let _ = self.tray_icon.set_tooltip(Some(&tooltip));
 
@@ -225,16 +231,19 @@ impl TrayManager {
 
     /// Show stale data indicator
     #[allow(dead_code)]
-    pub fn show_stale(&self, session_percent: f64, weekly_percent: f64, provider_name: &str, age_minutes: u64) {
+    pub fn show_stale(
+        &self,
+        session_percent: f64,
+        weekly_percent: f64,
+        provider_name: &str,
+        age_minutes: u64,
+    ) {
         let icon = create_bar_icon(session_percent, weekly_percent, IconOverlay::Stale);
         let _ = self.tray_icon.set_icon(Some(icon));
 
         let tooltip = format!(
             "{}: Session {}% | Weekly {}% (data {}m old)",
-            provider_name,
-            session_percent as i32,
-            weekly_percent as i32,
-            age_minutes
+            provider_name, session_percent as i32, weekly_percent as i32, age_minutes
         );
         let _ = self.tray_icon.set_tooltip(Some(&tooltip));
     }
@@ -247,8 +256,7 @@ impl TrayManager {
 
         let tooltip = format!(
             "{}: Weekly quota exhausted | {:.0}% credits remaining",
-            provider_name,
-            credits_percent
+            provider_name, credits_percent
         );
         let _ = self.tray_icon.set_tooltip(Some(&tooltip));
     }
@@ -313,7 +321,13 @@ impl TrayManager {
     }
 
     /// Show a surprise animation frame
-    pub fn show_surprise(&self, animation: SurpriseAnimation, frame: u32, session_percent: f64, weekly_percent: f64) {
+    pub fn show_surprise(
+        &self,
+        animation: SurpriseAnimation,
+        frame: u32,
+        session_percent: f64,
+        weekly_percent: f64,
+    ) {
         let icon = create_surprise_icon(animation, frame, session_percent, weekly_percent);
         let _ = self.tray_icon.set_icon(Some(icon));
     }
@@ -337,7 +351,11 @@ impl TrayManager {
     }
 
     /// Update a single provider's menu item label with status prefix
-    pub fn update_provider_status(&self, provider_id: ProviderId, status_level: IndicatorStatusLevel) {
+    pub fn update_provider_status(
+        &self,
+        provider_id: ProviderId,
+        status_level: IndicatorStatusLevel,
+    ) {
         if let Some(check_item) = self.provider_menu_items.get(&provider_id) {
             let base_name = provider_id.display_name();
             let prefix = status_level.status_prefix();
@@ -376,7 +394,12 @@ impl TrayManager {
 }
 
 impl TrayManager {
-    fn usage_signature(session_percent: f64, weekly_percent: f64, provider_name: &str, overlay: IconOverlay) -> u64 {
+    fn usage_signature(
+        session_percent: f64,
+        weekly_percent: f64,
+        provider_name: &str,
+        overlay: IconOverlay,
+    ) -> u64 {
         let mut hasher = DefaultHasher::new();
         let session_tenths = (session_percent * 10.0).round() as i32;
         let weekly_tenths = (weekly_percent * 10.0).round() as i32;
@@ -387,8 +410,15 @@ impl TrayManager {
         hasher.finish()
     }
 
-    fn should_update_usage(&self, session_percent: f64, weekly_percent: f64, provider_name: &str, overlay: IconOverlay) -> bool {
-        let signature = Self::usage_signature(session_percent, weekly_percent, provider_name, overlay);
+    fn should_update_usage(
+        &self,
+        session_percent: f64,
+        weekly_percent: f64,
+        provider_name: &str,
+        overlay: IconOverlay,
+    ) -> bool {
+        let signature =
+            Self::usage_signature(session_percent, weekly_percent, provider_name, overlay);
         if self.last_usage_signature.get() == Some(signature) {
             return false;
         }
@@ -444,7 +474,9 @@ impl MultiTrayManager {
         // Remove icons for providers that are no longer enabled
         let enabled_set: std::collections::HashSet<_> = enabled_providers.iter().collect();
         self.provider_icons.retain(|id, _| enabled_set.contains(id));
-        self.provider_signatures.borrow_mut().retain(|id, _| enabled_set.contains(id));
+        self.provider_signatures
+            .borrow_mut()
+            .retain(|id, _| enabled_set.contains(id));
 
         // Add icons for newly enabled providers
         for provider_id in enabled_providers {
@@ -511,9 +543,19 @@ impl MultiTrayManager {
     }
 
     /// Update a specific provider's tray icon
-    pub fn update_provider(&self, provider_id: ProviderId, session_percent: f64, weekly_percent: f64) {
+    pub fn update_provider(
+        &self,
+        provider_id: ProviderId,
+        session_percent: f64,
+        weekly_percent: f64,
+    ) {
         if let Some(tray_icon) = self.provider_icons.get(&provider_id) {
-            let signature = TrayManager::usage_signature(session_percent, weekly_percent, provider_id.display_name(), IconOverlay::None);
+            let signature = TrayManager::usage_signature(
+                session_percent,
+                weekly_percent,
+                provider_id.display_name(),
+                IconOverlay::None,
+            );
             let mut sigs = self.provider_signatures.borrow_mut();
             if sigs.get(&provider_id) != Some(&signature) {
                 sigs.insert(provider_id, signature);
@@ -541,7 +583,12 @@ impl MultiTrayManager {
         overlay: IconOverlay,
     ) {
         if let Some(tray_icon) = self.provider_icons.get(&provider_id) {
-            let signature = TrayManager::usage_signature(session_percent, weekly_percent, provider_id.display_name(), overlay);
+            let signature = TrayManager::usage_signature(
+                session_percent,
+                weekly_percent,
+                provider_id.display_name(),
+                overlay,
+            );
             let mut sigs = self.provider_signatures.borrow_mut();
             if sigs.get(&provider_id) != Some(&signature) {
                 sigs.insert(provider_id, signature);
@@ -570,14 +617,22 @@ impl MultiTrayManager {
     }
 
     /// Show loading state for a specific provider
-    pub fn show_provider_loading(&self, provider_id: ProviderId, pattern: LoadingPattern, phase: f64) {
+    pub fn show_provider_loading(
+        &self,
+        provider_id: ProviderId,
+        pattern: LoadingPattern,
+        phase: f64,
+    ) {
         if let Some(tray_icon) = self.provider_icons.get(&provider_id) {
             let primary = pattern.value(phase);
             let secondary = pattern.value(phase + pattern.secondary_offset());
 
             let icon = create_loading_icon(primary, secondary);
             let _ = tray_icon.set_icon(Some(icon));
-            let _ = tray_icon.set_tooltip(Some(&format!("{} - Loading...", provider_id.display_name())));
+            let _ = tray_icon.set_tooltip(Some(&format!(
+                "{} - Loading...",
+                provider_id.display_name()
+            )));
         }
     }
 
@@ -662,7 +717,9 @@ impl UnifiedTrayManager {
     /// Update usage for a single provider display
     pub fn update_usage(&self, session_percent: f64, weekly_percent: f64, tooltip_name: &str) {
         match self {
-            UnifiedTrayManager::Single(tm) => tm.update_usage(session_percent, weekly_percent, tooltip_name),
+            UnifiedTrayManager::Single(tm) => {
+                tm.update_usage(session_percent, weekly_percent, tooltip_name)
+            }
             UnifiedTrayManager::PerProvider(_) => {
                 // Per-provider mode doesn't use single update
             }
@@ -721,7 +778,11 @@ fn create_bar_icon(session_percent: f64, weekly_percent: f64, overlay: IconOverl
             }
             IconOverlay::Stale => {
                 // Dim colors by 40%
-                ((r as f32 * 0.6) as u8, (g as f32 * 0.6) as u8, (b as f32 * 0.6) as u8)
+                (
+                    (r as f32 * 0.6) as u8,
+                    (g as f32 * 0.6) as u8,
+                    (b as f32 * 0.6) as u8,
+                )
             }
             _ => (r, g, b),
         }
@@ -1009,7 +1070,12 @@ fn create_loading_icon(primary_percent: f64, secondary_percent: f64) -> Icon {
 }
 
 /// Create a surprise animation icon frame
-fn create_surprise_icon(animation: SurpriseAnimation, frame: u32, session_percent: f64, weekly_percent: f64) -> Icon {
+fn create_surprise_icon(
+    animation: SurpriseAnimation,
+    frame: u32,
+    session_percent: f64,
+    weekly_percent: f64,
+) -> Icon {
     let mut img: RgbaImage = ImageBuffer::new(ICON_SIZE, ICON_SIZE);
 
     // Fill with transparent background
@@ -1040,36 +1106,44 @@ fn create_surprise_icon(animation: SurpriseAnimation, frame: u32, session_percen
         SurpriseAnimation::Blink => {
             // Flash to white and back
             let flash = if progress < 0.5 {
-                progress * 2.0  // Fade to white
+                progress * 2.0 // Fade to white
             } else {
-                (1.0 - progress) * 2.0  // Fade back
+                (1.0 - progress) * 2.0 // Fade back
             };
-            let blend = 1.0 + flash * 0.8;  // Boost brightness
+            let blend = 1.0 + flash * 0.8; // Boost brightness
             ((blend, blend, blend), 0, 0)
         }
         SurpriseAnimation::Wiggle => {
             // Shake left and right
-            let shake = (progress * std::f64::consts::PI * 6.0).sin();  // 3 full oscillations
-            let offset = (shake * 2.0) as i32;  // +/- 2 pixels
+            let shake = (progress * std::f64::consts::PI * 6.0).sin(); // 3 full oscillations
+            let offset = (shake * 2.0) as i32; // +/- 2 pixels
             ((1.0, 1.0, 1.0), offset, 0)
         }
         SurpriseAnimation::Pulse => {
             // Gentle pulse - grow and shrink brightness
-            let pulse = (progress * std::f64::consts::PI * 2.0).sin();  // One full cycle
-            let intensity = 1.0 + pulse * 0.3;  // +/- 30% brightness
+            let pulse = (progress * std::f64::consts::PI * 2.0).sin(); // One full cycle
+            let intensity = 1.0 + pulse * 0.3; // +/- 30% brightness
             ((intensity, intensity, intensity), 0, 0)
         }
         SurpriseAnimation::Rainbow => {
             // Sweep through rainbow colors
             let hue = progress * 360.0;
             let (r, g, b) = hsv_to_rgb(hue, 0.8, 1.0);
-            ((r as f64 / 255.0 * 2.0, g as f64 / 255.0 * 2.0, b as f64 / 255.0 * 2.0), 0, 0)
+            (
+                (
+                    r as f64 / 255.0 * 2.0,
+                    g as f64 / 255.0 * 2.0,
+                    b as f64 / 255.0 * 2.0,
+                ),
+                0,
+                0,
+            )
         }
         SurpriseAnimation::Tilt => {
             // Tilt effect - slight diagonal shift that returns
-            let tilt = (progress * std::f64::consts::PI).sin();  // 0 -> 1 -> 0
-            let x_off = (tilt * 2.0) as i32;  // +2 pixels at peak
-            let y_off = (tilt * 1.0) as i32;  // +1 pixel at peak (slight diagonal)
+            let tilt = (progress * std::f64::consts::PI).sin(); // 0 -> 1 -> 0
+            let x_off = (tilt * 2.0) as i32; // +2 pixels at peak
+            let y_off = (tilt * 1.0) as i32; // +1 pixel at peak (slight diagonal)
             ((1.0, 1.0, 1.0), x_off, y_off)
         }
     };
@@ -1085,7 +1159,9 @@ fn create_surprise_icon(animation: SurpriseAnimation, frame: u32, session_percen
     // Track (gray)
     for y in 8..15 {
         for x in bar_left..bar_right {
-            let adjusted_x = (x as i32 + x_offset).max(bar_left as i32).min(bar_right as i32 - 1) as u32;
+            let adjusted_x = (x as i32 + x_offset)
+                .max(bar_left as i32)
+                .min(bar_right as i32 - 1) as u32;
             let adjusted_y = (y as i32 + y_offset).max(4).min(ICON_SIZE as i32 - 4) as u32;
             img.put_pixel(adjusted_x, adjusted_y, Rgba([80, 80, 90, 255]));
         }
@@ -1093,7 +1169,9 @@ fn create_surprise_icon(animation: SurpriseAnimation, frame: u32, session_percen
     // Fill (colored with animation)
     for y in 8..15 {
         for x in bar_left..(bar_left + session_fill).min(bar_right) {
-            let adjusted_x = (x as i32 + x_offset).max(bar_left as i32).min(bar_right as i32 - 1) as u32;
+            let adjusted_x = (x as i32 + x_offset)
+                .max(bar_left as i32)
+                .min(bar_right as i32 - 1) as u32;
             let adjusted_y = (y as i32 + y_offset).max(4).min(ICON_SIZE as i32 - 4) as u32;
             img.put_pixel(adjusted_x, adjusted_y, Rgba([sr, sg, sb, 255]));
         }
@@ -1110,7 +1188,9 @@ fn create_surprise_icon(animation: SurpriseAnimation, frame: u32, session_percen
     // Track (gray)
     for y in 18..23 {
         for x in bar_left..bar_right {
-            let adjusted_x = (x as i32 + x_offset).max(bar_left as i32).min(bar_right as i32 - 1) as u32;
+            let adjusted_x = (x as i32 + x_offset)
+                .max(bar_left as i32)
+                .min(bar_right as i32 - 1) as u32;
             let adjusted_y = (y as i32 + y_offset).max(4).min(ICON_SIZE as i32 - 4) as u32;
             img.put_pixel(adjusted_x, adjusted_y, Rgba([80, 80, 90, 255]));
         }
@@ -1118,7 +1198,9 @@ fn create_surprise_icon(animation: SurpriseAnimation, frame: u32, session_percen
     // Fill (colored with animation)
     for y in 18..23 {
         for x in bar_left..(bar_left + weekly_fill).min(bar_right) {
-            let adjusted_x = (x as i32 + x_offset).max(bar_left as i32).min(bar_right as i32 - 1) as u32;
+            let adjusted_x = (x as i32 + x_offset)
+                .max(bar_left as i32)
+                .min(bar_right as i32 - 1) as u32;
             let adjusted_y = (y as i32 + y_offset).max(4).min(ICON_SIZE as i32 - 4) as u32;
             img.put_pixel(adjusted_x, adjusted_y, Rgba([wr, wg, wb, 255]));
         }
@@ -1164,7 +1246,15 @@ fn create_morph_icon(progress: f64, session_percent: f64, weekly_percent: f64) -
     let seg1_len = lerp(seg1_start_len, seg1_end_len, t);
     let seg1_thickness = lerp(3.5, 7.0, t);
 
-    draw_rotated_ribbon(&mut img, center_x, seg1_y, seg1_len, seg1_thickness, seg1_angle, ribbon_color);
+    draw_rotated_ribbon(
+        &mut img,
+        center_x,
+        seg1_y,
+        seg1_len,
+        seg1_thickness,
+        seg1_angle,
+        ribbon_color,
+    );
 
     // Segment 2: Lower ribbon -> bottom bar
     let seg2_start_y = center_y - 2.0;
@@ -1178,7 +1268,15 @@ fn create_morph_icon(progress: f64, session_percent: f64, weekly_percent: f64) -
     let seg2_len = lerp(seg2_start_len, seg2_end_len, t);
     let seg2_thickness = lerp(3.5, 5.0, t);
 
-    draw_rotated_ribbon(&mut img, center_x, seg2_y, seg2_len, seg2_thickness, seg2_angle, ribbon_color);
+    draw_rotated_ribbon(
+        &mut img,
+        center_x,
+        seg2_y,
+        seg2_len,
+        seg2_thickness,
+        seg2_angle,
+        ribbon_color,
+    );
 
     // Segment 3: Side ribbon that fades out
     let seg3_alpha = ((1.0 - t * 1.1).max(0.0) * 255.0) as u8;
@@ -1188,7 +1286,15 @@ fn create_morph_icon(progress: f64, session_percent: f64, weekly_percent: f64) -
         let seg3_len = lerp(16.0, 8.0, t);
         let seg3_thickness = lerp(3.5, 1.8, t);
         let fading_color = Rgba([200, 200, 210, seg3_alpha]);
-        draw_rotated_ribbon(&mut img, center_x, seg3_y, seg3_len, seg3_thickness, seg3_angle, fading_color);
+        draw_rotated_ribbon(
+            &mut img,
+            center_x,
+            seg3_y,
+            seg3_len,
+            seg3_thickness,
+            seg3_angle,
+            fading_color,
+        );
     }
 
     // Cross-fade in colored fill bars near the end of the morph
@@ -1235,7 +1341,15 @@ fn create_morph_icon(progress: f64, session_percent: f64, weekly_percent: f64) -
 }
 
 /// Draw a rotated ribbon/rounded rectangle
-fn draw_rotated_ribbon(img: &mut RgbaImage, cx: f32, cy: f32, length: f32, thickness: f32, angle_deg: f32, color: Rgba<u8>) {
+fn draw_rotated_ribbon(
+    img: &mut RgbaImage,
+    cx: f32,
+    cy: f32,
+    length: f32,
+    thickness: f32,
+    angle_deg: f32,
+    color: Rgba<u8>,
+) {
     let angle_rad = angle_deg.to_radians();
     let cos_a = angle_rad.cos();
     let sin_a = angle_rad.sin();
@@ -1264,7 +1378,11 @@ fn draw_rotated_ribbon(img: &mut RgbaImage, cx: f32, cy: f32, length: f32, thick
                 let final_x = (cx + dx as f32) as i32;
                 let final_y = (cy + dy as f32) as i32;
 
-                if final_x >= 0 && final_x < ICON_SIZE as i32 && final_y >= 0 && final_y < ICON_SIZE as i32 {
+                if final_x >= 0
+                    && final_x < ICON_SIZE as i32
+                    && final_y >= 0
+                    && final_y < ICON_SIZE as i32
+                {
                     let existing = img.get_pixel(final_x as u32, final_y as u32);
                     let blended = blend_alpha(existing, &color);
                     img.put_pixel(final_x as u32, final_y as u32, blended);
@@ -1358,31 +1476,61 @@ mod tests {
 
         assert_eq!(sig1, sig1_repeat, "same inputs should yield same signature");
         assert_ne!(sig1, sig_overlay, "overlay changes should change signature");
-        assert_ne!(sig1, sig_provider, "provider name changes should change signature");
-        assert_ne!(sig1, sig_values, "usage values changes should change signature");
+        assert_ne!(
+            sig1, sig_provider,
+            "provider name changes should change signature"
+        );
+        assert_ne!(
+            sig1, sig_values,
+            "usage values changes should change signature"
+        );
     }
 
     #[test]
     fn test_merged_signature_tracks_list_content() {
         let providers_a = vec![
-            ProviderUsage { name: "Claude".into(), session_percent: 10.0, weekly_percent: 20.0 },
-            ProviderUsage { name: "Codex".into(), session_percent: 30.0, weekly_percent: 40.0 },
+            ProviderUsage {
+                name: "Claude".into(),
+                session_percent: 10.0,
+                weekly_percent: 20.0,
+            },
+            ProviderUsage {
+                name: "Codex".into(),
+                session_percent: 30.0,
+                weekly_percent: 40.0,
+            },
         ];
         let providers_b = vec![
-            ProviderUsage { name: "Claude".into(), session_percent: 10.0, weekly_percent: 20.0 },
-            ProviderUsage { name: "Codex".into(), session_percent: 30.0, weekly_percent: 50.0 },
+            ProviderUsage {
+                name: "Claude".into(),
+                session_percent: 10.0,
+                weekly_percent: 20.0,
+            },
+            ProviderUsage {
+                name: "Codex".into(),
+                session_percent: 30.0,
+                weekly_percent: 50.0,
+            },
         ];
-        let providers_c = vec![
-            ProviderUsage { name: "Claude".into(), session_percent: 10.0, weekly_percent: 20.0 },
-        ];
+        let providers_c = vec![ProviderUsage {
+            name: "Claude".into(),
+            session_percent: 10.0,
+            weekly_percent: 20.0,
+        }];
 
         let sig_a1 = TrayManager::merged_signature(&providers_a);
         let sig_a2 = TrayManager::merged_signature(&providers_a);
         let sig_b = TrayManager::merged_signature(&providers_b);
         let sig_c = TrayManager::merged_signature(&providers_c);
 
-        assert_eq!(sig_a1, sig_a2, "same provider list should yield stable signature");
+        assert_eq!(
+            sig_a1, sig_a2,
+            "same provider list should yield stable signature"
+        );
         assert_ne!(sig_a1, sig_b, "value change should alter signature");
-        assert_ne!(sig_a1, sig_c, "length/content change should alter signature");
+        assert_ne!(
+            sig_a1, sig_c,
+            "length/content change should alter signature"
+        );
     }
 }

--- a/rust/src/tray/menu_invalidation.rs
+++ b/rust/src/tray/menu_invalidation.rs
@@ -47,10 +47,7 @@ impl MenuInvalidationTracker {
         if !open.is_empty() {
             // Defer invalidation until menus close
             self.pending_invalidation.fetch_add(1, Ordering::SeqCst);
-            tracing::debug!(
-                "Menu invalidation deferred (open menus: {})",
-                open.len()
-            );
+            tracing::debug!("Menu invalidation deferred (open menus: {})", open.len());
             return false;
         }
         drop(open);
@@ -261,7 +258,11 @@ impl StalenessChecker {
 
     /// Get time since last update
     pub fn time_since_update(&self, key: &str) -> Option<Duration> {
-        self.update_times.read().unwrap().get(key).map(|t| t.elapsed())
+        self.update_times
+            .read()
+            .unwrap()
+            .get(key)
+            .map(|t| t.elapsed())
     }
 
     /// Clear all tracked times

--- a/rust/src/tray/mod.rs
+++ b/rust/src/tray/mod.rs
@@ -14,10 +14,12 @@ pub mod weekly_indicator;
 pub use blink::{BlinkConfig, BlinkOutput, BlinkState, EyeBlinkSystem, MotionEffect};
 pub use icon::LoadingPattern;
 pub use icon_twist::{Decoration, DecorationKind, EyeShape, IconFeatures, IconTwist};
-pub use manager::{IconOverlay, MultiTrayManager, ProviderUsage, SurpriseAnimation, TrayManager, TrayMenuAction, UnifiedTrayManager};
+pub use manager::{
+    IconOverlay, MultiTrayManager, ProviderUsage, SurpriseAnimation, TrayManager, TrayMenuAction,
+    UnifiedTrayManager,
+};
 pub use menu_invalidation::{
-    MenuDirtyState, MenuInvalidationTracker, MenuSection, StalenessChecker,
-    MENU_OPEN_REFRESH_DELAY,
+    MenuDirtyState, MenuInvalidationTracker, MenuSection, StalenessChecker, MENU_OPEN_REFRESH_DELAY,
 };
 pub use weekly_indicator::{
     calculate_weekly_remaining, UsageDisplayMode, WeeklyIndicatorColors, WeeklyIndicatorConfig,

--- a/rust/src/tray/weekly_indicator.rs
+++ b/rust/src/tray/weekly_indicator.rs
@@ -85,27 +85,27 @@ impl WeeklyIndicatorColors {
     /// Get the brand color for a provider
     fn provider_color(provider: ProviderId) -> (u8, u8, u8, u8) {
         match provider {
-            ProviderId::Codex => (0, 200, 83, 255),      // OpenAI green
-            ProviderId::Claude => (217, 119, 87, 255),   // Claude terracotta
-            ProviderId::Cursor => (59, 130, 246, 255),   // Cursor blue
-            ProviderId::Factory => (139, 92, 246, 255),  // Factory purple
-            ProviderId::Gemini => (66, 133, 244, 255),   // Google blue
+            ProviderId::Codex => (0, 200, 83, 255),     // OpenAI green
+            ProviderId::Claude => (217, 119, 87, 255),  // Claude terracotta
+            ProviderId::Cursor => (59, 130, 246, 255),  // Cursor blue
+            ProviderId::Factory => (139, 92, 246, 255), // Factory purple
+            ProviderId::Gemini => (66, 133, 244, 255),  // Google blue
             ProviderId::Antigravity => (156, 39, 176, 255), // Purple
-            ProviderId::Copilot => (36, 41, 47, 255),    // GitHub dark
-            ProviderId::Zai => (255, 107, 0, 255),       // Zai orange
-            ProviderId::MiniMax => (255, 193, 7, 255),   // Yellow
-            ProviderId::Kilo => (242, 112, 39, 255),     // Kilo orange
-            ProviderId::Kiro => (255, 153, 0, 255),      // AWS orange
+            ProviderId::Copilot => (36, 41, 47, 255),   // GitHub dark
+            ProviderId::Zai => (255, 107, 0, 255),      // Zai orange
+            ProviderId::MiniMax => (255, 193, 7, 255),  // Yellow
+            ProviderId::Kilo => (242, 112, 39, 255),    // Kilo orange
+            ProviderId::Kiro => (255, 153, 0, 255),     // AWS orange
             ProviderId::VertexAI => (66, 133, 244, 255), // Google blue
-            ProviderId::Augment => (46, 125, 50, 255),   // Green
+            ProviderId::Augment => (46, 125, 50, 255),  // Green
             ProviderId::OpenCode => (99, 102, 241, 255), // Indigo
-            ProviderId::Kimi => (255, 87, 34, 255),      // Deep orange
-            ProviderId::KimiK2 => (255, 87, 34, 255),    // Deep orange
-            ProviderId::Amp => (233, 30, 99, 255),       // Pink
+            ProviderId::Kimi => (255, 87, 34, 255),     // Deep orange
+            ProviderId::KimiK2 => (255, 87, 34, 255),   // Deep orange
+            ProviderId::Amp => (233, 30, 99, 255),      // Pink
             ProviderId::Synthetic => (158, 158, 158, 255), // Gray
-            ProviderId::JetBrains => (255, 128, 0, 255),  // JetBrains orange
-            ProviderId::Warp => (1, 217, 166, 255),       // Warp teal
-            ProviderId::Ollama => (255, 255, 255, 255),    // Ollama white
+            ProviderId::JetBrains => (255, 128, 0, 255), // JetBrains orange
+            ProviderId::Warp => (1, 217, 166, 255),     // Warp teal
+            ProviderId::Ollama => (255, 255, 255, 255), // Ollama white
             ProviderId::OpenRouter => (110, 65, 226, 255), // OpenRouter purple
         }
     }
@@ -235,8 +235,7 @@ mod tests {
         let config = config.with_selected(true);
         assert!(!config.should_draw());
 
-        let config = WeeklyIndicatorConfig::new(ProviderId::Claude, 50.0)
-            .with_visibility(false);
+        let config = WeeklyIndicatorConfig::new(ProviderId::Claude, 50.0).with_visibility(false);
         assert!(!config.should_draw());
     }
 
@@ -264,10 +263,7 @@ mod tests {
     #[test]
     fn test_draw_data_creation() {
         let config = WeeklyIndicatorConfig::new(ProviderId::Claude, 50.0);
-        let draw_data = WeeklyIndicatorDrawData::from_config(
-            &config,
-            10, 20, 100, 40
-        );
+        let draw_data = WeeklyIndicatorDrawData::from_config(&config, 10, 20, 100, 40);
 
         assert!(draw_data.is_some());
         let data = draw_data.unwrap();

--- a/rust/src/updater.rs
+++ b/rust/src/updater.rs
@@ -1,11 +1,11 @@
 //! Auto-update checker for CodexBar
 //! Checks GitHub releases for new versions and handles background downloads
 
+use crate::settings::UpdateChannel;
 use serde::Deserialize;
 use std::path::PathBuf;
 use std::sync::Arc;
 use tokio::sync::watch;
-use crate::settings::UpdateChannel;
 
 const GITHUB_REPO: &str = "Finesssee/Win-CodexBar";
 const CURRENT_VERSION: &str = env!("CARGO_PKG_VERSION");
@@ -77,10 +77,7 @@ pub async fn check_for_updates_with_channel(channel: UpdateChannel) -> Option<Up
     let url = match channel {
         UpdateChannel::Beta => {
             // For beta, we need to check all releases and find the latest (including pre-releases)
-            format!(
-                "https://api.github.com/repos/{}/releases",
-                GITHUB_REPO
-            )
+            format!("https://api.github.com/repos/{}/releases", GITHUB_REPO)
         }
         UpdateChannel::Stable => {
             // For stable, use the /latest endpoint which excludes pre-releases
@@ -149,10 +146,7 @@ pub async fn check_for_updates_with_channel(channel: UpdateChannel) -> Option<Up
 /// Compare semantic versions, returns true if remote is newer
 fn is_newer_version(remote: &str, current: &str) -> bool {
     let parse_version = |v: &str| -> (u32, u32, u32) {
-        let parts: Vec<u32> = v
-            .split('.')
-            .filter_map(|p| p.parse().ok())
-            .collect();
+        let parts: Vec<u32> = v.split('.').filter_map(|p| p.parse().ok()).collect();
         (
             parts.first().copied().unwrap_or(0),
             parts.get(1).copied().unwrap_or(0),
@@ -185,15 +179,16 @@ pub async fn download_update(
     update_info: &UpdateInfo,
     progress_tx: watch::Sender<UpdateState>,
 ) -> Result<PathBuf, String> {
-    let download_dir = get_download_dir()
-        .ok_or_else(|| "Could not determine download directory".to_string())?;
+    let download_dir =
+        get_download_dir().ok_or_else(|| "Could not determine download directory".to_string())?;
 
     // Create download directory if it doesn't exist
     std::fs::create_dir_all(&download_dir)
         .map_err(|e| format!("Failed to create download directory: {}", e))?;
 
     // Extract filename from URL or use default
-    let filename = update_info.download_url
+    let filename = update_info
+        .download_url
         .split('/')
         .last()
         .unwrap_or("CodexBar-Setup.exe")
@@ -214,7 +209,10 @@ pub async fn download_update(
         .map_err(|e| format!("Failed to start download: {}", e))?;
 
     if !response.status().is_success() {
-        return Err(format!("Download failed with status: {}", response.status()));
+        return Err(format!(
+            "Download failed with status: {}",
+            response.status()
+        ));
     }
 
     let total_size = response.content_length().unwrap_or(0);
@@ -269,7 +267,7 @@ async fn verify_download_hash(
     download_url: &str,
     file_path: &PathBuf,
 ) -> Result<(), String> {
-    use sha2::{Sha256, Digest};
+    use sha2::{Digest, Sha256};
 
     let hash_url = format!("{}.sha256", download_url);
 
@@ -301,7 +299,10 @@ async fn verify_download_hash(
         .to_lowercase();
 
     if expected.len() != 64 {
-        return Err(format!("Invalid SHA256 hash length: {} chars", expected.len()));
+        return Err(format!(
+            "Invalid SHA256 hash length: {} chars",
+            expected.len()
+        ));
     }
 
     let file_bytes = tokio::fs::read(file_path)
@@ -331,7 +332,10 @@ async fn verify_download_hash(
 #[allow(dead_code)]
 pub fn start_background_download(
     update_info: UpdateInfo,
-) -> (Arc<watch::Receiver<UpdateState>>, std::thread::JoinHandle<()>) {
+) -> (
+    Arc<watch::Receiver<UpdateState>>,
+    std::thread::JoinHandle<()>,
+) {
     let (tx, rx) = watch::channel(UpdateState::Available);
     let rx = Arc::new(rx);
 


### PR DESCRIPTION
The app was dark-mode only. 
This adds runtime theme switching with system theme detection on Windows.
## After
### Light Mode
<img width="1726" height="1210" alt="image" src="https://github.com/user-attachments/assets/259d0a95-24c9-4e1f-a8e8-8474a151f753" />

### Dark Mode
<img width="1720" height="1207" alt="image" src="https://github.com/user-attachments/assets/1b3a1a25-e32a-4faf-885a-c9fbf3ccfde8" />
