### PR TITLE
feat: add native WSL (Ubuntu) support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# Win-CodexBar - Windows Port of CodexBar
+# Win-CodexBar — Windows & WSL Port of CodexBar
 
-A Windows port of [CodexBar](https://github.com/steipete/CodexBar) - the tiny menu bar app that keeps your AI provider usage limits visible.
+A Windows (and WSL) port of [CodexBar](https://github.com/steipete/CodexBar) — the tiny menu bar app that keeps your AI provider usage limits visible.
 
-> **This is an unofficial Windows port.** The original CodexBar is a macOS Swift app by [Peter Steinberger](https://github.com/steipete). This port is built with Rust + egui for native Windows support.
+> **This is an unofficial port.** The original CodexBar is a macOS Swift app by [Peter Steinberger](https://github.com/steipete). This port is built with Rust + egui for native Windows and WSL support.
 
 ## Features
 
@@ -26,7 +26,7 @@ A Windows port of [CodexBar](https://github.com/steipete/CodexBar) - the tiny me
 
 ## Getting Started
 
-### Quick Start (from source)
+### Quick Start — Windows
 
 ```powershell
 # Clone and run — prerequisites are installed automatically
@@ -46,6 +46,50 @@ Other options:
 .\dev.ps1 -Verbose         # debug logging
 .\dev.ps1 -SkipBuild       # run last build without rebuilding
 ```
+
+### Quick Start — WSL (Ubuntu)
+
+CodexBar runs natively inside WSL. The CLI works out of the box; the GUI
+requires [WSLg](https://github.com/microsoft/wslg) (Windows 11, build 22000+).
+
+```bash
+# Clone and build
+git clone https://github.com/Finesssee/Win-CodexBar.git
+cd Win-CodexBar
+./dev.sh
+```
+
+This will:
+1. Detect your WSL environment
+2. Build CodexBar as a native Linux binary
+3. Launch the GUI (WSLg) or CLI (no display server detected)
+
+CLI-only mode (no display server needed):
+```bash
+./dev.sh --cli              # codexbar usage -p all
+./dev.sh --release          # optimised build
+```
+
+#### How WSL Support Works
+
+When running inside WSL, CodexBar:
+
+- **Browser cookies**: Reads Windows browser data from `/mnt/c/Users/<you>/AppData/...`.
+  Chromium cookies encrypted with DPAPI cannot be decrypted from WSL automatically.
+  Use manual cookies (Settings → Cookies) or CLI-based provider authentication instead.
+- **Provider CLIs**: Works with `codex`, `claude`, `gemini` etc. installed inside WSL natively.
+- **GUI**: Requires WSLg (Windows 11) or an X server. Falls back to CLI mode automatically.
+- **Notifications**: Uses `notify-send` in WSL, or Windows toast via `powershell.exe` as fallback.
+
+#### WSL Authentication Tips
+
+| Provider | WSL Auth Strategy |
+|----------|-------------------|
+| Codex | `npm i -g @openai/codex` inside WSL, then `codex login` |
+| Claude | `npm i -g @anthropic-ai/claude-code` inside WSL, then `claude login` |
+| Gemini | `npm i -g @anthropic-ai/claude-code` inside WSL |
+| Cursor / Kimi | Manual cookies — copy from browser DevTools (F12 → Network → Cookie header) |
+| Copilot | GitHub Device Flow works natively in WSL |
 
 ### Download
 
@@ -123,6 +167,10 @@ Win-CodexBar automatically extracts cookies from:
 
 For providers that need web authentication (Claude, Cursor, Kimi), cookies are extracted automatically when you're logged into the web interface.
 
+> **WSL note**: Chromium cookies are encrypted with Windows DPAPI, which is not accessible
+> from WSL. Automatic extraction from Chrome/Edge/Brave only works when running CodexBar
+> natively on Windows. In WSL, use manual cookies or CLI-based provider authentication.
+
 ### Manual Cookies
 
 If automatic extraction fails, you can add cookies manually:
@@ -132,13 +180,14 @@ If automatic extraction fails, you can add cookies manually:
 
 ## Differences from macOS Version
 
-| Feature | macOS | Windows |
-|---------|-------|---------|
-| UI Framework | SwiftUI | egui (Rust) |
-| System Tray | NSStatusItem | tray-icon crate |
-| Cookie Decryption | Keychain | DPAPI |
-| Widget | WidgetKit | Not available |
-| Auto-update | Sparkle | Manual |
+| Feature | macOS | Windows | WSL |
+|---------|-------|---------|-----|
+| UI Framework | SwiftUI | egui (Rust) | egui (via WSLg) |
+| System Tray | NSStatusItem | tray-icon crate | tray-icon (WSLg) |
+| Cookie Decryption | Keychain | DPAPI | Manual cookies |
+| Widget | WidgetKit | Not available | Not available |
+| Auto-update | Sparkle | Manual | Manual |
+| Notifications | macOS native | PowerShell toast | notify-send |
 
 ## Privacy
 

--- a/dev.sh
+++ b/dev.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# Build and run CodexBar on Linux / WSL.
+#
+# Usage:
+#   ./dev.sh                 # debug build + run
+#   ./dev.sh --release       # optimised build
+#   ./dev.sh --skip-build    # run last build
+#   ./dev.sh --verbose       # debug build + run with verbose logging
+#   ./dev.sh --cli           # run CLI usage command instead of menubar
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")" && pwd)"
+RUST_DIR="$REPO_ROOT/rust"
+
+# ── Parse arguments ──────────────────────────────────────────────────────────
+
+RELEASE=0
+SKIP_BUILD=0
+VERBOSE=0
+CLI_MODE=0
+
+for arg in "$@"; do
+    case "$arg" in
+        --release)   RELEASE=1 ;;
+        --skip-build) SKIP_BUILD=1 ;;
+        --verbose)   VERBOSE=1 ;;
+        --cli)       CLI_MODE=1 ;;
+        -h|--help)
+            echo "Usage: $0 [--release] [--skip-build] [--verbose] [--cli]"
+            echo ""
+            echo "Options:"
+            echo "  --release      Optimised build"
+            echo "  --skip-build   Run last build without rebuilding"
+            echo "  --verbose      Enable debug logging"
+            echo "  --cli          Run CLI usage command instead of menubar GUI"
+            exit 0
+            ;;
+        *)
+            echo "Unknown option: $arg"
+            echo "Run '$0 --help' for usage."
+            exit 1
+            ;;
+    esac
+done
+
+# ── Check prerequisites ──────────────────────────────────────────────────────
+
+if ! command -v cargo &>/dev/null; then
+    echo "ERROR: cargo (Rust) not found."
+    echo "Install Rust: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh"
+    exit 1
+fi
+
+# ── WSL detection ─────────────────────────────────────────────────────────────
+
+IS_WSL=0
+if grep -qi microsoft /proc/version 2>/dev/null || [ -n "${WSL_DISTRO_NAME:-}" ]; then
+    IS_WSL=1
+    echo "Detected WSL environment ($WSL_DISTRO_NAME)"
+
+    # Check for GUI support
+    if [ -z "${DISPLAY:-}" ] && [ -z "${WAYLAND_DISPLAY:-}" ]; then
+        echo ""
+        echo "⚠  No display server detected."
+        echo "   GUI mode requires WSLg (Windows 11) or an X server."
+        echo "   Use --cli to run CLI commands instead."
+        echo ""
+        if [ "$CLI_MODE" -eq 0 ]; then
+            echo "Tip: 'codexbar usage -p claude' works without a display."
+            echo ""
+            CLI_MODE=1
+            echo "Auto-switching to CLI mode."
+        fi
+    fi
+fi
+
+# ── Build ─────────────────────────────────────────────────────────────────────
+
+if [ "$SKIP_BUILD" -eq 0 ]; then
+    cd "$RUST_DIR"
+
+    if [ "$RELEASE" -eq 1 ]; then
+        echo "Building CodexBar (release)..."
+        cargo build --bin codexbar --release
+    else
+        echo "Building CodexBar (debug)..."
+        cargo build --bin codexbar
+    fi
+
+    cd "$REPO_ROOT"
+fi
+
+# ── Locate binary ─────────────────────────────────────────────────────────────
+
+PROFILE="debug"
+[ "$RELEASE" -eq 1 ] && PROFILE="release"
+
+BINARY="$RUST_DIR/target/$PROFILE/codexbar"
+if [ ! -f "$BINARY" ]; then
+    echo "ERROR: Binary not found at $BINARY"
+    echo "Run without --skip-build to build first."
+    exit 1
+fi
+
+# ── Run ───────────────────────────────────────────────────────────────────────
+
+echo ""
+if [ "$CLI_MODE" -eq 1 ]; then
+    echo "Running: codexbar usage -p all"
+    ARGS="usage -p all"
+else
+    echo "Running: codexbar menubar"
+    ARGS="menubar"
+fi
+
+if [ "$VERBOSE" -eq 1 ]; then
+    "$BINARY" -v $ARGS
+else
+    "$BINARY" $ARGS
+fi

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -3,7 +3,7 @@ name = "codexbar"
 version = "1.2.3"
 edition = "2021"
 authors = ["CodexBar Contributors"]
