### PR TITLE
chore: release v1.2.10

### DIFF
--- a/rust/CHANGELOG.md
+++ b/rust/CHANGELOG.md
@@ -20,6 +20,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ---
 
+## [1.2.10] — 2026-04-03
+
+### Added
+- Added NanoGPT as a supported provider on current `main`, including daily/monthly usage parsing and the related Windows preferences wiring.
+
+### Fixed
+- Aligned the CLI help text with the actual supported provider set so `nanogpt` now appears in both top-level help and `codexbar usage --help`.
+
+---
+
 ## [1.2.9] — 2026-04-03
 
 ### Changed
@@ -172,7 +182,8 @@ Complete porting of Swift CodexBar features to Rust Windows version:
 
 ---
 
-[Unreleased]: https://github.com/Finesssee/Win-CodexBar/compare/v1.2.9...HEAD
+[Unreleased]: https://github.com/Finesssee/Win-CodexBar/compare/v1.2.10...HEAD
+[1.2.10]: https://github.com/Finesssee/Win-CodexBar/compare/v1.2.9...v1.2.10
 [1.2.9]: https://github.com/Finesssee/Win-CodexBar/compare/v1.2.8...v1.2.9
 [1.2.8]: https://github.com/Finesssee/Win-CodexBar/compare/v1.2.7...v1.2.8
 [1.0.1]: https://github.com/Finesssee/Win-CodexBar/compare/v1.0.0...v1.0.1

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -560,7 +560,7 @@ dependencies = [
 
 [[package]]
 name = "codexbar"
-version = "1.2.9"
+version = "1.2.10"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codexbar"
-version = "1.2.9"
+version = "1.2.10"
 edition = "2024"
 authors = ["CodexBar Contributors"]
 description = "Windows and WSL system tray app for monitoring AI provider usage limits"


### PR DESCRIPTION
## Summary
- bump the app version to 1.2.10
- document the NanoGPT and CLI help updates in the changelog
- prepare main for the v1.2.10 release tag

## Verification
- cargo +stable fmt --manifest-path rust/Cargo.toml --all --check
- cargo +stable clippy --manifest-path rust/Cargo.toml --all-targets --target x86_64-unknown-linux-gnu -- -D warnings
- cargo +stable test --manifest-path rust/Cargo.toml --target x86_64-unknown-linux-gnu
- cargo +stable run --manifest-path rust/Cargo.toml -- --version