### PR TITLE
Add UI language switch and Claude usage fixes

### DIFF
--- a/dev.ps1
+++ b/dev.ps1
@@ -35,6 +35,20 @@ $ErrorActionPreference = 'Stop'
 $RepoRoot = $PSScriptRoot
 $RustDir = Join-Path $RepoRoot "rust"
 
+function Get-RustHostTriple {
+    if (-not (Get-Command rustc -ErrorAction SilentlyContinue)) {
+        return $null
+    }
+
+    $versionDetails = rustc -vV 2>$null
+    $hostLine = $versionDetails | Where-Object { $_ -like 'host:*' } | Select-Object -First 1
+    if (-not $hostLine) {
+        return $null
+    }
+
+    return ($hostLine -replace '^host:\s*', '').Trim()
+}
+
 # ── Ensure known tool paths are in current session PATH ─────────────────────
 
 $knownPaths = @("$env:USERPROFILE\.cargo\bin", "C:\mingw64\bin")
@@ -47,12 +61,14 @@ foreach ($p in $knownPaths) {
 # ── Check prerequisites ─────────────────────────────────────────────────────
 
 $hasCargo = [bool](Get-Command cargo -ErrorAction SilentlyContinue)
+$rustHostTriple = Get-RustHostTriple
+$needsDlltool = $rustHostTriple -like '*-windows-gnu'
 $hasDlltool = [bool](Get-Command dlltool -ErrorAction SilentlyContinue)
 
-if (-not $hasCargo -or -not $hasDlltool) {
+if (-not $hasCargo -or ($needsDlltool -and -not $hasDlltool)) {
     $missing = @()
     if (-not $hasCargo)   { $missing += "cargo (Rust)" }
-    if (-not $hasDlltool) { $missing += "dlltool (MinGW-w64)" }
+    if ($needsDlltool -and -not $hasDlltool) { $missing += "dlltool (MinGW-w64)" }
     Write-Host "Missing prerequisites: $($missing -join ', ')" -ForegroundColor Yellow
     Write-Host "Running setup script..." -ForegroundColor Cyan
     Write-Host ""
@@ -67,8 +83,10 @@ if (-not $hasCargo -or -not $hasDlltool) {
 
     # Re-check after setup
     $hasCargo = [bool](Get-Command cargo -ErrorAction SilentlyContinue)
+    $rustHostTriple = Get-RustHostTriple
+    $needsDlltool = $rustHostTriple -like '*-windows-gnu'
     $hasDlltool = [bool](Get-Command dlltool -ErrorAction SilentlyContinue)
-    if (-not $hasCargo -or -not $hasDlltool) {
+    if (-not $hasCargo -or ($needsDlltool -and -not $hasDlltool)) {
         Write-Host ""
         Write-Host "ERROR: Prerequisites still missing after setup." -ForegroundColor Red
         Write-Host "Please restart your terminal and try again." -ForegroundColor Yellow
@@ -99,10 +117,31 @@ if (-not $SkipBuild) {
 
 # Binary may be under target/<profile> or target/<triple>/<profile>
 $profile = if ($Release) { "release" } else { "debug" }
+$cargoConfigPath = Join-Path $RustDir ".cargo\config.toml"
+$configuredTarget = $null
+
+if ($env:CARGO_BUILD_TARGET) {
+    $configuredTarget = $env:CARGO_BUILD_TARGET
+} elseif (Test-Path $cargoConfigPath) {
+    $targetLine = Get-Content $cargoConfigPath | Where-Object { $_ -match '^\s*target\s*=\s*"([^"]+)"' } | Select-Object -First 1
+    if ($targetLine -and $targetLine -match '^\s*target\s*=\s*"([^"]+)"') {
+        $configuredTarget = $Matches[1]
+    }
+}
+
 $candidates = @(
-    (Join-Path $RustDir "target\$profile\codexbar.exe"),
-    (Join-Path $RustDir "target\x86_64-pc-windows-gnu\$profile\codexbar.exe")
+    (Join-Path $RustDir "target\$profile\codexbar.exe")
 )
+
+if ($configuredTarget) {
+    $candidates += Join-Path $RustDir "target\$configuredTarget\$profile\codexbar.exe"
+}
+
+$candidates += @(
+    (Join-Path $RustDir "target\x86_64-pc-windows-msvc\$profile\codexbar.exe"),
+    (Join-Path $RustDir "target\x86_64-pc-windows-gnu\$profile\codexbar.exe")
+) | Select-Object -Unique
+
 $binary = $candidates | Where-Object { Test-Path $_ } | Select-Object -First 1
 
 if (-not $binary) {

--- a/rust/src/i18n.rs
+++ b/rust/src/i18n.rs
@@ -1,0 +1,14 @@
+//! Minimal UI language helpers.
+
+pub const UI_LANGUAGE_EN: &str = "en";
+
+pub fn is_zh(language: &str) -> bool {
+    matches!(
+        language.trim().to_ascii_lowercase().as_str(),
+        "zh" | "zh-cn" | "zh_cn" | "cn" | "chinese"
+    )
+}
+
+pub fn tr<'a>(language: &str, en: &'a str, zh: &'a str) -> &'a str {
+    if is_zh(language) { zh } else { en }
+}

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -13,6 +13,7 @@ mod cli;
 mod core;
 mod cost_scanner;
 mod host;
+mod i18n;
 mod logging;
 mod login;
 mod native_ui;
@@ -28,7 +29,7 @@ mod updater;
 mod wsl;
 
 use clap::Parser;
-use cli::{exit_codes, Cli, Commands};
+use cli::{Cli, Commands, exit_codes};
 
 /// Redact sensitive CLI arguments (tokens, keys, cookies) from log output
 fn redact_sensitive_args(args: &[String]) -> Vec<String> {
@@ -236,7 +237,7 @@ fn categorize_error(e: &anyhow::Error) -> i32 {
 #[cfg(windows)]
 fn hide_console_window() {
     use windows::Win32::System::Console::GetConsoleWindow;
-    use windows::Win32::UI::WindowsAndMessaging::{ShowWindow, SW_HIDE};
+    use windows::Win32::UI::WindowsAndMessaging::{SW_HIDE, ShowWindow};
 
     unsafe {
         let console = GetConsoleWindow();

--- a/rust/src/native_ui/app.rs
+++ b/rust/src/native_ui/app.rs
@@ -22,6 +22,7 @@ use crate::core::{
 };
 use crate::core::{TokenAccountStore, TokenAccountSupport};
 use crate::cost_scanner::get_daily_cost_history;
+use crate::i18n::tr;
 use crate::login::LoginPhase;
 use crate::providers::*;
 use crate::settings::{ApiKeys, ManualCookies, Settings};
@@ -132,6 +133,7 @@ impl ProviderData {
         result: &ProviderFetchResult,
         metadata: &crate::core::ProviderMetadata,
         reset_time_relative: bool,
+        ui_language: &str,
     ) -> Self {
         let snapshot = &result.usage;
         let (pace_percent, pace_lasts) = calculate_pace(&snapshot.primary);
@@ -159,14 +161,16 @@ impl ProviderData {
             display_name: id.display_name().to_string(),
             account: snapshot.account_email.clone(), // Account email if available
             session_percent: Some(snapshot.primary.used_percent),
-            session_reset: snapshot
-                .primary
-                .resets_at
-                .map(|t| format_reset_time(t, reset_time_relative)),
+            session_reset: snapshot.primary.resets_at.map_or_else(
+                || snapshot.primary.reset_description.clone(),
+                |t| Some(format_reset_time(t, reset_time_relative, ui_language)),
+            ),
             weekly_percent: snapshot.secondary.as_ref().map(|s| s.used_percent),
             weekly_reset: snapshot.secondary.as_ref().and_then(|s| {
-                s.resets_at
-                    .map(|t| format_reset_time(t, reset_time_relative))
+                s.resets_at.map_or_else(
+                    || s.reset_description.clone(),
+                    |t| Some(format_reset_time(t, reset_time_relative, ui_language)),
+                )
             }),
             model_percent: snapshot.model_specific.as_ref().map(|m| m.used_percent),
             model_name: snapshot
@@ -260,13 +264,17 @@ impl ProviderData {
     }
 }
 
-fn format_reset_time(reset: chrono::DateTime<chrono::Utc>, relative: bool) -> String {
+fn format_reset_time(
+    reset: chrono::DateTime<chrono::Utc>,
+    relative: bool,
+    ui_language: &str,
+) -> String {
     if relative {
         let now = chrono::Utc::now();
         let diff = reset - now;
 
         if diff.num_seconds() <= 0 {
-            return "正在重置...".to_string();
+            return tr(ui_language, "Resetting...", "正在重置...").to_string();
         }
 
         let hours = diff.num_hours();
@@ -290,7 +298,11 @@ fn format_reset_time(reset: chrono::DateTime<chrono::Utc>, relative: bool) -> St
         if reset_date == today {
             local_time.format("%I:%M %p").to_string()
         } else if reset_date == today + chrono::Days::new(1) {
-            format!("明天 {}", local_time.format("%I:%M %p"))
+            format!(
+                "{} {}",
+                tr(ui_language, "Tomorrow", "明天"),
+                local_time.format("%I:%M %p")
+            )
         } else {
             local_time.format("%b %d, %I:%M %p").to_string()
         }
@@ -337,11 +349,19 @@ fn usage_display_percent(used_percent: f64, show_as_used: bool) -> f64 {
     }
 }
 
-fn usage_display_label(display_percent: f64, show_as_used: bool) -> String {
+fn usage_display_label(display_percent: f64, show_as_used: bool, ui_language: &str) -> String {
     if show_as_used {
-        format!("已使用 {:.0}%", display_percent)
+        format!(
+            "{} {:.0}%",
+            tr(ui_language, "Used", "已使用"),
+            display_percent
+        )
     } else {
-        format!("剩余 {:.0}%", display_percent)
+        format!(
+            "{} {:.0}%",
+            tr(ui_language, "Remaining", "剩余"),
+            display_percent
+        )
     }
 }
 
@@ -796,6 +816,7 @@ impl CodexBarApp {
         let manual_cookies = ManualCookies::load();
         let api_keys = ApiKeys::load();
         let reset_time_relative = self.settings.reset_time_relative;
+        let ui_language = self.settings.ui_language.clone();
         // Load token accounts for account switching support
         let token_accounts = TokenAccountStore::new().load().unwrap_or_default();
 
@@ -895,6 +916,7 @@ impl CodexBarApp {
                             ..FetchContext::default()
                         };
                         let state = Arc::clone(&state);
+                        let ui_language = ui_language.clone();
                         tokio::spawn(async move {
                             let provider = create_provider(id);
                             let metadata = provider.metadata().clone();
@@ -923,6 +945,7 @@ impl CodexBarApp {
                                     &result,
                                     &metadata,
                                     reset_time_relative,
+                                    &ui_language,
                                 ),
                                 Ok(Err(e)) => ProviderData::from_error(id, e.to_string()),
                                 Err(_) => ProviderData::from_error(id, "Timeout".to_string()),
@@ -1743,6 +1766,7 @@ impl eframe::App for CodexBarApp {
                                     show_credits,
                                     show_as_used,
                                     hide_personal_info,
+                                    &self.settings.ui_language,
                                 );
                                 manual_refresh_requested = refresh;
                                 account_switch_provider = switch;
@@ -1755,6 +1779,7 @@ impl eframe::App for CodexBarApp {
                                     show_credits,
                                     show_as_used,
                                     hide_personal_info,
+                                    &self.settings.ui_language,
                                 );
                                 manual_refresh_requested = refresh;
                                 account_switch_provider = switch;
@@ -1784,7 +1809,7 @@ impl eframe::App for CodexBarApp {
                                         ui.spinner();
                                         ui.add_space(Spacing::SM);
                                         ui.label(
-                                            RichText::new("正在加载服务商...")
+                                            RichText::new(tr(&self.settings.ui_language, "Loading providers...", "正在加载服务商..."))
                                                 .size(FontSize::BASE)
                                                 .color(Theme::TEXT_MUTED),
                                         );
@@ -1799,7 +1824,7 @@ impl eframe::App for CodexBarApp {
                                 .show(ui, |ui| {
                                     ui.vertical_centered(|ui| {
                                         ui.label(
-                                            RichText::new("暂无服务商数据。")
+                                            RichText::new(tr(&self.settings.ui_language, "No provider data available.", "暂无服务商数据。"))
                                                 .size(FontSize::BASE)
                                                 .color(Theme::TEXT_MUTED),
                                         );
@@ -1819,18 +1844,25 @@ impl eframe::App for CodexBarApp {
                                         ui.spinner();
                                         ui.add_space(Spacing::SM);
                                         ui.label(
-                                            RichText::new("正在加载服务商...")
+                                            RichText::new(tr(&self.settings.ui_language, "Loading providers...", "正在加载服务商..."))
                                                 .size(FontSize::BASE)
                                                 .color(Theme::TEXT_MUTED),
                                         );
                                     } else {
                                         ui.label(
-                                            RichText::new("尚未选择服务商。")
+                                            RichText::new(tr(&self.settings.ui_language, "No providers selected.", "尚未选择服务商。"))
                                                 .size(FontSize::BASE)
                                                 .color(Theme::TEXT_MUTED),
                                         );
                                         ui.add_space(Spacing::SM);
-                                        if ui.button("打开服务商设置").clicked() {
+                                        if ui
+                                            .button(tr(
+                                                &self.settings.ui_language,
+                                                "Open provider settings",
+                                                "打开服务商设置",
+                                            ))
+                                            .clicked()
+                                        {
                                             self.preferences_window.active_tab = super::preferences::PreferencesTab::Providers;
                                             self.preferences_window.open();
                                         }
@@ -1847,14 +1879,20 @@ impl eframe::App for CodexBarApp {
                     draw_horizontal_separator(ui, 0.0);
                     ui.add_space(4.0);
 
-                    if draw_text_menu_item(ui, "设置...") {
+                    if draw_text_menu_item(
+                        ui,
+                        tr(&self.settings.ui_language, "Settings...", "设置..."),
+                    ) {
                         self.preferences_window.open();
                     }
-                    if draw_text_menu_item(ui, "关于 CodexBar") {
+                    if draw_text_menu_item(
+                        ui,
+                        tr(&self.settings.ui_language, "About CodexBar", "关于 CodexBar"),
+                    ) {
                         self.preferences_window.active_tab = super::preferences::PreferencesTab::About;
                         self.preferences_window.open();
                     }
-                    if draw_text_menu_item(ui, "退出") {
+                    if draw_text_menu_item(ui, tr(&self.settings.ui_language, "Quit", "退出")) {
                         std::process::exit(0);
                     }
                 }); // end ScrollArea
@@ -1905,6 +1943,7 @@ fn draw_provider_detail_card(
     show_credits_extra: bool,
     show_as_used: bool,
     hide_personal_info: bool,
+    ui_language: &str,
 ) -> (bool, Option<String>) {
     let mut refresh_requested = false;
     let mut account_switch_requested: Option<String> = None;
@@ -1964,7 +2003,7 @@ fn draw_provider_detail_card(
                         );
                     } else {
                         ui.label(
-                            RichText::new("刚刚更新")
+                            RichText::new(tr(ui_language, "Updated just now", "刚刚更新"))
                                 .size(FontSize::XS)
                                 .color(Theme::TEXT_SECONDARY),
                         );
@@ -1992,9 +2031,13 @@ fn draw_provider_detail_card(
                         ui.horizontal(|ui| {
                             let status_col = status_color(provider.status_level);
                             ui.label(
-                                RichText::new(format!("状态：{}", status_desc))
-                                    .size(FontSize::XS)
-                                    .color(status_col),
+                                RichText::new(format!(
+                                    "{}: {}",
+                                    tr(ui_language, "Status", "状态"),
+                                    status_desc
+                                ))
+                                .size(FontSize::XS)
+                                .color(status_col),
                             );
                         });
                     }
@@ -2026,10 +2069,11 @@ fn draw_provider_detail_card(
             if let Some(session_pct) = provider.session_percent {
                 draw_metric_row(
                     ui,
-                    "会话",
+                    tr(ui_language, "Session", "会话"),
                     session_pct,
                     show_as_used,
                     provider.session_reset.as_deref(),
+                    ui_language,
                     brand_color,
                     content_width,
                     None, // No pace for session
@@ -2043,10 +2087,11 @@ fn draw_provider_detail_card(
 
                 draw_metric_row(
                     ui,
-                    "周度",
+                    tr(ui_language, "Weekly", "周度"),
                     weekly_pct,
                     show_as_used,
                     provider.weekly_reset.as_deref(),
+                    ui_language,
                     brand_color,
                     content_width,
                     provider.pace_percent,
@@ -2058,13 +2103,18 @@ fn draw_provider_detail_card(
             if let Some(model_pct) = provider.model_percent {
                 ui.add_space(12.0);
 
-                let model_label = provider.model_name.as_deref().unwrap_or("模型");
+                let model_label =
+                    provider
+                        .model_name
+                        .as_deref()
+                        .unwrap_or(tr(ui_language, "Model", "模型"));
                 draw_metric_row(
                     ui,
                     model_label,
                     model_pct,
                     show_as_used,
                     None,
+                    ui_language,
                     brand_color,
                     content_width,
                     None, // No pace for model
@@ -2078,7 +2128,7 @@ fn draw_provider_detail_card(
             ui.horizontal(|ui| {
                 ui.add_space(16.0);
                 ui.label(
-                    RichText::new("无法获取用量")
+                    RichText::new(tr(ui_language, "Unable to fetch usage", "无法获取用量"))
                         .size(FontSize::SM)
                         .color(Theme::TEXT_SECONDARY),
                 );
@@ -2100,7 +2150,7 @@ fn draw_provider_detail_card(
 
                 // Title: "Credits" - .font(.body).fontWeight(.medium)
                 ui.label(
-                    RichText::new("额度")
+                    RichText::new(tr(ui_language, "Credits", "额度"))
                         .size(FontSize::BASE)
                         .color(Theme::TEXT_PRIMARY)
                         .strong(),
@@ -2131,9 +2181,13 @@ fn draw_provider_detail_card(
                 ui.add_space(6.0);
                 ui.horizontal(|ui| {
                     ui.label(
-                        RichText::new(format!("剩余 {:.2}", credits))
-                            .size(FontSize::XS)
-                            .color(Theme::TEXT_PRIMARY),
+                        RichText::new(format!(
+                            "{} {:.2}",
+                            tr(ui_language, "Remaining", "剩余"),
+                            credits
+                        ))
+                        .size(FontSize::XS)
+                        .color(Theme::TEXT_PRIMARY),
                     );
                     ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
                         ui.label(
@@ -2146,7 +2200,7 @@ fn draw_provider_detail_card(
 
                 // Buy Credits link
                 ui.add_space(6.0);
-                if draw_menu_item(ui, "⊕", "购买额度...") {
+                if draw_menu_item(ui, "⊕", tr(ui_language, "Buy credits...", "购买额度...")) {
                     if let Some(ref url) = provider.dashboard_url {
                         let _ = open::that(url);
                     }
@@ -2176,7 +2230,7 @@ fn draw_provider_detail_card(
             ui.add_space(12.0);
 
             ui.label(
-                RichText::new("用量明细")
+                RichText::new(tr(ui_language, "Usage breakdown", "用量明细"))
                     .size(FontSize::BASE)
                     .color(Theme::TEXT_PRIMARY)
                     .strong(),
@@ -2199,7 +2253,7 @@ fn draw_provider_detail_card(
 
             // Title: "Cost" - .font(.body).fontWeight(.medium)
             ui.label(
-                RichText::new("费用")
+                RichText::new(tr(ui_language, "Cost", "费用"))
                     .size(FontSize::BASE)
                     .color(Theme::TEXT_PRIMARY)
                     .strong(),
@@ -2213,14 +2267,22 @@ fn draw_provider_detail_card(
                 let today_cost: f64 = provider.cost_history.last().map(|(_, c)| *c).unwrap_or(0.0);
 
                 ui.label(
-                    RichText::new(format!("今日：${:.2}", today_cost))
-                        .size(FontSize::XS)
-                        .color(Theme::TEXT_PRIMARY),
+                    RichText::new(format!(
+                        "{}: ${:.2}",
+                        tr(ui_language, "Today", "今日"),
+                        today_cost
+                    ))
+                    .size(FontSize::XS)
+                    .color(Theme::TEXT_PRIMARY),
                 );
                 ui.label(
-                    RichText::new(format!("近 30 天：${:.2}", total_30d))
-                        .size(FontSize::XS)
-                        .color(Theme::TEXT_PRIMARY),
+                    RichText::new(format!(
+                        "{}: ${:.2}",
+                        tr(ui_language, "Last 30 days", "近 30 天"),
+                        total_30d
+                    ))
+                    .size(FontSize::XS)
+                    .color(Theme::TEXT_PRIMARY),
                 );
             } else if let Some(cost_used) = &provider.cost_used {
                 ui.label(
@@ -2258,7 +2320,7 @@ fn draw_provider_detail_card(
 
             // Vertical action links like macOS
             // Refresh button - first action
-            if draw_menu_item(ui, "↻", "刷新") {
+            if draw_menu_item(ui, "↻", tr(ui_language, "Refresh", "刷新")) {
                 refresh_requested = true;
             }
 
@@ -2266,7 +2328,11 @@ fn draw_provider_detail_card(
             if TokenAccountSupport::is_supported(
                 ProviderId::from_cli_name(&provider.name).unwrap_or(ProviderId::Claude),
             ) {
-                if draw_menu_item(ui, "->", "切换账号...") {
+                if draw_menu_item(
+                    ui,
+                    "->",
+                    tr(ui_language, "Switch account...", "切换账号..."),
+                ) {
                     account_switch_requested = Some(provider.name.clone());
                 }
             }
@@ -2274,14 +2340,15 @@ fn draw_provider_detail_card(
             // Usage Dashboard link
             if let Some(ref url) = provider.dashboard_url {
                 let dashboard_url = url.clone();
-                if draw_menu_item(ui, "📊", "用量仪表盘") {
+                if draw_menu_item(ui, "📊", tr(ui_language, "Usage dashboard", "用量仪表盘"))
+                {
                     let _ = open::that(&dashboard_url);
                 }
             }
 
             // Status Page link
             if let Some(status_url) = get_status_page_url(&provider.name) {
-                if draw_menu_item(ui, "⚡", "状态页面") {
+                if draw_menu_item(ui, "⚡", tr(ui_language, "Status page", "状态页面")) {
                     let _ = open::that(status_url);
                 }
             }
@@ -2289,7 +2356,7 @@ fn draw_provider_detail_card(
             // Copy Error link
             if let Some(ref error) = provider.error {
                 let error_text = error.clone();
-                if draw_menu_item(ui, "📋", "复制错误") {
+                if draw_menu_item(ui, "📋", tr(ui_language, "Copy error", "复制错误")) {
                     if let Ok(mut clipboard) = arboard::Clipboard::new() {
                         let _ = clipboard.set_text(&error_text);
                     }
@@ -2363,6 +2430,7 @@ fn draw_metric_row(
     percent: f64,
     show_as_used: bool,
     reset_text: Option<&str>,
+    ui_language: &str,
     color: Color32,
     _content_width: f32,
     pace_percent: Option<f64>,
@@ -2420,18 +2488,22 @@ fn draw_metric_row(
     // Info row: X% used (left) | Pace status | Resets in Xh (right) - .font(.footnote)
     ui.horizontal(|ui| {
         ui.label(
-            RichText::new(usage_display_label(display_percent, show_as_used))
-                .size(FontSize::XS)
-                .color(Theme::TEXT_PRIMARY),
+            RichText::new(usage_display_label(
+                display_percent,
+                show_as_used,
+                ui_language,
+            ))
+            .size(FontSize::XS)
+            .color(Theme::TEXT_PRIMARY),
         );
 
         // Pace status indicator
         if display_pace_percent.is_some() {
             ui.add_space(8.0);
             let (pace_text, pace_color) = if pace_lasts_to_reset {
-                ("进度正常", Theme::GREEN)
+                (tr(ui_language, "On pace", "进度正常"), Theme::GREEN)
             } else {
-                ("进度滞后", Theme::YELLOW)
+                (tr(ui_language, "Behind pace", "进度滞后"), Theme::YELLOW)
             };
             ui.label(
                 RichText::new(pace_text)
@@ -2443,9 +2515,13 @@ fn draw_metric_row(
         ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
             if let Some(reset) = reset_text {
                 ui.label(
-                    RichText::new(format!("重置于 {}", reset))
-                        .size(FontSize::XS)
-                        .color(Theme::TEXT_SECONDARY),
+                    RichText::new(format!(
+                        "{} {}",
+                        tr(ui_language, "Resets at", "重置于"),
+                        reset
+                    ))
+                    .size(FontSize::XS)
+                    .color(Theme::TEXT_SECONDARY),
                 );
             }
         });

--- a/rust/src/native_ui/preferences.rs
+++ b/rust/src/native_ui/preferences.rs
@@ -10,12 +10,13 @@ use std::cell::RefCell;
 use std::sync::{Arc, Mutex};
 
 use super::provider_icons::ProviderIconCache;
-use super::theme::{provider_color, provider_icon, FontSize, Radius, Spacing, Theme};
+use super::theme::{FontSize, Radius, Spacing, Theme, provider_color, provider_icon};
 use crate::browser::cookies::get_cookie_header_from_browser;
 use crate::browser::detection::{BrowserDetector, BrowserType};
 use crate::core::{PersonalInfoRedactor, ProviderId, WidgetSnapshot, WidgetSnapshotStore};
 use crate::core::{ProviderAccountData, TokenAccount, TokenAccountStore, TokenAccountSupport};
-use crate::settings::{get_api_key_providers, ApiKeys, ManualCookies, Settings, TrayIconMode};
+use crate::i18n::tr;
+use crate::settings::{ApiKeys, ManualCookies, Settings, TrayIconMode, get_api_key_providers};
 use crate::shortcuts::format_shortcut;
 use std::collections::HashMap;
 
@@ -38,15 +39,15 @@ pub enum PreferencesTab {
 }
 
 impl PreferencesTab {
-    fn label(&self) -> &'static str {
+    fn label(&self, ui_language: &str) -> &'static str {
         match self {
-            PreferencesTab::General => "通用",
-            PreferencesTab::Providers => "服务商",
-            PreferencesTab::Display => "显示",
-            PreferencesTab::ApiKeys => "API 密钥",
+            PreferencesTab::General => tr(ui_language, "General", "通用"),
+            PreferencesTab::Providers => tr(ui_language, "Providers", "服务商"),
+            PreferencesTab::Display => tr(ui_language, "Display", "显示"),
+            PreferencesTab::ApiKeys => tr(ui_language, "API Keys", "API 密钥"),
             PreferencesTab::Cookies => "Cookies",
-            PreferencesTab::Advanced => "高级",
-            PreferencesTab::About => "关于",
+            PreferencesTab::Advanced => tr(ui_language, "Advanced", "高级"),
+            PreferencesTab::About => tr(ui_language, "About", "关于"),
         }
     }
 
@@ -300,7 +301,7 @@ impl PreferencesWindow {
         };
 
         let mut builder = egui::ViewportBuilder::default()
-            .with_title("CodexBar 设置")
+            .with_title("CodexBar Settings")
             .with_inner_size([settings_size.x, settings_size.y])
             .with_min_inner_size([settings_min_size.x, settings_min_size.y])
             .with_clamp_size_to_monitor_size(true)
@@ -406,12 +407,8 @@ impl PreferencesWindow {
 
             // Sound effects toggle
             let mut sound_enabled = self.settings.sound_enabled;
-            if setting_toggle(
-                ui,
-                "声音提示",
-                "达到阈值时播放提示音",
-                &mut sound_enabled,
-            ) {
+            if setting_toggle(ui, "声音提示", "达到阈值时播放提示音", &mut sound_enabled)
+            {
                 self.settings.sound_enabled = sound_enabled;
                 self.settings_changed = true;
             }
@@ -1089,15 +1086,13 @@ impl PreferencesWindow {
                 if ui
                     .add_enabled(
                         can_import,
-                        egui::Button::new(
-                            RichText::new("导入 Cookies").size(FontSize::SM).color(
-                                if can_import {
-                                    Color32::WHITE
-                                } else {
-                                    Theme::TEXT_MUTED
-                                },
-                            ),
-                        )
+                        egui::Button::new(RichText::new("导入 Cookies").size(FontSize::SM).color(
+                            if can_import {
+                                Color32::WHITE
+                            } else {
+                                Theme::TEXT_MUTED
+                            },
+                        ))
                         .fill(if can_import {
                             Theme::ACCENT_PRIMARY
                         } else {
@@ -1134,8 +1129,12 @@ impl PreferencesWindow {
                                 }
                                 Ok(_) => {
                                     self.browser_import_status = Some((
-                                        format!("在 {} 的 {} 中未找到 Cookies。请先确认已登录。", browser_type.display_name(), domain),
-                                        true
+                                        format!(
+                                            "在 {} 的 {} 中未找到 Cookies。请先确认已登录。",
+                                            browser_type.display_name(),
+                                            domain
+                                        ),
+                                        true,
                                     ));
                                 }
                                 Err(e) => {
@@ -1479,8 +1478,7 @@ impl PreferencesWindow {
                                 None,
                             );
                             if let Err(e) = self.api_keys.save() {
-                                self.api_key_status_msg =
-                                    Some((format!("保存失败：{}", e), true));
+                                self.api_key_status_msg = Some((format!("保存失败：{}", e), true));
                             } else {
                                 self.api_key_status_msg =
                                     Some((format!("已保存 {} 的 API key", provider_name), false));
@@ -1516,11 +1514,9 @@ impl PreferencesWindow {
         section_header(ui, "Browser Cookies");
 
         ui.label(
-            RichText::new(
-                "Cookies 会自动从 Chrome、Edge、Brave 和 Firefox 中提取。",
-            )
-            .size(FontSize::SM)
-            .color(Theme::TEXT_MUTED),
+            RichText::new("Cookies 会自动从 Chrome、Edge、Brave 和 Firefox 中提取。")
+                .size(FontSize::SM)
+                .color(Theme::TEXT_MUTED),
         );
 
         ui.add_space(Spacing::LG);
@@ -2005,7 +2001,7 @@ fn work_area_rect(ctx: &egui::Context) -> Option<Rect> {
     {
         use windows::Win32::Foundation::RECT as WinRect;
         use windows::Win32::UI::WindowsAndMessaging::{
-            SystemParametersInfoW, SPI_GETWORKAREA, SYSTEM_PARAMETERS_INFO_UPDATE_FLAGS,
+            SPI_GETWORKAREA, SYSTEM_PARAMETERS_INFO_UPDATE_FLAGS, SystemParametersInfoW,
         };
 
         let mut rect = WinRect::default();
@@ -2052,6 +2048,11 @@ fn render_settings_ui(ui: &mut egui::Ui, shared_state: &Arc<Mutex<PreferencesSha
         state.active_tab
     } else {
         PreferencesTab::General
+    };
+    let ui_language = if let Ok(state) = shared_state.lock() {
+        state.settings.ui_language.clone()
+    } else {
+        crate::i18n::UI_LANGUAGE_EN.to_string()
     };
 
     ui.vertical(|ui| {
@@ -2135,7 +2136,7 @@ fn render_settings_ui(ui: &mut egui::Ui, shared_state: &Arc<Mutex<PreferencesSha
             ui.painter().text(
                 egui::pos2(tab_rect.center().x, tab_rect.min.y + 44.0),
                 egui::Align2::CENTER_CENTER,
-                tab.label(),
+                tab.label(&ui_language),
                 egui::FontId::proportional(11.0),
                 label_color,
             );
@@ -2177,7 +2178,7 @@ fn render_settings_ui(ui: &mut egui::Ui, shared_state: &Arc<Mutex<PreferencesSha
                             PreferencesTab::ApiKeys => render_api_keys_tab(ui, shared_state),
                             PreferencesTab::Cookies => render_cookies_tab(ui, shared_state),
                             PreferencesTab::Advanced => render_advanced_tab(ui, shared_state),
-                            PreferencesTab::About => render_about_tab(ui),
+                            PreferencesTab::About => render_about_tab(ui, shared_state),
                             PreferencesTab::Providers => unreachable!(),
                         }
                         ui.add_space(Spacing::LG);
@@ -2185,6 +2186,14 @@ fn render_settings_ui(ui: &mut egui::Ui, shared_state: &Arc<Mutex<PreferencesSha
             }
         }
     });
+}
+
+fn current_ui_language(shared_state: &Arc<Mutex<PreferencesSharedState>>) -> String {
+    if let Ok(state) = shared_state.lock() {
+        state.settings.ui_language.clone()
+    } else {
+        crate::i18n::UI_LANGUAGE_EN.to_string()
+    }
 }
 
 /// Render Providers tab with macOS-style sidebar + detail layout
@@ -3295,9 +3304,56 @@ fn render_accounts_section(
 
 /// Render General tab for viewport
 fn render_general_tab(ui: &mut egui::Ui, shared_state: &Arc<Mutex<PreferencesSharedState>>) {
+    let ui_language = current_ui_language(shared_state);
     section_header(ui, "Startup");
 
     settings_card(ui, |ui| {
+        ui.horizontal(|ui| {
+            ui.vertical(|ui| {
+                ui.label(
+                    RichText::new(tr(&ui_language, "Language", "语言"))
+                        .size(FontSize::MD)
+                        .color(Theme::TEXT_PRIMARY),
+                );
+                ui.label(
+                    RichText::new(tr(
+                        &ui_language,
+                        "Change the tray and window language",
+                        "切换托盘和窗口语言",
+                    ))
+                    .size(FontSize::SM)
+                    .color(Theme::TEXT_MUTED),
+                );
+            });
+
+            ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+                let current = if let Ok(state) = shared_state.lock() {
+                    state.settings.ui_language.clone()
+                } else {
+                    crate::i18n::UI_LANGUAGE_EN.to_string()
+                };
+                let mut selected = current.clone();
+                egui::ComboBox::from_id_salt("ui_language")
+                    .selected_text(if selected == "zh" {
+                        "中文"
+                    } else {
+                        "English"
+                    })
+                    .show_ui(ui, |ui| {
+                        ui.selectable_value(&mut selected, "en".to_string(), "English");
+                        ui.selectable_value(&mut selected, "zh".to_string(), "中文");
+                    });
+                if selected != current {
+                    if let Ok(mut state) = shared_state.lock() {
+                        state.settings.ui_language = selected;
+                        state.settings_changed = true;
+                    }
+                }
+            });
+        });
+
+        setting_divider(ui);
+
         let mut start_at_login = if let Ok(state) = shared_state.lock() {
             state.settings.start_at_login
         } else {
@@ -3306,8 +3362,12 @@ fn render_general_tab(ui: &mut egui::Ui, shared_state: &Arc<Mutex<PreferencesSha
 
         if setting_toggle(
             ui,
-            "开机启动",
-            "登录后自动启动 CodexBar",
+            tr(&ui_language, "Start at login", "开机启动"),
+            tr(
+                &ui_language,
+                "Automatically launch CodexBar after sign-in",
+                "登录后自动启动 CodexBar",
+            ),
             &mut start_at_login,
         ) {
             if let Ok(mut state) = shared_state.lock() {
@@ -3329,8 +3389,12 @@ fn render_general_tab(ui: &mut egui::Ui, shared_state: &Arc<Mutex<PreferencesSha
 
         if setting_toggle(
             ui,
-            "最小化启动",
-            "启动后停留在系统托盘",
+            tr(&ui_language, "Start minimized", "最小化启动"),
+            tr(
+                &ui_language,
+                "Keep CodexBar in the system tray on launch",
+                "启动后停留在系统托盘",
+            ),
             &mut start_minimized,
         ) {
             if let Ok(mut state) = shared_state.lock() {
@@ -3353,8 +3417,12 @@ fn render_general_tab(ui: &mut egui::Ui, shared_state: &Arc<Mutex<PreferencesSha
 
         if setting_toggle(
             ui,
-            "显示通知",
-            "达到用量阈值时提醒",
+            tr(&ui_language, "Show notifications", "显示通知"),
+            tr(
+                &ui_language,
+                "Notify when usage reaches warning levels",
+                "达到用量阈值时提醒",
+            ),
             &mut show_notifications,
         ) {
             if let Ok(mut state) = shared_state.lock() {
@@ -3374,8 +3442,12 @@ fn render_general_tab(ui: &mut egui::Ui, shared_state: &Arc<Mutex<PreferencesSha
 
         if setting_toggle(
             ui,
-            "声音提示",
-            "达到阈值时播放提示音",
+            tr(&ui_language, "Sound alerts", "声音提示"),
+            tr(
+                &ui_language,
+                "Play a sound when thresholds are reached",
+                "达到阈值时播放提示音",
+            ),
             &mut sound_enabled,
         ) {
             if let Ok(mut state) = shared_state.lock() {
@@ -3398,7 +3470,7 @@ fn render_general_tab(ui: &mut egui::Ui, shared_state: &Arc<Mutex<PreferencesSha
                 // Title row with volume badge on right
                 ui.horizontal(|ui| {
                     ui.label(
-                        RichText::new("提示音音量")
+                        RichText::new(tr(&ui_language, "Alert volume", "提示音音量"))
                             .size(FontSize::MD)
                             .color(Theme::TEXT_PRIMARY),
                     );
@@ -3420,9 +3492,13 @@ fn render_general_tab(ui: &mut egui::Ui, shared_state: &Arc<Mutex<PreferencesSha
 
                 ui.add_space(2.0);
                 ui.label(
-                    RichText::new("告警提示音音量")
-                        .size(FontSize::SM)
-                        .color(Theme::TEXT_MUTED),
+                    RichText::new(tr(
+                        &ui_language,
+                        "Volume for warning and alert sounds",
+                        "告警提示音音量",
+                    ))
+                    .size(FontSize::SM)
+                    .color(Theme::TEXT_MUTED),
                 );
                 ui.add_space(6.0);
 
@@ -3456,7 +3532,7 @@ fn render_general_tab(ui: &mut egui::Ui, shared_state: &Arc<Mutex<PreferencesSha
             // Title row with percentage badge on right
             ui.horizontal(|ui| {
                 ui.label(
-                    RichText::new("高位预警")
+                    RichText::new(tr(&ui_language, "High usage warning", "高位预警"))
                         .size(FontSize::MD)
                         .color(Theme::TEXT_PRIMARY),
                 );
@@ -3478,9 +3554,13 @@ fn render_general_tab(ui: &mut egui::Ui, shared_state: &Arc<Mutex<PreferencesSha
 
             ui.add_space(2.0);
             ui.label(
-                RichText::new("在该用量水平显示预警")
-                    .size(FontSize::SM)
-                    .color(Theme::TEXT_MUTED),
+                RichText::new(tr(
+                    &ui_language,
+                    "Show a warning at this usage level",
+                    "在该用量水平显示预警",
+                ))
+                .size(FontSize::SM)
+                .color(Theme::TEXT_MUTED),
             );
             ui.add_space(6.0);
 
@@ -3515,7 +3595,7 @@ fn render_general_tab(ui: &mut egui::Ui, shared_state: &Arc<Mutex<PreferencesSha
             // Title row with percentage badge on right
             ui.horizontal(|ui| {
                 ui.label(
-                    RichText::new("严重告警")
+                    RichText::new(tr(&ui_language, "Critical alert", "严重告警"))
                         .size(FontSize::MD)
                         .color(Theme::TEXT_PRIMARY),
                 );
@@ -3537,9 +3617,13 @@ fn render_general_tab(ui: &mut egui::Ui, shared_state: &Arc<Mutex<PreferencesSha
 
             ui.add_space(2.0);
             ui.label(
-                RichText::new("在该水平显示严重告警")
-                    .size(FontSize::SM)
-                    .color(Theme::TEXT_MUTED),
+                RichText::new(tr(
+                    &ui_language,
+                    "Show a critical alert at this level",
+                    "在该水平显示严重告警",
+                ))
+                .size(FontSize::SM)
+                .color(Theme::TEXT_MUTED),
             );
             ui.add_space(6.0);
 
@@ -3573,8 +3657,12 @@ fn render_general_tab(ui: &mut egui::Ui, shared_state: &Arc<Mutex<PreferencesSha
 
         if setting_toggle(
             ui,
-            "隐藏个人信息",
-            "遮蔽邮箱和账号名称（适合直播时使用）",
+            tr(&ui_language, "Hide personal information", "隐藏个人信息"),
+            tr(
+                &ui_language,
+                "Mask emails and account names for streaming or screenshots",
+                "遮蔽邮箱和账号名称（适合直播时使用）",
+            ),
             &mut hide_personal_info,
         ) {
             if let Ok(mut state) = shared_state.lock() {
@@ -3592,14 +3680,18 @@ fn render_general_tab(ui: &mut egui::Ui, shared_state: &Arc<Mutex<PreferencesSha
         ui.horizontal(|ui| {
             ui.vertical(|ui| {
                 ui.label(
-                    RichText::new("更新通道")
+                    RichText::new(tr(&ui_language, "Update channel", "更新通道"))
                         .size(FontSize::MD)
                         .color(Theme::TEXT_PRIMARY),
                 );
                 ui.label(
-                    RichText::new("在稳定版与测试预览版之间选择")
-                        .size(FontSize::SM)
-                        .color(Theme::TEXT_MUTED),
+                    RichText::new(tr(
+                        &ui_language,
+                        "Choose between stable and preview builds",
+                        "在稳定版与测试预览版之间选择",
+                    ))
+                    .size(FontSize::SM)
+                    .color(Theme::TEXT_MUTED),
                 );
             });
 
@@ -3654,14 +3746,18 @@ fn render_general_tab(ui: &mut egui::Ui, shared_state: &Arc<Mutex<PreferencesSha
         ui.horizontal(|ui| {
             ui.vertical(|ui| {
                 ui.label(
-                    RichText::new("全局快捷键")
+                    RichText::new(tr(&ui_language, "Global shortcut", "全局快捷键"))
                         .size(FontSize::MD)
                         .color(Theme::TEXT_PRIMARY),
                 );
                 ui.label(
-                    RichText::new("按下此快捷键可在任意位置打开 CodexBar")
-                        .size(FontSize::SM)
-                        .color(Theme::TEXT_MUTED),
+                    RichText::new(tr(
+                        &ui_language,
+                        "Open CodexBar from anywhere with this shortcut",
+                        "按下此快捷键可在任意位置打开 CodexBar",
+                    ))
+                    .size(FontSize::SM)
+                    .color(Theme::TEXT_MUTED),
                 );
             });
 
@@ -3741,6 +3837,7 @@ fn render_general_tab(ui: &mut egui::Ui, shared_state: &Arc<Mutex<PreferencesSha
 
 /// Render Display tab for viewport
 fn render_display_tab(ui: &mut egui::Ui, shared_state: &Arc<Mutex<PreferencesSharedState>>) {
+    let ui_language = current_ui_language(shared_state);
     section_header(ui, "Appearance");
 
     settings_card(ui, |ui| {
@@ -3752,8 +3849,12 @@ fn render_display_tab(ui: &mut egui::Ui, shared_state: &Arc<Mutex<PreferencesSha
 
         if setting_toggle(
             ui,
-            "Relative time",
-            "Show reset time as relative (3h 45m) instead of absolute",
+            tr(&ui_language, "Relative time", "相对时间"),
+            tr(
+                &ui_language,
+                "Show reset time as relative (3h 45m) instead of absolute",
+                "显示重置时间为相对时间（3h 45m）而不是绝对时间",
+            ),
             &mut relative_time,
         ) {
             if let Ok(mut state) = shared_state.lock() {
@@ -3772,8 +3873,12 @@ fn render_display_tab(ui: &mut egui::Ui, shared_state: &Arc<Mutex<PreferencesSha
 
         if setting_toggle(
             ui,
-            "Surprise animations",
-            "Show occasional fun animations in the tray icon",
+            tr(&ui_language, "Surprise animations", "趣味动画"),
+            tr(
+                &ui_language,
+                "Show occasional fun animations in the tray icon",
+                "在托盘图标中偶尔显示趣味动画",
+            ),
             &mut surprise,
         ) {
             if let Ok(mut state) = shared_state.lock() {
@@ -4071,8 +4176,7 @@ fn render_api_keys_tab(ui: &mut egui::Ui, shared_state: &Arc<Mutex<PreferencesSh
                             let value = state.new_api_key_value.trim().to_string();
                             state.api_keys.set(&provider, &value, None);
                             if let Err(e) = state.api_keys.save() {
-                                state.api_key_status_msg =
-                                    Some((format!("保存失败：{}", e), true));
+                                state.api_key_status_msg = Some((format!("保存失败：{}", e), true));
                             } else {
                                 state.api_key_status_msg =
                                     Some((format!("已保存 {} 的 API key", provider_name), false));
@@ -4109,12 +4213,17 @@ fn render_api_keys_tab(ui: &mut egui::Ui, shared_state: &Arc<Mutex<PreferencesSh
 
 /// Render Cookies tab for viewport
 fn render_cookies_tab(ui: &mut egui::Ui, shared_state: &Arc<Mutex<PreferencesSharedState>>) {
+    let ui_language = current_ui_language(shared_state);
     section_header(ui, "Browser Cookies");
 
     ui.label(
-        RichText::new("Cookies 会自动从 Chrome、Edge、Brave 和 Firefox 中提取。")
-            .size(FontSize::SM)
-            .color(Theme::TEXT_MUTED),
+        RichText::new(tr(
+            &ui_language,
+            "Cookies are automatically extracted from Chrome, Edge, Brave, and Firefox.",
+            "Cookies 会自动从 Chrome、Edge、Brave 和 Firefox 中提取。",
+        ))
+        .size(FontSize::SM)
+        .color(Theme::TEXT_MUTED),
     );
 
     ui.add_space(Spacing::LG);
@@ -4159,7 +4268,7 @@ fn render_cookies_tab(ui: &mut egui::Ui, shared_state: &Arc<Mutex<PreferencesSha
                     );
 
                     ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
-                        if small_button(ui, "Remove", Theme::RED) {
+                        if small_button(ui, tr(&ui_language, "Remove", "移除"), Theme::RED) {
                             to_remove = Some(cookie_info.provider_id.clone());
                         }
                     });
@@ -4174,8 +4283,14 @@ fn render_cookies_tab(ui: &mut egui::Ui, shared_state: &Arc<Mutex<PreferencesSha
                 if let Ok(mut state) = shared_state.lock() {
                     state.cookies.remove(&provider_id);
                     let _ = state.cookies.save();
-                    state.cookie_status_msg =
-                        Some((format!("已移除 {} 的 Cookie", provider_id), false));
+                    state.cookie_status_msg = Some((
+                        format!(
+                            "{} {}",
+                            tr(&ui_language, "Removed cookie for", "已移除"),
+                            provider_id
+                        ),
+                        false,
+                    ));
                 }
             }
         });
@@ -4197,14 +4312,14 @@ fn render_cookies_tab(ui: &mut egui::Ui, shared_state: &Arc<Mutex<PreferencesSha
         // Provider selection row
         ui.horizontal(|ui| {
             ui.label(
-                RichText::new("Provider")
+                RichText::new(tr(&ui_language, "Provider", "服务商"))
                     .size(FontSize::MD)
                     .color(Theme::TEXT_PRIMARY),
             );
             ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
                 let combo = egui::ComboBox::from_id_salt("cookie_provider_viewport")
                     .selected_text(if current_provider.is_empty() {
-                        "Select..."
+                        tr(&ui_language, "Select...", "请选择...")
                     } else {
                         &current_provider
                     })
@@ -4236,7 +4351,7 @@ fn render_cookies_tab(ui: &mut egui::Ui, shared_state: &Arc<Mutex<PreferencesSha
 
         // Cookie header label
         ui.label(
-            RichText::new("Cookie 头")
+            RichText::new(tr(&ui_language, "Cookie header", "Cookie 头"))
                 .size(FontSize::MD)
                 .color(Theme::TEXT_PRIMARY),
         );
@@ -4260,7 +4375,11 @@ fn render_cookies_tab(ui: &mut egui::Ui, shared_state: &Arc<Mutex<PreferencesSha
                     .desired_width(ui.available_width())
                     .desired_rows(4)
                     .frame(false)
-                    .hint_text("Paste cookie header from browser dev tools");
+                    .hint_text(tr(
+                        &ui_language,
+                        "Paste cookie header from browser dev tools",
+                        "粘贴浏览器开发者工具中的 Cookie 头",
+                    ));
                 let response = ui.add(text_edit);
 
                 if response.changed() {
@@ -4287,13 +4406,15 @@ fn render_cookies_tab(ui: &mut egui::Ui, shared_state: &Arc<Mutex<PreferencesSha
         if ui
             .add_enabled(
                 can_save,
-                egui::Button::new(RichText::new("保存 Cookie").size(FontSize::SM).color(
-                    if can_save {
-                        Color32::WHITE
-                    } else {
-                        Theme::TEXT_MUTED
-                    },
-                ))
+                egui::Button::new(
+                    RichText::new(tr(&ui_language, "Save Cookie", "保存 Cookie"))
+                        .size(FontSize::SM)
+                        .color(if can_save {
+                            Color32::WHITE
+                        } else {
+                            Theme::TEXT_MUTED
+                        }),
+                )
                 .fill(if can_save {
                     Theme::ACCENT_PRIMARY
                 } else {
@@ -4314,13 +4435,22 @@ fn render_cookies_tab(ui: &mut egui::Ui, shared_state: &Arc<Mutex<PreferencesSha
                 let value = state.new_cookie_value.clone();
                 state.cookies.set(&provider, &value);
                 if let Err(e) = state.cookies.save() {
-                    state.cookie_status_msg = Some((format!("保存失败：{}", e), true));
+                    state.cookie_status_msg = Some((
+                        format!("{}: {}", tr(&ui_language, "Save failed", "保存失败"), e),
+                        true,
+                    ));
                 } else {
                     let provider_name = ProviderId::from_cli_name(&provider)
                         .map(|id| id.display_name().to_string())
                         .unwrap_or_else(|| provider.clone());
-                    state.cookie_status_msg =
-                        Some((format!("已保存 {} 的 Cookie", provider_name), false));
+                    state.cookie_status_msg = Some((
+                        format!(
+                            "{} {}",
+                            tr(&ui_language, "Saved cookie for", "已保存"),
+                            provider_name
+                        ),
+                        false,
+                    ));
                     state.new_cookie_provider.clear();
                     state.new_cookie_value.clear();
                 }
@@ -4331,12 +4461,13 @@ fn render_cookies_tab(ui: &mut egui::Ui, shared_state: &Arc<Mutex<PreferencesSha
 
 /// Render Advanced tab for viewport
 fn render_advanced_tab(ui: &mut egui::Ui, shared_state: &Arc<Mutex<PreferencesSharedState>>) {
+    let ui_language = current_ui_language(shared_state);
     section_header(ui, "Refresh");
 
     settings_card(ui, |ui| {
         ui.horizontal(|ui| {
             ui.label(
-                RichText::new("自动刷新间隔")
+                RichText::new(tr(&ui_language, "Auto-refresh interval", "自动刷新间隔"))
                     .size(FontSize::MD)
                     .color(Theme::TEXT_PRIMARY),
             );
@@ -4349,7 +4480,7 @@ fn render_advanced_tab(ui: &mut egui::Ui, shared_state: &Arc<Mutex<PreferencesSh
                 };
 
                 let intervals = [
-                    (0, "从不"),
+                    (0, tr(&ui_language, "Never", "从不")),
                     (30, "30 sec"),
                     (60, "1 min"),
                     (300, "5 min"),
@@ -4360,7 +4491,7 @@ fn render_advanced_tab(ui: &mut egui::Ui, shared_state: &Arc<Mutex<PreferencesSh
                     .iter()
                     .find(|(v, _)| *v == current_interval)
                     .map(|(_, l)| *l)
-                    .unwrap_or("自定义");
+                    .unwrap_or(tr(&ui_language, "Custom", "自定义"));
 
                 // Style combobox to match theme
                 ui.style_mut().visuals.widgets.inactive.bg_fill = Theme::BG_TERTIARY;
@@ -4393,7 +4524,8 @@ fn render_advanced_tab(ui: &mut egui::Ui, shared_state: &Arc<Mutex<PreferencesSh
 }
 
 /// Render About tab for viewport
-fn render_about_tab(ui: &mut egui::Ui) {
+fn render_about_tab(ui: &mut egui::Ui, shared_state: &Arc<Mutex<PreferencesSharedState>>) {
+    let ui_language = current_ui_language(shared_state);
     ui.vertical_centered(|ui| {
         ui.add_space(Spacing::XL);
 
@@ -4414,18 +4546,26 @@ fn render_about_tab(ui: &mut egui::Ui) {
 
         // Version
         ui.label(
-            RichText::new(format!("版本 {}", env!("CARGO_PKG_VERSION")))
-                .size(FontSize::MD)
-                .color(Theme::TEXT_SECONDARY),
+            RichText::new(format!(
+                "{} {}",
+                tr(&ui_language, "Version", "版本"),
+                env!("CARGO_PKG_VERSION")
+            ))
+            .size(FontSize::MD)
+            .color(Theme::TEXT_SECONDARY),
         );
 
         ui.add_space(Spacing::SM);
 
         // Tagline
         ui.label(
-            RichText::new("监控 AI 服务商用量限制")
-                .size(FontSize::SM)
-                .color(Theme::TEXT_MUTED),
+            RichText::new(tr(
+                &ui_language,
+                "Monitor AI provider usage limits",
+                "监控 AI 服务商用量限制",
+            ))
+            .size(FontSize::SM)
+            .color(Theme::TEXT_MUTED),
         );
 
         ui.add_space(Spacing::XL);
@@ -4436,9 +4576,13 @@ fn render_about_tab(ui: &mut egui::Ui) {
     settings_card(ui, |ui| {
         ui.vertical(|ui| {
             ui.label(
-                RichText::new("由 CodexBar 贡献者维护")
-                    .size(FontSize::SM)
-                    .color(Theme::TEXT_PRIMARY),
+                RichText::new(tr(
+                    &ui_language,
+                    "Maintained by CodexBar contributors",
+                    "由 CodexBar 贡献者维护",
+                ))
+                .size(FontSize::SM)
+                .color(Theme::TEXT_PRIMARY),
             );
             ui.add_space(Spacing::XS);
             ui.label(
@@ -4455,11 +4599,19 @@ fn render_about_tab(ui: &mut egui::Ui) {
     section_header(ui, "Links");
     settings_card(ui, |ui| {
         ui.vertical(|ui| {
-            if text_button(ui, "→ 查看 GitHub", Theme::ACCENT_PRIMARY) {
+            if text_button(
+                ui,
+                tr(&ui_language, "-> View GitHub", "→ 查看 GitHub"),
+                Theme::ACCENT_PRIMARY,
+            ) {
                 let _ = open::that("https://github.com/Finesssee/Win-CodexBar");
             }
             ui.add_space(Spacing::XS);
-            if text_button(ui, "→ 提交问题", Theme::ACCENT_PRIMARY) {
+            if text_button(
+                ui,
+                tr(&ui_language, "-> Report an issue", "→ 提交问题"),
+                Theme::ACCENT_PRIMARY,
+            ) {
                 let _ = open::that("https://github.com/Finesssee/Win-CodexBar/issues");
             }
         });
@@ -4476,7 +4628,7 @@ fn render_about_tab(ui: &mut egui::Ui) {
 
             ui.horizontal(|ui| {
                 ui.label(
-                    RichText::new("提交:")
+                    RichText::new(tr(&ui_language, "Commit:", "提交:"))
                         .size(FontSize::SM)
                         .color(Theme::TEXT_MUTED),
                 );
@@ -4492,7 +4644,7 @@ fn render_about_tab(ui: &mut egui::Ui) {
 
             ui.horizontal(|ui| {
                 ui.label(
-                    RichText::new("构建:")
+                    RichText::new(tr(&ui_language, "Build:", "构建:"))
                         .size(FontSize::SM)
                         .color(Theme::TEXT_MUTED),
                 );
@@ -4592,33 +4744,7 @@ fn section_header(ui: &mut egui::Ui, text: &str) {
 }
 
 fn zh_section_label(text: &str) -> &str {
-    match text {
-        "Startup" => "启动",
-        "Notifications" => "通知",
-        "Info" => "信息",
-        "Usage" => "用量",
-        "Quick Actions" => "快捷操作",
-        "Browser Cookie Import" => "浏览器 Cookie 导入",
-        "Usage Display" => "用量显示",
-        "Tray Icon" => "托盘图标",
-        "API Keys" => "API 密钥",
-        "Browser Cookies" => "浏览器 Cookie",
-        "Saved Cookies" => "已保存 Cookies",
-        "Add Manual Cookie" => "添加手动 Cookie",
-        "Refresh" => "刷新",
-        "Animations" => "动画",
-        "Menu Bar" => "菜单栏",
-        "Fun" => "趣味",
-        "Privacy" => "隐私",
-        "Updates" => "更新",
-        "Keyboard Shortcuts" => "快捷键",
-        "Appearance" => "外观",
-        "Credits" => "鸣谢",
-        "Links" => "链接",
-        "Build Info" => "构建信息",
-        "Enabled Providers" => "已启用服务商",
-        _ => text,
-    }
+    text
 }
 
 /// Settings card container - grouped settings with rounded corners and border

--- a/rust/src/providers/claude/mod.rs
+++ b/rust/src/providers/claude/mod.rs
@@ -169,6 +169,7 @@ impl ClaudeProvider {
         // Send /usage command
         if let Some(mut stdin) = child.stdin.take() {
             let _ = stdin.write_all(b"/usage\n").await;
+            tokio::time::sleep(std::time::Duration::from_millis(1500)).await;
             let _ = stdin.write_all(b"/exit\n").await;
             drop(stdin);
         }
@@ -207,6 +208,7 @@ impl ClaudeProvider {
     /// Parse Claude CLI /usage output
     fn parse_cli_output(&self, output: &str) -> Result<ProviderFetchResult, ProviderError> {
         let clean = strip_ansi(output);
+        let clean_lower = clean.to_lowercase();
 
         if clean.trim().is_empty() {
             return Err(ProviderError::Parse(
@@ -257,6 +259,20 @@ impl ClaudeProvider {
         // Extract reset times
         let session_reset = extract_reset_description(&clean, "current session");
         let weekly_reset = extract_reset_description(&clean, "current week");
+
+        // Newer Claude CLI builds can collapse the exhausted-session case down to a
+        // short status line without an explicit percent in the section we previously
+        // parsed. Treat that as a fully used current session instead of showing 0%.
+        let short_form_reset = if clean_lower.contains("out of extra usage") {
+            extract_inline_reset_description(&clean)
+        } else {
+            None
+        };
+        let session_reset = session_reset.or(short_form_reset);
+
+        if session_percent.is_none() && clean_lower.contains("out of extra usage") {
+            session_percent = Some(100.0);
+        }
 
         // Build usage snapshot
         let session_used = session_percent.unwrap_or(0.0);
@@ -517,6 +533,13 @@ fn extract_reset_description(text: &str, label: &str) -> Option<String> {
     None
 }
 
+/// Extract "resets ..." from a short single-line status, preserving original casing.
+fn extract_inline_reset_description(text: &str) -> Option<String> {
+    let lower = text.to_lowercase();
+    let pos = lower.find("resets")?;
+    Some(text[pos..].trim().to_string())
+}
+
 /// Clean up a plan name by removing ANSI codes and extra whitespace
 fn clean_plan_name(text: &str) -> String {
     let cleaned = strip_ansi(text);
@@ -524,4 +547,62 @@ fn clean_plan_name(text: &str) -> String {
     let re = Regex::new(r"\[\d+m").unwrap_or_else(|_| Regex::new(".^").unwrap());
     let result = re.replace_all(&cleaned, "");
     result.trim().to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_current_cli_usage_screen() {
+        let provider = ClaudeProvider::new();
+        let output = r#"
+Status   Config   Usage
+
+  Current session
+  ██████████████████████████████████████████████████ 100% used
+  Resets 12pm (America/Bogota)
+
+  Current week (all models)
+  ████████████████████████▌                          49% used
+  Resets Apr 3, 2pm (America/Bogota)
+
+  Extra usage
+  ██▍                                                4% used
+  $3.31 / $70.00 spent · Resets Apr 1 (America/Bogota)
+"#;
+
+        let result = provider.parse_cli_output(output).expect("should parse");
+
+        assert_eq!(result.source, "cli");
+        assert_eq!(result.usage.primary.used_percent, 100.0);
+        assert_eq!(
+            result.usage.primary.reset_description.as_deref(),
+            Some("Resets 12pm (America/Bogota)")
+        );
+
+        let weekly = result
+            .usage
+            .secondary
+            .expect("weekly usage should be present");
+        assert_eq!(weekly.used_percent, 49.0);
+        assert_eq!(
+            weekly.reset_description.as_deref(),
+            Some("Resets Apr 3, 2pm (America/Bogota)")
+        );
+    }
+
+    #[test]
+    fn parses_exhausted_short_form_as_full_session_usage() {
+        let provider = ClaudeProvider::new();
+        let output = "You're out of extra usage · resets 12pm (America/Bogota)";
+
+        let result = provider.parse_cli_output(output).expect("should parse");
+
+        assert_eq!(result.usage.primary.used_percent, 100.0);
+        assert_eq!(
+            result.usage.primary.reset_description.as_deref(),
+            Some("resets 12pm (America/Bogota)")
+        );
+    }
 }

--- a/rust/src/providers/claude/oauth.rs
+++ b/rust/src/providers/claude/oauth.rs
@@ -332,7 +332,7 @@ impl ClaudeOAuthFetcher {
 
     /// Convert OAuth usage window to RateWindow
     fn to_rate_window(window: &UsageWindow, window_minutes: Option<u32>) -> Option<RateWindow> {
-        let utilization = window.utilization?;
+        let utilization = normalize_utilization(window.utilization?);
 
         let resets_at = window
             .resets_at
@@ -350,9 +350,34 @@ impl ClaudeOAuthFetcher {
     }
 }
 
+fn normalize_utilization(utilization: f64) -> f64 {
+    if utilization > 0.0 && utilization <= 1.0 {
+        utilization * 100.0
+    } else {
+        utilization
+    }
+}
+
 impl Default for ClaudeOAuthFetcher {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::normalize_utilization;
+
+    #[test]
+    fn normalizes_fractional_utilization_to_percent() {
+        assert!((normalize_utilization(0.23) - 23.0).abs() < f64::EPSILON);
+        assert!((normalize_utilization(1.0) - 100.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn preserves_percent_utilization_values() {
+        assert!((normalize_utilization(23.0) - 23.0).abs() < f64::EPSILON);
+        assert!(normalize_utilization(0.0).abs() < f64::EPSILON);
     }
 }
 

--- a/rust/src/providers/claude/web_api.rs
+++ b/rust/src/providers/claude/web_api.rs
@@ -1,7 +1,7 @@
 //! Claude Web API fetcher - uses browser cookies to fetch usage from claude.ai
 
 use chrono::{DateTime, Utc};
-use reqwest::{header, Client};
+use reqwest::{Client, header};
 use serde::Deserialize;
 
 use crate::browser::cookies::get_cookie_header;
@@ -315,7 +315,7 @@ impl ClaudeWebApiFetcher {
 
     /// Convert a usage window to a RateWindow
     fn to_rate_window(&self, window: &UsageWindow, window_minutes: Option<u32>) -> RateWindow {
-        let used_percent = window.utilization.unwrap_or(0.0);
+        let used_percent = normalize_utilization(window.utilization.unwrap_or(0.0));
 
         let resets_at = window
             .resets_at
@@ -357,8 +357,33 @@ impl ClaudeWebApiFetcher {
     }
 }
 
+fn normalize_utilization(utilization: f64) -> f64 {
+    if utilization > 0.0 && utilization <= 1.0 {
+        utilization * 100.0
+    } else {
+        utilization
+    }
+}
+
 impl Default for ClaudeWebApiFetcher {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::normalize_utilization;
+
+    #[test]
+    fn normalizes_fractional_utilization_to_percent() {
+        assert!((normalize_utilization(0.23) - 23.0).abs() < f64::EPSILON);
+        assert!((normalize_utilization(1.0) - 100.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn preserves_percent_utilization_values() {
+        assert!((normalize_utilization(23.0) - 23.0).abs() < f64::EPSILON);
+        assert!(normalize_utilization(0.0).abs() < f64::EPSILON);
     }
 }

--- a/rust/src/providers/kiro/mod.rs
+++ b/rust/src/providers/kiro/mod.rs
@@ -8,14 +8,13 @@ pub mod version;
 // Re-exports for version compatibility checking
 #[allow(unused_imports)]
 pub use version::{
-    detect_version, find_kiro_cli, get_version, is_compatible, is_installed, KiroVersion,
+    KiroVersion, detect_version, find_kiro_cli, get_version, is_compatible, is_installed,
 };
 
 use async_trait::async_trait;
 use chrono::Datelike;
 use regex_lite::Regex;
 #[cfg(windows)]
-use std::os::windows::process::CommandExt;
 use std::path::PathBuf;
 use std::process::Stdio;
 use tokio::process::Command;
@@ -340,7 +339,7 @@ impl KiroProvider {
                 // Skip escape sequence
                 if chars.peek() == Some(&'[') {
                     chars.next(); // consume '['
-                                  // Skip until we hit a letter
+                    // Skip until we hit a letter
                     while let Some(&next) = chars.peek() {
                         chars.next();
                         if next.is_ascii_alphabetic() {

--- a/rust/src/providers/vertexai/mod.rs
+++ b/rust/src/providers/vertexai/mod.rs
@@ -11,7 +11,6 @@ pub use token_refresher::{RefreshError, VertexAIOAuthCredentials, VertexAITokenR
 
 use async_trait::async_trait;
 #[cfg(windows)]
-use std::os::windows::process::CommandExt;
 use std::path::PathBuf;
 
 use crate::core::{

--- a/rust/src/settings.rs
+++ b/rust/src/settings.rs
@@ -180,6 +180,10 @@ pub struct Settings {
     /// Hide personal info (emails, account names) for streaming/sharing
     pub hide_personal_info: bool,
 
+    /// UI language for tray and popup labels ("en" or "zh")
+    #[serde(default = "default_ui_language")]
+    pub ui_language: String,
+
     /// Update channel for receiving updates (Stable or Beta)
     pub update_channel: UpdateChannel,
 
@@ -208,6 +212,10 @@ fn default_global_shortcut() -> String {
     "Ctrl+Shift+U".to_string()
 }
 
+fn default_ui_language() -> String {
+    crate::i18n::UI_LANGUAGE_EN.to_string()
+}
+
 impl Default for Settings {
     fn default() -> Self {
         let mut enabled = HashSet::new();
@@ -234,6 +242,7 @@ impl Default for Settings {
             menu_bar_display_mode: "detailed".to_string(), // Detailed mode by default
             show_credits_extra_usage: true, // Show credits + extra usage by default
             hide_personal_info: false, // Show personal info by default
+            ui_language: default_ui_language(), // English by default
             update_channel: UpdateChannel::default(), // Stable by default
             provider_metrics: HashMap::new(), // Empty = use Automatic for all
             global_shortcut: default_global_shortcut(), // Ctrl+Shift+U by default
@@ -300,8 +309,8 @@ impl Settings {
 
         #[cfg(target_os = "windows")]
         {
-            use winreg::enums::*;
             use winreg::RegKey;
+            use winreg::enums::*;
 
             let hkcu = RegKey::predef(HKEY_CURRENT_USER);
             let run_key = hkcu.open_subkey_with_flags(
@@ -328,8 +337,8 @@ impl Settings {
     /// Check if start at login is actually enabled in registry
     #[cfg(target_os = "windows")]
     pub fn is_start_at_login_enabled() -> bool {
-        use winreg::enums::*;
         use winreg::RegKey;
+        use winreg::enums::*;
 
         let hkcu = RegKey::predef(HKEY_CURRENT_USER);
         if let Ok(run_key) = hkcu.open_subkey(r"Software\Microsoft\Windows\CurrentVersion\Run") {
@@ -735,7 +744,9 @@ pub fn get_api_key_providers() -> Vec<ProviderConfigInfo> {
             name: "Warp",
             requires_api_key: true,
             api_key_env_var: Some("WARP_API_KEY"),
-            api_key_help: Some("Get your API key from Warp → Settings → API Keys (docs.warp.dev/reference/cli/api-keys)"),
+            api_key_help: Some(
+                "Get your API key from Warp → Settings → API Keys (docs.warp.dev/reference/cli/api-keys)",
+            ),
             config_file_path: None,
             dashboard_url: Some("https://docs.warp.dev/reference/cli/api-keys"),
         },

--- a/rust/src/tray/manager.rs
+++ b/rust/src/tray/manager.rs
@@ -6,15 +6,16 @@
 
 use image::{ImageBuffer, Rgba, RgbaImage};
 use std::cell::{Cell, RefCell};
-use std::collections::{hash_map::DefaultHasher, HashMap};
+use std::collections::{HashMap, hash_map::DefaultHasher};
 use std::hash::{Hash, Hasher};
 use tray_icon::{
-    menu::{CheckMenuItem, Menu, MenuEvent, MenuItem, PredefinedMenuItem, Submenu},
     Icon, TrayIcon, TrayIconBuilder,
+    menu::{CheckMenuItem, Menu, MenuEvent, MenuItem, PredefinedMenuItem, Submenu},
 };
 
 use super::icon::{LoadingPattern, UsageLevel};
 use crate::core::ProviderId;
+use crate::i18n::{is_zh, tr};
 use crate::settings::{Settings, TrayIconMode};
 use crate::status::IndicatorStatusLevel;
 
@@ -94,6 +95,7 @@ pub struct ProviderUsage {
 /// System tray manager
 pub struct TrayManager {
     tray_icon: TrayIcon,
+    ui_language: String,
     /// Provider menu items for updating with status prefixes
     provider_menu_items: HashMap<ProviderId, CheckMenuItem>,
     last_usage_signature: Cell<Option<u64>>,
@@ -104,17 +106,28 @@ impl TrayManager {
     /// Create a new tray manager with default icon
     pub fn new() -> anyhow::Result<Self> {
         let settings = Settings::load();
+        let ui_language = settings.ui_language.clone();
         let menu = Menu::new();
 
         // Open CodexBar
-        let open_item = MenuItem::with_id("open", "打开 CodexBar", true, None);
+        let open_item = MenuItem::with_id(
+            "open",
+            tr(&ui_language, "Open CodexBar", "打开 CodexBar"),
+            true,
+            None,
+        );
         menu.append(&open_item)?;
 
         // Separator
         menu.append(&PredefinedMenuItem::separator())?;
 
         // Refresh All
-        let refresh_item = MenuItem::with_id("refresh", "全部刷新", true, None);
+        let refresh_item = MenuItem::with_id(
+            "refresh",
+            tr(&ui_language, "Refresh All", "全部刷新"),
+            true,
+            None,
+        );
         menu.append(&refresh_item)?;
 
         // Separator
@@ -122,7 +135,7 @@ impl TrayManager {
 
         // Providers submenu with check items
         // Build submenu items first, then add to parent menu to avoid Windows duplication bug
-        let providers_submenu = Submenu::new("服务商", true);
+        let providers_submenu = Submenu::new(tr(&ui_language, "Providers", "服务商"), true);
         let mut provider_menu_items = HashMap::new();
         for provider_id in ProviderId::all() {
             let cli_name = provider_id.cli_name();
@@ -139,30 +152,45 @@ impl TrayManager {
         menu.append(&PredefinedMenuItem::separator())?;
 
         // Settings
-        let settings_item = MenuItem::with_id("settings", "设置...", true, None);
+        let settings_item = MenuItem::with_id(
+            "settings",
+            tr(&ui_language, "Settings...", "设置..."),
+            true,
+            None,
+        );
         menu.append(&settings_item)?;
 
         // Check for Updates
-        let updates_item = MenuItem::with_id("updates", "检查更新", true, None);
+        let updates_item = MenuItem::with_id(
+            "updates",
+            tr(&ui_language, "Check for Updates", "检查更新"),
+            true,
+            None,
+        );
         menu.append(&updates_item)?;
 
         // Separator
         menu.append(&PredefinedMenuItem::separator())?;
 
         // Quit
-        let quit_item = MenuItem::with_id("quit", "退出", true, None);
+        let quit_item = MenuItem::with_id("quit", tr(&ui_language, "Quit", "退出"), true, None);
         menu.append(&quit_item)?;
 
         let icon = create_bar_icon(0.0, 0.0, IconOverlay::None);
 
         let tray_icon = TrayIconBuilder::new()
             .with_menu(Box::new(menu))
-            .with_tooltip("CodexBar - 加载中...")
+            .with_tooltip(tr(
+                &ui_language,
+                "CodexBar - Loading...",
+                "CodexBar - 加载中...",
+            ))
             .with_icon(icon)
             .build()?;
 
         Ok(Self {
             tray_icon,
+            ui_language,
             provider_menu_items,
             last_usage_signature: Cell::new(None),
             last_merged_signature: Cell::new(None),
@@ -171,10 +199,17 @@ impl TrayManager {
 
     /// Update the tray icon based on usage percentages (single provider mode)
     pub fn update_usage(&self, session_percent: f64, weekly_percent: f64, provider_name: &str) {
-        let tooltip = format!(
-            "{}：会话 {}% | 周度 {}%",
-            provider_name, session_percent as i32, weekly_percent as i32
-        );
+        let tooltip = if is_zh(&self.ui_language) {
+            format!(
+                "{}：会话 {}% | 周度 {}%",
+                provider_name, session_percent as i32, weekly_percent as i32
+            )
+        } else {
+            format!(
+                "{}: Session {}% | Weekly {}%",
+                provider_name, session_percent as i32, weekly_percent as i32
+            )
+        };
         let _ = self.tray_icon.set_tooltip(Some(&tooltip));
 
         if !self.should_update_usage(
@@ -200,16 +235,23 @@ impl TrayManager {
     ) {
         let status_suffix = match overlay {
             IconOverlay::None => "",
-            IconOverlay::Error => "（错误）",
-            IconOverlay::Stale => "（数据过期）",
-            IconOverlay::Incident => "（故障）",
-            IconOverlay::Partial => "（部分中断）",
+            IconOverlay::Error => tr(&self.ui_language, " (Error)", "（错误）"),
+            IconOverlay::Stale => tr(&self.ui_language, " (Stale Data)", "（数据过期）"),
+            IconOverlay::Incident => tr(&self.ui_language, " (Incident)", "（故障）"),
+            IconOverlay::Partial => tr(&self.ui_language, " (Partial Outage)", "（部分中断）"),
         };
 
-        let tooltip = format!(
-            "{}：会话 {}% | 周度 {}%{}",
-            provider_name, session_percent as i32, weekly_percent as i32, status_suffix
-        );
+        let tooltip = if is_zh(&self.ui_language) {
+            format!(
+                "{}：会话 {}% | 周度 {}%{}",
+                provider_name, session_percent as i32, weekly_percent as i32, status_suffix
+            )
+        } else {
+            format!(
+                "{}: Session {}% | Weekly {}%{}",
+                provider_name, session_percent as i32, weekly_percent as i32, status_suffix
+            )
+        };
         let _ = self.tray_icon.set_tooltip(Some(&tooltip));
 
         if !self.should_update_usage(session_percent, weekly_percent, provider_name, overlay) {
@@ -241,10 +283,17 @@ impl TrayManager {
         let icon = create_bar_icon(session_percent, weekly_percent, IconOverlay::Stale);
         let _ = self.tray_icon.set_icon(Some(icon));
 
-        let tooltip = format!(
-            "{}：会话 {}% | 周度 {}%（数据 {} 分钟前）",
-            provider_name, session_percent as i32, weekly_percent as i32, age_minutes
-        );
+        let tooltip = if is_zh(&self.ui_language) {
+            format!(
+                "{}：会话 {}% | 周度 {}%（数据 {} 分钟前）",
+                provider_name, session_percent as i32, weekly_percent as i32, age_minutes
+            )
+        } else {
+            format!(
+                "{}: Session {}% | Weekly {}% (data {} minutes ago)",
+                provider_name, session_percent as i32, weekly_percent as i32, age_minutes
+            )
+        };
         let _ = self.tray_icon.set_tooltip(Some(&tooltip));
     }
 
@@ -254,10 +303,17 @@ impl TrayManager {
         let icon = create_credits_icon(credits_percent);
         let _ = self.tray_icon.set_icon(Some(icon));
 
-        let tooltip = format!(
-            "{}：周额度已用尽 | 剩余额度 {:.0}%",
-            provider_name, credits_percent
-        );
+        let tooltip = if is_zh(&self.ui_language) {
+            format!(
+                "{}：周额度已用尽 | 剩余额度 {:.0}%",
+                provider_name, credits_percent
+            )
+        } else {
+            format!(
+                "{}: Weekly quota exhausted | Credits remaining {:.0}%",
+                provider_name, credits_percent
+            )
+        };
         let _ = self.tray_icon.set_tooltip(Some(&tooltip));
     }
 
@@ -266,7 +322,11 @@ impl TrayManager {
         if providers.is_empty() {
             let icon = create_bar_icon(0.0, 0.0, IconOverlay::None);
             let _ = self.tray_icon.set_icon(Some(icon));
-            let _ = self.tray_icon.set_tooltip(Some("CodexBar - 无可用服务商"));
+            let _ = self.tray_icon.set_tooltip(Some(tr(
+                &self.ui_language,
+                "CodexBar - No providers available",
+                "CodexBar - 无可用服务商",
+            )));
             return;
         }
 
@@ -309,7 +369,11 @@ impl TrayManager {
 
         let icon = create_loading_icon(primary, secondary);
         let _ = self.tray_icon.set_icon(Some(icon));
-        let _ = self.tray_icon.set_tooltip(Some("CodexBar - 加载中..."));
+        let _ = self.tray_icon.set_tooltip(Some(tr(
+            &self.ui_language,
+            "CodexBar - Loading...",
+            "CodexBar - 加载中...",
+        )));
     }
 
     /// Show morph animation on the tray icon (Unbraid effect)
@@ -317,7 +381,11 @@ impl TrayManager {
     pub fn show_morph(&self, progress: f64, session_percent: f64, weekly_percent: f64) {
         let icon = create_morph_icon(progress, session_percent, weekly_percent);
         let _ = self.tray_icon.set_icon(Some(icon));
-        let _ = self.tray_icon.set_tooltip(Some("CodexBar - 加载中..."));
+        let _ = self.tray_icon.set_tooltip(Some(tr(
+            &self.ui_language,
+            "CodexBar - Loading...",
+            "CodexBar - 加载中...",
+        )));
     }
 
     /// Show a surprise animation frame
@@ -456,14 +524,17 @@ pub enum TrayMenuAction {
 pub struct MultiTrayManager {
     /// Map of provider ID to their individual tray icon
     provider_icons: HashMap<ProviderId, TrayIcon>,
+    ui_language: String,
     provider_signatures: RefCell<HashMap<ProviderId, u64>>,
 }
 
 impl MultiTrayManager {
     /// Create a new multi-tray manager with icons for enabled providers
     pub fn new() -> anyhow::Result<Self> {
+        let settings = Settings::load();
         Ok(Self {
             provider_icons: HashMap::new(),
+            ui_language: settings.ui_language,
             provider_signatures: RefCell::new(HashMap::new()),
         })
     }
@@ -506,13 +577,18 @@ impl MultiTrayManager {
         menu.append(&PredefinedMenuItem::separator())?;
 
         // Open CodexBar
-        let open_item = MenuItem::with_id("open", "打开 CodexBar", true, None);
+        let open_item = MenuItem::with_id(
+            "open",
+            tr(&self.ui_language, "Open CodexBar", "打开 CodexBar"),
+            true,
+            None,
+        );
         menu.append(&open_item)?;
 
         // Refresh
         let refresh_item = MenuItem::with_id(
             &format!("refresh_{}", provider_id.cli_name()),
-            "刷新",
+            tr(&self.ui_language, "Refresh", "刷新"),
             true,
             None,
         );
@@ -521,17 +597,27 @@ impl MultiTrayManager {
         menu.append(&PredefinedMenuItem::separator())?;
 
         // Settings
-        let settings_item = MenuItem::with_id("settings", "设置...", true, None);
+        let settings_item = MenuItem::with_id(
+            "settings",
+            tr(&self.ui_language, "Settings...", "设置..."),
+            true,
+            None,
+        );
         menu.append(&settings_item)?;
 
         menu.append(&PredefinedMenuItem::separator())?;
 
         // Quit
-        let quit_item = MenuItem::with_id("quit", "退出", true, None);
+        let quit_item =
+            MenuItem::with_id("quit", tr(&self.ui_language, "Quit", "退出"), true, None);
         menu.append(&quit_item)?;
 
         let icon = create_bar_icon(0.0, 0.0, IconOverlay::None);
-        let tooltip = format!("{} - 加载中...", provider_id.display_name());
+        let tooltip = format!(
+            "{} - {}",
+            provider_id.display_name(),
+            tr(&self.ui_language, "Loading...", "加载中...")
+        );
 
         let tray_icon = TrayIconBuilder::new()
             .with_menu(Box::new(menu))
@@ -565,7 +651,7 @@ impl MultiTrayManager {
             let _ = tray_icon.set_icon(Some(icon));
 
             let tooltip = format!(
-                "{}：会话 {}% | 周度 {}%",
+                "{}: Session {}% | Weekly {}%",
                 provider_id.display_name(),
                 session_percent as i32,
                 weekly_percent as i32
@@ -599,14 +685,14 @@ impl MultiTrayManager {
 
             let status_suffix = match overlay {
                 IconOverlay::None => "",
-                IconOverlay::Error => "（错误）",
-                IconOverlay::Stale => "（数据过期）",
-                IconOverlay::Incident => "（故障）",
-                IconOverlay::Partial => "（部分中断）",
+                IconOverlay::Error => " (Error)",
+                IconOverlay::Stale => " (Stale Data)",
+                IconOverlay::Incident => " (Incident)",
+                IconOverlay::Partial => " (Partial Outage)",
             };
 
             let tooltip = format!(
-                "{}：会话 {}% | 周度 {}%{}",
+                "{}: Session {}% | Weekly {}%{}",
                 provider_id.display_name(),
                 session_percent as i32,
                 weekly_percent as i32,
@@ -630,7 +716,7 @@ impl MultiTrayManager {
             let icon = create_loading_icon(primary, secondary);
             let _ = tray_icon.set_icon(Some(icon));
             let _ = tray_icon.set_tooltip(Some(&format!(
-                "{} - 加载中...",
+                "{} - Loading...",
                 provider_id.display_name()
             )));
         }


### PR DESCRIPTION
## Summary
- add a minimal English/Chinese UI language setting and wire key tray/popup/preferences strings through it
- fix Claude utilization parsing for web/oauth responses that return fractional values
- improve Claude CLI usage parsing for current `/usage` output, including exhausted-session handling and reset text
- update the Windows dev script to resolve the built binary from the active Cargo target

## Verification
- `cargo fmt --all`
- `cargo check --bin codexbar`

## Notes
- Claude weekly usage is only available when the CLI returns the full interactive usage screen. In non-interactive mode, Claude may only emit the short exhausted-session line, which limits what can be shown from CLI source alone.