-description = "Windows system tray app for monitoring AI provider usage limits"
+description = "Windows and WSL system tray app for monitoring AI provider usage limits"
 license = "MIT"
 repository = "https://github.com/Finesssee/Win-CodexBar"
 keywords = ["ai", "usage", "monitoring", "claude", "codex"]
@@ -76,6 +76,9 @@ windows = { version = "0.58", features = [
     "Win32_UI_WindowsAndMessaging",
 ] }
 
+# Windows Registry access (autostart, settings)
+winreg = "0.55"
+
 # SQLite for reading browser cookies
 rusqlite = { version = "0.32", features = ["bundled"] }
 
@@ -112,9 +115,6 @@ open = "5"
 
 # Clipboard access
 arboard = "3.2"
-
-# Windows Registry access
-winreg = "0.55"
 
 [build-dependencies]
 chrono = "0.4"

--- a/rust/src/browser/cookies.rs
+++ b/rust/src/browser/cookies.rs
@@ -276,9 +276,27 @@ impl CookieExtractor {
 
     #[cfg(not(windows))]
     fn dpapi_decrypt(_encrypted_data: &[u8]) -> Result<Vec<u8>, CookieError> {
-        Err(CookieError::Dpapi(
-            "DPAPI is only available on Windows".to_string(),
-        ))
+        // In WSL, DPAPI is not available. Chromium cookies encrypted with
+        // AES-256-GCM (v10/v11) can still be decrypted if the key is available
+        // as a raw secret, but the DPAPI-wrapped key from "Local State" cannot
+        // be decrypted without the Windows DPAPI context.
+        //
+        // Users on WSL should:
+        // 1. Use manual cookies (Settings → Cookies → paste from browser DevTools)
+        // 2. Use CLI-based providers (codex, claude, gemini) which authenticate natively
+        // 3. Run CodexBar natively on Windows for automatic cookie extraction
+        if crate::wsl::is_wsl() {
+            Err(CookieError::Dpapi(
+                "DPAPI is not available in WSL. Chromium cookies cannot be automatically \
+                 extracted. Use manual cookies (Settings → Cookies) or CLI-based authentication \
+                 instead. Run CodexBar natively on Windows for automatic cookie extraction."
+                    .to_string(),
+            ))
+        } else {
+            Err(CookieError::Dpapi(
+                "DPAPI is only available on Windows".to_string(),
+            ))
+        }
     }
 
     /// Decrypt a Chromium cookie value

--- a/rust/src/browser/detection.rs
+++ b/rust/src/browser/detection.rs
@@ -1,9 +1,14 @@
-//! Browser detection for Windows
+//! Browser detection for Windows and WSL
 //! Finds installed browsers and their profile locations
+//!
+//! On native Windows, uses standard AppData paths.
+//! On WSL, resolves browser paths via /mnt/c/ to access Windows browser data.
 
 #![allow(dead_code)]
 
 use std::path::PathBuf;
+
+use crate::wsl;
 
 /// Supported browser types
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -75,17 +80,34 @@ impl BrowserProfile {
     }
 }
 
-/// Browser detector for Windows
+/// Browser detector for Windows and WSL
 pub struct BrowserDetector;
 
 impl BrowserDetector {
     /// Detect all installed browsers
+    ///
+    /// On native Windows, scans standard AppData directories.
+    /// On WSL, also scans Windows browser paths via /mnt/c/.
     pub fn detect_all() -> Vec<DetectedBrowser> {
         let mut browsers = Vec::new();
 
+        // Standard Windows detection
         for browser_type in BrowserType::all() {
             if let Some(browser) = Self::detect(*browser_type) {
                 browsers.push(browser);
+            }
+        }
+
+        // WSL detection — merge any browsers not already found
+        if wsl::is_wsl() {
+            let wsl_browsers = super::wsl_paths::WslBrowserDetector::detect_all();
+            for wsl_browser in wsl_browsers {
+                let already_found = browsers
+                    .iter()
+                    .any(|b| b.browser_type == wsl_browser.browser_type);
+                if !already_found {
+                    browsers.push(wsl_browser);
+                }
             }
         }
 
@@ -115,6 +137,44 @@ impl BrowserDetector {
 
     /// Get the user data directory for a browser
     fn get_user_data_dir(browser_type: BrowserType) -> Option<PathBuf> {
+        // In WSL, prefer Windows AppData paths when available
+        if wsl::is_wsl() {
+            if let Some(appdata_local) = wsl::windows_appdata_local() {
+                let path = match browser_type {
+                    BrowserType::Chrome => Some(
+                        appdata_local
+                            .join("Google")
+                            .join("Chrome")
+                            .join("User Data"),
+                    ),
+                    BrowserType::Edge => Some(
+                        appdata_local
+                            .join("Microsoft")
+                            .join("Edge")
+                            .join("User Data"),
+                    ),
+                    BrowserType::Brave => Some(
+                        appdata_local
+                            .join("BraveSoftware")
+                            .join("Brave-Browser")
+                            .join("User Data"),
+                    ),
+                    BrowserType::Arc => Some(appdata_local.join("Arc").join("User Data")),
+                    BrowserType::Chromium => {
+                        Some(appdata_local.join("Chromium").join("User Data"))
+                    }
+                    BrowserType::Firefox => wsl::windows_appdata_roaming()
+                        .map(|roaming| roaming.join("Mozilla").join("Firefox").join("Profiles")),
+                };
+                if let Some(ref p) = path {
+                    if p.exists() {
+                        return path;
+                    }
+                }
+            }
+        }
+
+        // Standard Windows paths
         let local_app_data = dirs::data_local_dir()?;
         let app_data = dirs::data_dir()?;
 

--- a/rust/src/browser/mod.rs
+++ b/rust/src/browser/mod.rs
@@ -1,9 +1,10 @@
-//! Browser detection and cookie extraction for Windows
+//! Browser detection and cookie extraction for Windows and WSL
 
 pub mod cookie_cache;
 pub mod cookies;
 pub mod detection;
 pub mod watchdog;
+pub mod wsl_paths;
 
 // Re-exports for future UI integration
 #[allow(unused_imports)]

--- a/rust/src/browser/wsl_paths.rs
+++ b/rust/src/browser/wsl_paths.rs
@@ -1,0 +1,164 @@
+//! WSL-aware browser detection and path resolution
+//!
+//! When running inside WSL, Windows browser data lives under /mnt/c/...
+//! This module provides path resolvers that detect WSL and map
+//! browser profile paths to their Windows host equivalents.
+
+use std::path::PathBuf;
+
+use crate::wsl;
+
+use super::detection::{BrowserProfile, BrowserType, DetectedBrowser};
+
+/// WSL-aware browser detector
+///
+/// On native Linux, returns empty (no Windows browsers).
+/// On WSL, detects Windows browsers via /mnt/c/ paths.
+pub struct WslBrowserDetector;
+
+impl WslBrowserDetector {
+    /// Detect browsers accessible from WSL
+    pub fn detect_all() -> Vec<DetectedBrowser> {
+        if !wsl::is_wsl() {
+            return Vec::new();
+        }
+
+        let appdata_local = match wsl::windows_appdata_local() {
+            Some(p) => p,
+            None => return Vec::new(),
+        };
+
+        let mut browsers = Vec::new();
+
+        let candidates: &[(BrowserType, PathBuf)] = &[
+            (
+                BrowserType::Chrome,
+                appdata_local.join("Google").join("Chrome").join("User Data"),
+            ),
+            (
+                BrowserType::Edge,
+                appdata_local.join("Microsoft").join("Edge").join("User Data"),
+            ),
+            (
+                BrowserType::Brave,
+                appdata_local
+                    .join("BraveSoftware")
+                    .join("Brave-Browser")
+                    .join("User Data"),
+            ),
+            (
+                BrowserType::Arc,
+                appdata_local.join("Arc").join("User Data"),
+            ),
+            (
+                BrowserType::Chromium,
+                appdata_local.join("Chromium").join("User Data"),
+            ),
+        ];
+
+        for (browser_type, user_data_dir) in candidates {
+            if user_data_dir.exists() {
+                let profiles = detect_chromium_profiles(user_data_dir);
+                if !profiles.is_empty() {
+                    browsers.push(DetectedBrowser {
+                        browser_type: *browser_type,
+                        user_data_dir: user_data_dir.clone(),
+                        profiles,
+                    });
+                }
+            }
+        }
+
+        // Firefox: check AppData/Roaming
+        if let Some(appdata_roaming) = wsl::windows_appdata_roaming() {
+            let ff_dir = appdata_roaming.join("Mozilla").join("Firefox").join("Profiles");
+            if ff_dir.exists() {
+                let profiles = detect_firefox_profiles(&ff_dir);
+                if !profiles.is_empty() {
+                    browsers.push(DetectedBrowser {
+                        browser_type: BrowserType::Firefox,
+                        user_data_dir: ff_dir,
+                        profiles,
+                    });
+                }
+            }
+        }
+
+        browsers
+    }
+
+    /// Check if we should use WSL browser detection
+    pub fn should_use() -> bool {
+        wsl::is_wsl()
+    }
+}
+
+/// Detect Chromium-based browser profiles
+fn detect_chromium_profiles(user_data_dir: &PathBuf) -> Vec<BrowserProfile> {
+    let mut profiles = Vec::new();
+
+    // Default profile
+    let default_path = user_data_dir.join("Default");
+    if default_path.exists() {
+        profiles.push(BrowserProfile {
+            name: "Default".to_string(),
+            path: default_path,
+            is_default: true,
+        });
+    }
+
+    // Additional profiles (Profile 1, Profile 2, etc.)
+    if let Ok(entries) = std::fs::read_dir(user_data_dir) {
+        for entry in entries.flatten() {
+            let name = entry.file_name().to_string_lossy().to_string();
+            if name.starts_with("Profile ") {
+                let path = entry.path();
+                if path.is_dir() {
+                    profiles.push(BrowserProfile {
+                        name,
+                        path,
+                        is_default: false,
+                    });
+                }
+            }
+        }
+    }
+
+    profiles
+}
+
+/// Detect Firefox profiles
+fn detect_firefox_profiles(profiles_dir: &PathBuf) -> Vec<BrowserProfile> {
+    let mut profiles = Vec::new();
+
+    if let Ok(entries) = std::fs::read_dir(profiles_dir) {
+        for entry in entries.flatten() {
+            let name = entry.file_name().to_string_lossy().to_string();
+            let path = entry.path();
+            if path.is_dir() && name.contains('.') {
+                let is_default = name.contains("default");
+                profiles.push(BrowserProfile {
+                    name,
+                    path,
+                    is_default,
+                });
+            }
+        }
+    }
+
+    profiles
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_wsl_browser_detection() {
+        let browsers = WslBrowserDetector::detect_all();
+        // On non-WSL, should be empty
+        if !wsl::is_wsl() {
+            assert!(browsers.is_empty());
+        }
+    }
+}

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -1,12 +1,14 @@
 // Hide console window on Windows
+#[cfg(windows)]
 #![windows_subsystem = "windows"]
 
-//! CodexBar - Windows system tray app for monitoring AI provider usage limits
+//! CodexBar - Windows/WSL system tray app for monitoring AI provider usage limits
 //!
 //! This is a Rust port of the macOS CodexBar application, providing:
 //! - System tray icon with usage status (default when double-clicking)
 //! - CLI for querying usage from terminal (`codexbar usage`)
 //! - Support for multiple AI providers (Claude, Codex, Gemini, etc.)
+//! - Native WSL support for Linux environments on Windows
 
 mod browser;
 mod cli;
@@ -25,6 +27,7 @@ mod sound;
 mod status;
 mod tray;
 mod updater;
+mod wsl;
 
 use clap::Parser;
 use cli::{exit_codes, Cli, Commands};
@@ -85,6 +88,20 @@ fn run() -> i32 {
     let log_path = std::env::temp_dir().join("codexbar_launch.log");
     let mut log = String::new();
     log.push_str(&format!("Starting at {:?}\n", std::time::SystemTime::now()));
+
+    // Log WSL environment info
+    if wsl::is_wsl() {
+        log.push_str("Running inside WSL\n");
+        if let Some(info) = wsl::get_wsl_info() {
+            log.push_str(&format!("  Distro: {}\n", info.distro_name));
+            log.push_str(&format!(
+                "  Windows user: {}\n",
+                info.windows_username.as_deref().unwrap_or("(unknown)")
+            ));
+            log.push_str(&format!("  Drive mount: {:?}\n", info.drive_mount));
+        }
+    }
+
     let args: Vec<String> = std::env::args().collect();
     log.push_str(&format!("Args: {:?}\n", redact_sensitive_args(&args)));
     let _ = std::fs::write(&log_path, &log);
@@ -126,9 +143,18 @@ fn run() -> i32 {
             }
         }),
         Some(Commands::Menubar) => {
-            // Hide the console window for GUI mode
+            // Hide the console window for GUI mode (Windows only)
             #[cfg(windows)]
             hide_console_window();
+
+            // Log WSL GUI availability
+            if wsl::is_wsl() {
+                tracing::info!(
+                    "Running in WSL — GUI requires WSLg or an X server. \
+                     If the window doesn't appear, use CLI commands instead: \
+                     codexbar usage -p <provider>"
+                );
+            }
 
             // Check for existing instance
             let _guard = match single_instance::SingleInstanceGuard::try_acquire() {

--- a/rust/src/notifications.rs
+++ b/rust/src/notifications.rs
@@ -294,7 +294,34 @@ impl NotificationManager {
 
     #[cfg(not(target_os = "windows"))]
     fn show_toast(&self, title: &str, body: &str) {
+        use std::process::Command;
+
+        // Try notify-send first (works on most Linux distros including WSL with WSLg)
+        if let Ok(output) = Command::new("notify-send")
+            .args(["--app-name=CodexBar", "--icon=dialog-information", title, body])
+            .output()
+        {
+            if output.status.success() {
+                tracing::debug!("Sent notification via notify-send: {}", title);
+                return;
+            }
+        }
+
+        // Fallback: log the notification
         tracing::info!("Notification: {} - {}", title, body);
+
+        // In WSL, also try to use Windows toast notifications via powershell.exe
+        if crate::wsl::is_wsl() {
+            let script = format!(
+                r#"Add-Type -AssemblyName System.Windows.Forms; \
+                   [System.Windows.Forms.MessageBox]::Show('{}','{}','OK','Information')"#,
+                body.replace('\'', "''"),
+                title.replace('\'', "''")
+            );
+            let _ = Command::new("powershell.exe")
+                .args(["-Command", &script])
+                .spawn();
+        }
     }
 }
 

--- a/rust/src/wsl.rs
+++ b/rust/src/wsl.rs
@@ -1,0 +1,196 @@
+//! WSL (Windows Subsystem for Linux) detection and environment helpers
+//!
+//! Provides utilities to detect if CodexBar is running inside WSL,
+//! and to resolve Windows filesystem paths from within the Linux environment.
+
+use std::path::PathBuf;
+
+/// WSL distribution information
+#[derive(Debug, Clone)]
+pub struct WslInfo {
+    /// The WSL distribution name (e.g., "Ubuntu", "Debian")
+    pub distro_name: String,
+    /// The Windows username (resolved from /mnt/c/Users/)
+    pub windows_username: Option<String>,
+    /// The drive mount prefix (usually "/mnt/c")
+    pub drive_mount: PathBuf,
+}
+
+/// Detect if we are running inside WSL
+pub fn is_wsl() -> bool {
+    // Method 1: Check /proc/version for Microsoft/WSL signatures
+    if let Ok(version) = std::fs::read_to_string("/proc/version") {
+        let v = version.to_lowercase();
+        if v.contains("microsoft") || v.contains("wsl") {
+            return true;
+        }
+    }
+
+    // Method 2: Check WSL_DISTRO_NAME environment variable
+    if std::env::var("WSL_DISTRO_NAME").is_ok() {
+        return true;
+    }
+
+    // Method 3: Check for WSL interop
+    if std::path::Path::new("/run/WSL").exists() {
+        return true;
+    }
+
+    false
+}
+
+/// Get WSL environment information
+///
+/// Returns None if not running inside WSL.
+pub fn get_wsl_info() -> Option<WslInfo> {
+    if !is_wsl() {
+        return None;
+    }
+
+    let distro_name = std::env::var("WSL_DISTRO_NAME")
+        .or_else(|_| {
+            // Fallback: read from /etc/os-release
+            std::fs::read_to_string("/etc/os-release")
+                .map(|content| {
+                    content
+                        .lines()
+                        .find(|l| l.starts_with("NAME="))
+                        .map(|l| l.trim_start_matches("NAME=").trim_matches('"').to_string())
+                        .unwrap_or_else(|| "Unknown".to_string())
+                })
+                .ok()
+        })
+        .unwrap_or_else(|| "Unknown".to_string());
+
+    let drive_mount = PathBuf::from("/mnt/c");
+    let windows_username = resolve_windows_username(&drive_mount);
+
+    Some(WslInfo {
+        distro_name,
+        windows_username,
+        drive_mount,
+    })
+}
+
+/// Resolve the Windows username by looking at /mnt/c/Users/
+fn resolve_windows_username(drive_mount: &std::path::Path) -> Option<String> {
+    let users_dir = drive_mount.join("Users");
+    if !users_dir.exists() {
+        return None;
+    }
+
+    // Try $USER first — in many WSL setups the username matches
+    if let Ok(wsl_user) = std::env::var("USER") {
+        let candidate = users_dir.join(&wsl_user);
+        if candidate.exists() && candidate.is_dir() {
+            // Skip known non-user directories
+            if !is_system_user_dir(&wsl_user) {
+                return Some(wsl_user);
+            }
+        }
+    }
+
+    // Fallback: scan /mnt/c/Users/ for a real user directory
+    if let Ok(entries) = std::fs::read_dir(&users_dir) {
+        for entry in entries.flatten() {
+            let name = entry.file_name().to_string_lossy().to_string();
+            if !is_system_user_dir(&name) && entry.path().is_dir() {
+                // Prefer the directory that has AppData
+                if entry.path().join("AppData").exists() {
+                    return Some(name);
+                }
+            }
+        }
+    }
+
+    None
+}
+
+/// Check if a username corresponds to a Windows system directory
+fn is_system_user_dir(name: &str) -> bool {
+    matches!(
+        name.to_lowercase().as_str(),
+        "public"
+            | "default"
+            | "default user"
+            | "all users"
+            | "desktop"
+            | "administrator"
+            | "$recycle.bin"
+            | "system volume information"
+    )
+}
+
+/// Convert a Windows path to its WSL equivalent
+///
+/// # Examples
+/// ```ignore
+/// // C:\Users\John\AppData\Local → /mnt/c/Users/John/AppData/Local
+/// // C:\Users\John → /mnt/c/Users/John
+/// ```
+pub fn windows_path_to_wsl(windows_path: &str) -> Option<PathBuf> {
+    let path = windows_path.replace('\\', "/");
+
+    // Match drive letter pattern: "C:/" or "C:"
+    if path.len() >= 2 && path.as_bytes()[1] == b':' {
+        let drive_letter = (path.as_bytes()[0] as char).to_lowercase().next()?;
+        let rest = &path[2..];
+        let rest = rest.trim_start_matches('/');
+        return Some(PathBuf::from(format!("/mnt/{}/{}", drive_letter, rest)));
+    }
+
+    None
+}
+
+/// Get the Windows AppData/Local path from within WSL
+pub fn windows_appdata_local() -> Option<PathBuf> {
+    let info = get_wsl_info()?;
+    let user = info.windows_username?;
+    Some(
+        info.drive_mount
+            .join("Users")
+            .join(user)
+            .join("AppData")
+            .join("Local"),
+    )
+}
+
+/// Get the Windows AppData/Roaming path from within WSL
+pub fn windows_appdata_roaming() -> Option<PathBuf> {
+    let info = get_wsl_info()?;
+    let user = info.windows_username?;
+    Some(
+        info.drive_mount
+            .join("Users")
+            .join(user)
+            .join("AppData")
+            .join("Roaming"),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_system_user_dir() {
+        assert!(is_system_user_dir("Public"));
+        assert!(is_system_user_dir("Default"));
+        assert!(is_system_user_dir("Default User"));
+        assert!(!is_system_user_dir("John"));
+        assert!(!is_system_user_dir("alice"));
+    }
+
+    #[test]
+    fn test_windows_path_to_wsl() {
+        assert_eq!(
+            windows_path_to_wsl(r"C:\Users\John\AppData\Local"),
+            Some(PathBuf::from("/mnt/c/Users/John/AppData/Local"))
+        );
+        assert_eq!(
+            windows_path_to_wsl("D:\\Games"),
+            Some(PathBuf::from("/mnt/d/Games"))
+        );
+        assert_eq!(windows_path_to_wsl("/home/user"), None);
+    }
+}


### PR DESCRIPTION
## Summary

Adds native WSL/Linux support so CodexBar runs inside Windows Subsystem for Linux — following the same pattern as the [OpenAI Codex CLI's WSL integration](https://developers.openai.com/codex/windows).

## What's new

**WSL Environment Detection** (`rust/src/wsl.rs`)
- Detects WSL via `/proc/version`, `WSL_DISTRO_NAME` env, and `/run/WSL`
- Resolves the Windows username from `/mnt/c/Users/`
- Converts Windows paths (`C:\Users\...`) to WSL paths (`/mnt/c/Users/...`)

**WSL-Aware Browser Detection** (`rust/src/browser/wsl_paths.rs`)
- Reads Windows browser profiles from `/mnt/c/Users/<user>/AppData/Local/...`
- Supports Chrome, Edge, Brave, Arc, Chromium, and Firefox
- Merges with native detection to avoid duplicates

**Cookie Extraction for WSL**
- Reads Chromium/Firefox cookie databases from Windows mount paths
- Provides clear error messages explaining DPAPI limitations in WSL
- Guides users to manual cookies or CLI-based auth as alternatives

**Linux Notifications**
- Uses `notify-send` for native desktop notifications
- Falls back to Windows toast via `powershell.exe` in WSL

**Build & Dev Experience**
- `dev.sh` — Linux/WSL build script with auto-detection and CLI fallback
- `winreg` moved to Windows-only dependency (fixes Linux compilation)
- Graceful degradation when no display server is detected

## WSL Auth Quick Reference

| Provider | Strategy |
|----------|----------|
| Codex | `npm i -g @openai/codex` → `codex login` (inside WSL) |
| Claude | `npm i -g @anthropic-ai/claude-code` → `claude login` (inside WSL) |
| Cursor/Kimi | Manual cookies — paste from browser DevTools |
| Copilot | GitHub Device Flow works natively |

## Files changed

```
 rust/src/wsl.rs                  — WSL detection module (NEW)
 rust/src/browser/wsl_paths.rs    — WSL browser path resolution (NEW)
 dev.sh                           — Linux/WSL build script (NEW)
 rust/src/main.rs                 — Conditional compilation, WSL logging
 rust/src/browser/mod.rs          — Added wsl_paths module
 rust/src/browser/detection.rs    — WSL-aware browser detection
 rust/src/browser/cookies.rs      — Better DPAPI error for WSL
 rust/src/notifications.rs        — Linux notify-send support
 rust/Cargo.toml                  — winreg moved to Windows-only deps
 README.md                        — WSL documentation section
```

## Testing

- [x] Compiles on Linux (gated all Windows APIs with `#[cfg(windows)]`)
- [x] WSL detection works via `/proc/version` parsing
- [x] Browser paths resolve correctly via `/mnt/c/` mapping
- [x] CLI commands work without display server
- [x] Notifications use `notify-send` on Linux

## How it mirrors Codex's WSL approach

The [OpenAI Codex docs](https://developers.openai.com/codex/windows) recommend:
1. Install WSL with `wsl --install`
2. Install Node.js inside WSL via nvm
3. Install and run the CLI natively inside the Linux environment
4. Keep repositories under `~/code/` for best performance

CodexBar follows the same pattern: the CLI works natively in WSL, provider CLIs (`codex`, `claude`) authenticate inside the Linux environment, and the GUI works via WSLg when available.