### PR TITLE
fix: secure persisted credentials and restore TLS verification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - "**"
   pull_request:
+  workflow_dispatch:
 
 jobs:
   rust-quality-linux:

--- a/rust/src/browser/cookie_cache.rs
+++ b/rust/src/browser/cookie_cache.rs
@@ -5,7 +5,7 @@
 
 #![allow(dead_code)]
 
-use crate::core::ProviderId;
+use crate::core::{CredentialStore, ProviderId, WindowsCredentialStore};
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use std::fs;
@@ -15,6 +15,7 @@ use std::path::PathBuf;
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CookieHeaderEntry {
     /// The normalized cookie header string
+    #[serde(skip_serializing, default)]
     pub cookie_header: String,
     /// When this entry was stored
     pub stored_at: DateTime<Utc>,
@@ -41,12 +42,26 @@ impl CookieHeaderEntry {
 /// Cookie header cache store
 pub struct CookieHeaderCache;
 
+const COOKIE_CACHE_SERVICE: &str = "CodexBar";
+
 impl CookieHeaderCache {
+    fn credential_key(provider: ProviderId) -> String {
+        format!("{}-cookie-cache", provider.cli_name())
+    }
+
+    fn credential_store() -> WindowsCredentialStore {
+        WindowsCredentialStore::new()
+    }
+
     /// Load cached cookie header for a provider
     pub fn load(provider: ProviderId) -> Option<CookieHeaderEntry> {
         let path = Self::cache_path(provider)?;
         let data = fs::read_to_string(&path).ok()?;
-        serde_json::from_str(&data).ok()
+        let mut entry: CookieHeaderEntry = serde_json::from_str(&data).ok()?;
+        entry.cookie_header = Self::credential_store()
+            .get(COOKIE_CACHE_SERVICE, &Self::credential_key(provider))
+            .ok()?;
+        Some(entry)
     }
 
     /// Store a cookie header for a provider
@@ -66,8 +81,12 @@ impl CookieHeaderCache {
             return Ok(());
         }
 
-        let entry = CookieHeaderEntry::new(normalized, source_label);
+        let entry = CookieHeaderEntry::new(normalized.clone(), source_label);
         let path = Self::cache_path(provider).ok_or(CookieHeaderCacheError::PathNotAvailable)?;
+
+        Self::credential_store()
+            .set(COOKIE_CACHE_SERVICE, &Self::credential_key(provider), &normalized)
+            .map_err(|e| CookieHeaderCacheError::Credential(e.to_string()))?;
 
         // Create parent directory
         if let Some(parent) = path.parent() {
@@ -88,6 +107,7 @@ impl CookieHeaderCache {
 
     /// Clear cached cookie header for a provider
     pub fn clear(provider: ProviderId) {
+        let _ = Self::credential_store().delete(COOKIE_CACHE_SERVICE, &Self::credential_key(provider));
         if let Some(path) = Self::cache_path(provider)
             && let Err(e) = fs::remove_file(&path)
             && e.kind() != std::io::ErrorKind::NotFound
@@ -158,6 +178,8 @@ pub enum CookieHeaderCacheError {
     Io(#[from] std::io::Error),
     #[error("JSON error: {0}")]
     Json(#[from] serde_json::Error),
+    #[error("Credential error: {0}")]
+    Credential(String),
 }
 
 #[cfg(test)]
@@ -189,5 +211,12 @@ mod tests {
 
         let whitespace = CookieHeaderCache::normalize_cookie_header("   ;  ;  ");
         assert!(whitespace.is_empty());
+    }
+
+    #[test]
+    fn test_cookie_cache_entry_serialization_does_not_include_cookie_value() {
+        let entry = CookieHeaderEntry::new("session=secret", "Chrome");
+        let json = serde_json::to_string(&entry).unwrap();
+        assert!(!json.contains("session=secret"));
     }
 }

--- a/rust/src/browser/cookie_cache.rs
+++ b/rust/src/browser/cookie_cache.rs
@@ -85,7 +85,11 @@ impl CookieHeaderCache {
         let path = Self::cache_path(provider).ok_or(CookieHeaderCacheError::PathNotAvailable)?;
 
         Self::credential_store()
-            .set(COOKIE_CACHE_SERVICE, &Self::credential_key(provider), &normalized)
+            .set(
+                COOKIE_CACHE_SERVICE,
+                &Self::credential_key(provider),
+                &normalized,
+            )
             .map_err(|e| CookieHeaderCacheError::Credential(e.to_string()))?;
 
         // Create parent directory
@@ -107,7 +111,8 @@ impl CookieHeaderCache {
 
     /// Clear cached cookie header for a provider
     pub fn clear(provider: ProviderId) {
-        let _ = Self::credential_store().delete(COOKIE_CACHE_SERVICE, &Self::credential_key(provider));
+        let _ =
+            Self::credential_store().delete(COOKIE_CACHE_SERVICE, &Self::credential_key(provider));
         if let Some(path) = Self::cache_path(provider)
             && let Err(e) = fs::remove_file(&path)
             && e.kind() != std::io::ErrorKind::NotFound

--- a/rust/src/core/credentials.rs
+++ b/rust/src/core/credentials.rs
@@ -78,6 +78,52 @@ impl CredentialStore for WindowsCredentialStore {
     }
 }
 
+#[cfg(not(windows))]
+pub struct WindowsCredentialStore;
+
+#[cfg(not(windows))]
+impl WindowsCredentialStore {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+#[cfg(not(windows))]
+impl Default for WindowsCredentialStore {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(not(windows))]
+impl CredentialStore for WindowsCredentialStore {
+    fn get(&self, service: &str, key: &str) -> Result<String, CredentialError> {
+        let entry = keyring::Entry::new(service, key)
+            .map_err(|e| CredentialError::Storage(e.to_string()))?;
+        entry.get_password().map_err(|e| match e {
+            keyring::Error::NoEntry => CredentialError::NotFound,
+            keyring::Error::Ambiguous(_) => CredentialError::Storage("Ambiguous entry".to_string()),
+            _ => CredentialError::Storage(e.to_string()),
+        })
+    }
+
+    fn set(&self, service: &str, key: &str, value: &str) -> Result<(), CredentialError> {
+        let entry = keyring::Entry::new(service, key)
+            .map_err(|e| CredentialError::Storage(e.to_string()))?;
+        entry
+            .set_password(value)
+            .map_err(|e| CredentialError::Storage(e.to_string()))
+    }
+
+    fn delete(&self, service: &str, key: &str) -> Result<(), CredentialError> {
+        let entry = keyring::Entry::new(service, key)
+            .map_err(|e| CredentialError::Storage(e.to_string()))?;
+        entry.delete_credential().map_err(|e| match e {
+            keyring::Error::NoEntry => CredentialError::NotFound,
+            _ => CredentialError::Storage(e.to_string()),
+        })
+    }
+}
 /// OAuth credentials structure
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct OAuthCredentials {

--- a/rust/src/core/token_accounts.rs
+++ b/rust/src/core/token_accounts.rs
@@ -434,7 +434,11 @@ impl TokenAccountStore {
         for (provider, data) in &existing {
             if let Some(current) = accounts.get(provider) {
                 for account in &data.accounts {
-                    if !current.accounts.iter().any(|candidate| candidate.id == account.id) {
+                    if !current
+                        .accounts
+                        .iter()
+                        .any(|candidate| candidate.id == account.id)
+                    {
                         let _ = Self::credential_store().delete(
                             TOKEN_ACCOUNT_CREDENTIAL_SERVICE,
                             &Self::credential_key(*provider, account.id),

--- a/rust/src/core/token_accounts.rs
+++ b/rust/src/core/token_accounts.rs
@@ -3,7 +3,7 @@
 //! Store and manage multiple accounts/tokens per provider.
 //! Supports parallel fetching and account switching.
 
-use crate::core::ProviderId;
+use crate::core::{CredentialStore, ProviderId, WindowsCredentialStore};
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -53,7 +53,7 @@ impl TokenAccountSupport {
             }),
             ProviderId::Zai => Some(TokenAccountSupport {
                 title: "API tokens",
-                subtitle: "Stored locally in token-accounts.json.",
+                subtitle: "Stored securely in the system credential store.",
                 placeholder: "Paste token...",
                 injection: TokenInjection::Environment {
                     key: "ZED_API_TOKEN".to_string(),
@@ -205,6 +205,7 @@ pub struct TokenAccount {
     /// User-provided label
     pub label: String,
     /// The token/cookie value
+    #[serde(skip_serializing, default)]
     pub token: String,
     /// When this account was added (Unix timestamp in seconds)
     pub added_at: i64,
@@ -347,6 +348,8 @@ pub struct TokenAccountStore {
     file_path: PathBuf,
 }
 
+const TOKEN_ACCOUNT_CREDENTIAL_SERVICE: &str = "CodexBar";
+
 /// Errors that can occur with token account storage
 #[derive(Debug, thiserror::Error)]
 pub enum TokenAccountError {
@@ -354,9 +357,19 @@ pub enum TokenAccountError {
     Io(#[from] io::Error),
     #[error("JSON error: {0}")]
     Json(#[from] serde_json::Error),
+    #[error("Credential error: {0}")]
+    Credential(String),
 }
 
 impl TokenAccountStore {
+    fn credential_store() -> WindowsCredentialStore {
+        WindowsCredentialStore::new()
+    }
+
+    fn credential_key(provider: ProviderId, account_id: Uuid) -> String {
+        format!("token-account-{}-{}", provider.cli_name(), account_id)
+    }
+
     /// Create a new store with the default path
     pub fn new() -> Self {
         Self {
@@ -391,8 +404,16 @@ impl TokenAccountStore {
         let file: TokenAccountsFile = serde_json::from_str(&data)?;
 
         let mut result = HashMap::new();
-        for (key, value) in file.providers {
+        for (key, mut value) in file.providers {
             if let Some(provider) = ProviderId::from_cli_name(&key) {
+                for account in &mut value.accounts {
+                    if let Ok(secret) = Self::credential_store().get(
+                        TOKEN_ACCOUNT_CREDENTIAL_SERVICE,
+                        &Self::credential_key(provider, account.id),
+                    ) {
+                        account.token = secret;
+                    }
+                }
                 result.insert(provider, value);
             }
         }
@@ -409,8 +430,50 @@ impl TokenAccountStore {
             fs::create_dir_all(parent)?;
         }
 
+        let existing = self.load().unwrap_or_default();
+        for (provider, data) in &existing {
+            if let Some(current) = accounts.get(provider) {
+                for account in &data.accounts {
+                    if !current.accounts.iter().any(|candidate| candidate.id == account.id) {
+                        let _ = Self::credential_store().delete(
+                            TOKEN_ACCOUNT_CREDENTIAL_SERVICE,
+                            &Self::credential_key(*provider, account.id),
+                        );
+                    }
+                }
+            } else {
+                for account in &data.accounts {
+                    let _ = Self::credential_store().delete(
+                        TOKEN_ACCOUNT_CREDENTIAL_SERVICE,
+                        &Self::credential_key(*provider, account.id),
+                    );
+                }
+            }
+        }
+
+        for (provider, data) in accounts {
+            for account in &data.accounts {
+                if account.token.trim().is_empty() {
+                    let _ = Self::credential_store().delete(
+                        TOKEN_ACCOUNT_CREDENTIAL_SERVICE,
+                        &Self::credential_key(*provider, account.id),
+                    );
+                    continue;
+                }
+
+                Self::credential_store()
+                    .set(
+                        TOKEN_ACCOUNT_CREDENTIAL_SERVICE,
+                        &Self::credential_key(*provider, account.id),
+                        &account.token,
+                    )
+                    .map_err(|e| TokenAccountError::Credential(e.to_string()))?;
+            }
+        }
+
         let providers: HashMap<String, ProviderAccountData> = accounts
             .iter()
+            .filter(|(_, data)| !data.accounts.is_empty())
             .map(|(k, v)| (k.cli_name().to_string(), v.clone()))
             .collect();
 
@@ -568,5 +631,12 @@ mod tests {
 
         data.set_active(1);
         assert_eq!(data.active_account().unwrap().label, "Account 2");
+    }
+
+    #[test]
+    fn test_token_account_serialization_does_not_include_token_value() {
+        let account = TokenAccount::new("Work", "super-secret-token");
+        let json = serde_json::to_string(&account).unwrap();
+        assert!(!json.contains("super-secret-token"));
     }
 }

--- a/rust/src/native_ui/app.rs
+++ b/rust/src/native_ui/app.rs
@@ -1162,7 +1162,7 @@ impl CodexBarApp {
                 s.summary_providers = s.providers.clone();
                 s.last_refresh = Instant::now();
                 s.is_refreshing = false;
-                
+
                 // Check for usage alerts and send notifications
                 for provider in &s.providers {
                     if let Some(provider_id) = ProviderId::from_cli_name(&provider.name) {

--- a/rust/src/native_ui/app.rs
+++ b/rust/src/native_ui/app.rs
@@ -1167,11 +1167,11 @@ impl CodexBarApp {
                 for provider in &s.providers {
                     if let Some(provider_id) = ProviderId::from_cli_name(&provider.name) {
                         // Check primary session usage
-                        if let Some(session_percent) = provider.session_percent {
-                            if let Ok(mut nm) = notification_manager.lock() {
-                                nm.check_and_notify(provider_id, session_percent, &settings);
-                                nm.check_session_transition(provider_id, session_percent, &settings);
-                            }
+                        if let Some(session_percent) = provider.session_percent
+                            && let Ok(mut nm) = notification_manager.lock()
+                        {
+                            nm.check_and_notify(provider_id, session_percent, &settings);
+                            nm.check_session_transition(provider_id, session_percent, &settings);
                         }
                         // Note: Infini alerts are based on the highest usage across all windows
                         // The primary (5-hour) window is used as the main indicator

--- a/rust/src/providers/antigravity/mod.rs
+++ b/rust/src/providers/antigravity/mod.rs
@@ -494,8 +494,8 @@ mod tests {
 
     #[test]
     fn test_local_client_builder_keeps_tls_verification_enabled() {
-        let client = AntigravityProvider::build_local_client(std::time::Duration::from_secs(1))
-            .unwrap();
+        let client =
+            AntigravityProvider::build_local_client(std::time::Duration::from_secs(1)).unwrap();
         let _ = client;
     }
 }

--- a/rust/src/providers/antigravity/mod.rs
+++ b/rust/src/providers/antigravity/mod.rs
@@ -38,6 +38,14 @@ impl AntigravityProvider {
         }
     }
 
+    fn build_local_client(timeout: std::time::Duration) -> Result<reqwest::Client, ProviderError> {
+        reqwest::Client::builder()
+            .timeout(timeout)
+            .redirect(reqwest::redirect::Policy::none())
+            .build()
+            .map_err(|e| ProviderError::Other(e.to_string()))
+    }
+
     /// Detect running Antigravity language server and extract connection info
     fn detect_process_info() -> Result<ProcessInfo, ProviderError> {
         // Use PowerShell to get process command lines
@@ -99,15 +107,7 @@ impl AntigravityProvider {
     async fn find_api_port(extension_port: u16) -> Result<u16, ProviderError> {
         // The language server listens on multiple ports near the extension port
         // Try ports in range extension_port to extension_port + 20
-        // SECURITY: TLS verification is disabled because the local language server uses
-        // self-signed certificates. This is scoped to 127.0.0.1 only and the port range
-        // is limited. We verify the server responds with the expected gRPC endpoint.
-        let client = reqwest::Client::builder()
-            .timeout(std::time::Duration::from_secs(2))
-            .danger_accept_invalid_certs(true)
-            .redirect(reqwest::redirect::Policy::none())
-            .build()
-            .map_err(|e| ProviderError::Other(e.to_string()))?;
+        let client = Self::build_local_client(std::time::Duration::from_secs(2))?;
 
         for offset in 0..20 {
             let port = extension_port + offset;
@@ -161,13 +161,7 @@ impl AntigravityProvider {
         let process_info = Self::detect_process_info()?;
         let api_port = Self::find_api_port(process_info.extension_port).await?;
 
-        // SECURITY: TLS verification disabled for local language server (see find_api_port)
-        let client = reqwest::Client::builder()
-            .timeout(std::time::Duration::from_secs(8))
-            .danger_accept_invalid_certs(true)
-            .redirect(reqwest::redirect::Policy::none())
-            .build()
-            .map_err(|e| ProviderError::Other(e.to_string()))?;
+        let client = Self::build_local_client(std::time::Duration::from_secs(8))?;
 
         let url = format!(
             "https://127.0.0.1:{}/exa.language_server_pb.LanguageServerService/GetUserStatus",
@@ -496,5 +490,12 @@ mod tests {
         assert!((snap.primary.used_percent - 60.0).abs() < 0.1);
         assert!(snap.secondary.is_none());
         assert!(snap.model_specific.is_none());
+    }
+
+    #[test]
+    fn test_local_client_builder_keeps_tls_verification_enabled() {
+        let client = AntigravityProvider::build_local_client(std::time::Duration::from_secs(1))
+            .unwrap();
+        let _ = client;
     }
 }

--- a/rust/src/providers/infini.rs
+++ b/rust/src/providers/infini.rs
@@ -158,127 +158,6 @@ impl InfiniClient {
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_usage_period_deserialization() {
-        let json = r#"{"quota": 5000, "used": 1000, "remain": 4000}"#;
-        let period: UsagePeriod = serde_json::from_str(json).unwrap();
-        assert_eq!(period.quota, 5000);
-        assert_eq!(period.used, 1000);
-        assert_eq!(period.remain, 4000);
-    }
-
-    #[test]
-    fn test_infini_usage_deserialization() {
-        let json = r#"{
-            "5_hour": {"quota": 5000, "used": 1000, "remain": 4000},
-            "7_day": {"quota": 30000, "used": 5000, "remain": 25000},
-            "30_day": {"quota": 60000, "used": 10000, "remain": 50000}
-        }"#;
-        let usage: InfiniUsage = serde_json::from_str(json).unwrap();
-        assert_eq!(usage.five_hour.quota, 5000);
-        assert_eq!(usage.seven_day.used, 5000);
-        assert_eq!(usage.thirty_day.remain, 50000);
-    }
-
-    #[test]
-    fn test_plan_type_pro() {
-        let usage = InfiniUsage {
-            five_hour: UsagePeriod {
-                quota: 5000,
-                used: 1000,
-                remain: 4000,
-            },
-            seven_day: UsagePeriod {
-                quota: 30000,
-                used: 5000,
-                remain: 25000,
-            },
-            thirty_day: UsagePeriod {
-                quota: 60000,
-                used: 10000,
-                remain: 50000,
-            },
-        };
-        assert_eq!(usage.plan_type(), PlanType::Pro);
-    }
-
-    #[test]
-    fn test_plan_type_lite() {
-        let usage = InfiniUsage {
-            five_hour: UsagePeriod {
-                quota: 1000,
-                used: 500,
-                remain: 500,
-            },
-            seven_day: UsagePeriod {
-                quota: 7000,
-                used: 3500,
-                remain: 3500,
-            },
-            thirty_day: UsagePeriod {
-                quota: 30000,
-                used: 15000,
-                remain: 15000,
-            },
-        };
-        assert_eq!(usage.plan_type(), PlanType::Lite);
-    }
-
-    #[test]
-    fn test_percentage_calculation() {
-        let usage = InfiniUsage {
-            five_hour: UsagePeriod {
-                quota: 5000,
-                used: 2500,
-                remain: 2500,
-            },
-            seven_day: UsagePeriod {
-                quota: 30000,
-                used: 15000,
-                remain: 15000,
-            },
-            thirty_day: UsagePeriod {
-                quota: 60000,
-                used: 30000,
-                remain: 30000,
-            },
-        };
-        assert_eq!(usage.five_hour_percentage(), 50.0);
-        assert_eq!(usage.seven_day_percentage(), 50.0);
-        assert_eq!(usage.thirty_day_percentage(), 50.0);
-    }
-
-    #[test]
-    fn test_zero_quota_percentage() {
-        let usage = InfiniUsage {
-            five_hour: UsagePeriod {
-                quota: 0,
-                used: 0,
-                remain: 0,
-            },
-            seven_day: UsagePeriod {
-                quota: 0,
-                used: 0,
-                remain: 0,
-            },
-            thirty_day: UsagePeriod {
-                quota: 0,
-                used: 0,
-                remain: 0,
-            },
-        };
-        assert_eq!(usage.five_hour_percentage(), 0.0);
-        assert_eq!(usage.seven_day_percentage(), 0.0);
-        assert_eq!(usage.thirty_day_percentage(), 0.0);
-    }
-}
-
-// ==================== InfiniProvider ====================
-
 /// Infini AI Provider 实现
 pub struct InfiniProvider {
     metadata: ProviderMetadata,
@@ -409,5 +288,124 @@ impl std::fmt::Display for PlanType {
             PlanType::Pro => write!(f, "Infini Pro"),
             PlanType::Unknown => write!(f, "Infini"),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_usage_period_deserialization() {
+        let json = r#"{"quota": 5000, "used": 1000, "remain": 4000}"#;
+        let period: UsagePeriod = serde_json::from_str(json).unwrap();
+        assert_eq!(period.quota, 5000);
+        assert_eq!(period.used, 1000);
+        assert_eq!(period.remain, 4000);
+    }
+
+    #[test]
+    fn test_infini_usage_deserialization() {
+        let json = r#"{
+            "5_hour": {"quota": 5000, "used": 1000, "remain": 4000},
+            "7_day": {"quota": 30000, "used": 5000, "remain": 25000},
+            "30_day": {"quota": 60000, "used": 10000, "remain": 50000}
+        }"#;
+        let usage: InfiniUsage = serde_json::from_str(json).unwrap();
+        assert_eq!(usage.five_hour.quota, 5000);
+        assert_eq!(usage.seven_day.used, 5000);
+        assert_eq!(usage.thirty_day.remain, 50000);
+    }
+
+    #[test]
+    fn test_plan_type_pro() {
+        let usage = InfiniUsage {
+            five_hour: UsagePeriod {
+                quota: 5000,
+                used: 1000,
+                remain: 4000,
+            },
+            seven_day: UsagePeriod {
+                quota: 30000,
+                used: 5000,
+                remain: 25000,
+            },
+            thirty_day: UsagePeriod {
+                quota: 60000,
+                used: 10000,
+                remain: 50000,
+            },
+        };
+        assert_eq!(usage.plan_type(), PlanType::Pro);
+    }
+
+    #[test]
+    fn test_plan_type_lite() {
+        let usage = InfiniUsage {
+            five_hour: UsagePeriod {
+                quota: 1000,
+                used: 500,
+                remain: 500,
+            },
+            seven_day: UsagePeriod {
+                quota: 7000,
+                used: 3500,
+                remain: 3500,
+            },
+            thirty_day: UsagePeriod {
+                quota: 30000,
+                used: 15000,
+                remain: 15000,
+            },
+        };
+        assert_eq!(usage.plan_type(), PlanType::Lite);
+    }
+
+    #[test]
+    fn test_percentage_calculation() {
+        let usage = InfiniUsage {
+            five_hour: UsagePeriod {
+                quota: 5000,
+                used: 2500,
+                remain: 2500,
+            },
+            seven_day: UsagePeriod {
+                quota: 30000,
+                used: 15000,
+                remain: 15000,
+            },
+            thirty_day: UsagePeriod {
+                quota: 60000,
+                used: 30000,
+                remain: 30000,
+            },
+        };
+        assert_eq!(usage.five_hour_percentage(), 50.0);
+        assert_eq!(usage.seven_day_percentage(), 50.0);
+        assert_eq!(usage.thirty_day_percentage(), 50.0);
+    }
+
+    #[test]
+    fn test_zero_quota_percentage() {
+        let usage = InfiniUsage {
+            five_hour: UsagePeriod {
+                quota: 0,
+                used: 0,
+                remain: 0,
+            },
+            seven_day: UsagePeriod {
+                quota: 0,
+                used: 0,
+                remain: 0,
+            },
+            thirty_day: UsagePeriod {
+                quota: 0,
+                used: 0,
+                remain: 0,
+            },
+        };
+        assert_eq!(usage.five_hour_percentage(), 0.0);
+        assert_eq!(usage.seven_day_percentage(), 0.0);
+        assert_eq!(usage.thirty_day_percentage(), 0.0);
     }
 }

--- a/rust/src/providers/kiro/version.rs
+++ b/rust/src/providers/kiro/version.rs
@@ -26,8 +26,7 @@ fn is_allowed_kiro_binary(path: &Path) -> bool {
 
     #[cfg(target_os = "windows")]
     {
-        file_name.eq_ignore_ascii_case("kiro-cli.exe")
-            || file_name.eq_ignore_ascii_case("kiro.exe")
+        file_name.eq_ignore_ascii_case("kiro-cli.exe") || file_name.eq_ignore_ascii_case("kiro.exe")
     }
 
     #[cfg(not(target_os = "windows"))]

--- a/rust/src/providers/kiro/version.rs
+++ b/rust/src/providers/kiro/version.rs
@@ -26,8 +26,8 @@ fn is_allowed_kiro_binary(path: &Path) -> bool {
 
     #[cfg(target_os = "windows")]
     {
-        return file_name.eq_ignore_ascii_case("kiro-cli.exe")
-            || file_name.eq_ignore_ascii_case("kiro.exe");
+        file_name.eq_ignore_ascii_case("kiro-cli.exe")
+            || file_name.eq_ignore_ascii_case("kiro.exe")
     }
 
     #[cfg(not(target_os = "windows"))]
@@ -195,15 +195,15 @@ pub fn find_kiro_cli() -> Option<PathBuf> {
 
             // 2. Hardened PATH lookup - use which but validate the result
             //    (avoids CWD hijacking by not executing bare command names)
-            if let Ok(path) = which::which("kiro-cli") {
-                if is_allowed_kiro_binary(&path) {
-                    return Some(path);
-                }
+            if let Ok(path) = which::which("kiro-cli")
+                && is_allowed_kiro_binary(&path)
+            {
+                return Some(path);
             }
-            if let Ok(path) = which::which("kiro") {
-                if is_allowed_kiro_binary(&path) {
-                    return Some(path);
-                }
+            if let Ok(path) = which::which("kiro")
+                && is_allowed_kiro_binary(&path)
+            {
+                return Some(path);
             }
 
             // 3. Fall back to known install locations

--- a/rust/src/providers/mod.rs
+++ b/rust/src/providers/mod.rs
@@ -12,6 +12,7 @@ pub mod copilot;
 pub mod cursor;
 pub mod factory;
 pub mod gemini;
+pub mod infini;
 pub mod jetbrains;
 pub mod kimi;
 pub mod kimik2;
@@ -26,7 +27,6 @@ pub mod synthetic;
 pub mod vertexai;
 pub mod warp;
 pub mod zai;
-pub mod infini;
 
 // Re-export provider implementations
 pub use alibaba::AlibabaProvider;
@@ -39,6 +39,7 @@ pub use copilot::CopilotProvider;
 pub use cursor::CursorProvider;
 pub use factory::FactoryProvider;
 pub use gemini::GeminiProvider;
+pub use infini::InfiniProvider;
 pub use jetbrains::JetBrainsProvider;
 pub use kimi::KimiProvider;
 pub use kimik2::KimiK2Provider;
@@ -52,4 +53,3 @@ pub use synthetic::SyntheticProvider;
 pub use vertexai::VertexAIProvider;
 pub use warp::WarpProvider;
 pub use zai::ZaiProvider;
-pub use infini::InfiniProvider;

--- a/rust/src/settings.rs
+++ b/rust/src/settings.rs
@@ -500,10 +500,8 @@ impl ManualCookies {
         let existing = Self::load();
         for provider_id in existing.cookies.keys() {
             if !self.cookies.contains_key(provider_id) {
-                let _ = Self::credential_store().delete(
-                    Self::CREDENTIAL_SERVICE,
-                    &Self::credential_key(provider_id),
-                );
+                let _ = Self::credential_store()
+                    .delete(Self::CREDENTIAL_SERVICE, &Self::credential_key(provider_id));
             }
         }
     }
@@ -545,10 +543,8 @@ impl ManualCookies {
 
         for (provider_id, entry) in &self.cookies {
             if entry.cookie_header.trim().is_empty() {
-                let _ = Self::credential_store().delete(
-                    Self::CREDENTIAL_SERVICE,
-                    &Self::credential_key(provider_id),
-                );
+                let _ = Self::credential_store()
+                    .delete(Self::CREDENTIAL_SERVICE, &Self::credential_key(provider_id));
                 continue;
             }
 
@@ -589,10 +585,8 @@ impl ManualCookies {
     /// Remove cookie for a provider
     pub fn remove(&mut self, provider_id: &str) {
         self.cookies.remove(provider_id);
-        let _ = Self::credential_store().delete(
-            Self::CREDENTIAL_SERVICE,
-            &Self::credential_key(provider_id),
-        );
+        let _ = Self::credential_store()
+            .delete(Self::CREDENTIAL_SERVICE, &Self::credential_key(provider_id));
     }
 
     /// Get all saved cookies for UI display
@@ -655,10 +649,8 @@ impl ApiKeys {
         let existing = Self::load();
         for provider_id in existing.keys.keys() {
             if !self.keys.contains_key(provider_id) {
-                let _ = Self::credential_store().delete(
-                    Self::CREDENTIAL_SERVICE,
-                    &Self::credential_key(provider_id),
-                );
+                let _ = Self::credential_store()
+                    .delete(Self::CREDENTIAL_SERVICE, &Self::credential_key(provider_id));
             }
         }
     }
@@ -700,10 +692,8 @@ impl ApiKeys {
 
         for (provider_id, entry) in &self.keys {
             if entry.api_key.trim().is_empty() {
-                let _ = Self::credential_store().delete(
-                    Self::CREDENTIAL_SERVICE,
-                    &Self::credential_key(provider_id),
-                );
+                let _ = Self::credential_store()
+                    .delete(Self::CREDENTIAL_SERVICE, &Self::credential_key(provider_id));
                 continue;
             }
 
@@ -743,10 +733,8 @@ impl ApiKeys {
     /// Remove API key for a provider
     pub fn remove(&mut self, provider_id: &str) {
         self.keys.remove(provider_id);
-        let _ = Self::credential_store().delete(
-            Self::CREDENTIAL_SERVICE,
-            &Self::credential_key(provider_id),
-        );
+        let _ = Self::credential_store()
+            .delete(Self::CREDENTIAL_SERVICE, &Self::credential_key(provider_id));
     }
 
     /// Check if a provider has an API key configured

--- a/rust/src/settings.rs
+++ b/rust/src/settings.rs
@@ -12,7 +12,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 
-use crate::core::ProviderId;
+use crate::core::{CredentialStore, ProviderId, WindowsCredentialStore};
 
 /// UI language for the application
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
@@ -480,11 +480,34 @@ pub struct ManualCookies {
 /// A single manual cookie entry
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ManualCookieEntry {
+    #[serde(skip_serializing, default)]
     pub cookie_header: String,
     pub saved_at: String,
 }
 
 impl ManualCookies {
+    const CREDENTIAL_SERVICE: &'static str = "CodexBar";
+
+    fn credential_key(provider_id: &str) -> String {
+        format!("manual-cookie-{}", provider_id)
+    }
+
+    fn credential_store() -> WindowsCredentialStore {
+        WindowsCredentialStore::new()
+    }
+
+    fn cleanup_stale_credentials(&self) {
+        let existing = Self::load();
+        for provider_id in existing.cookies.keys() {
+            if !self.cookies.contains_key(provider_id) {
+                let _ = Self::credential_store().delete(
+                    Self::CREDENTIAL_SERVICE,
+                    &Self::credential_key(provider_id),
+                );
+            }
+        }
+    }
+
     /// Get the cookies file path
     pub fn cookies_path() -> Option<PathBuf> {
         dirs::config_dir().map(|p| p.join("CodexBar").join("manual_cookies.json"))
@@ -496,7 +519,15 @@ impl ManualCookies {
             && path.exists()
             && let Ok(content) = std::fs::read_to_string(&path)
         {
-            return serde_json::from_str(&content).unwrap_or_default();
+            let mut cookies: Self = serde_json::from_str(&content).unwrap_or_default();
+            for (provider_id, entry) in &mut cookies.cookies {
+                if let Ok(secret) = Self::credential_store()
+                    .get(Self::CREDENTIAL_SERVICE, &Self::credential_key(provider_id))
+                {
+                    entry.cookie_header = secret;
+                }
+            }
+            return cookies;
         }
         Self::default()
     }
@@ -508,6 +539,26 @@ impl ManualCookies {
 
         if let Some(parent) = path.parent() {
             std::fs::create_dir_all(parent)?;
+        }
+
+        self.cleanup_stale_credentials();
+
+        for (provider_id, entry) in &self.cookies {
+            if entry.cookie_header.trim().is_empty() {
+                let _ = Self::credential_store().delete(
+                    Self::CREDENTIAL_SERVICE,
+                    &Self::credential_key(provider_id),
+                );
+                continue;
+            }
+
+            Self::credential_store()
+                .set(
+                    Self::CREDENTIAL_SERVICE,
+                    &Self::credential_key(provider_id),
+                    &entry.cookie_header,
+                )
+                .map_err(|e| anyhow::anyhow!(e.to_string()))?;
         }
 
         let json = serde_json::to_string_pretty(self)?;
@@ -538,6 +589,10 @@ impl ManualCookies {
     /// Remove cookie for a provider
     pub fn remove(&mut self, provider_id: &str) {
         self.cookies.remove(provider_id);
+        let _ = Self::credential_store().delete(
+            Self::CREDENTIAL_SERVICE,
+            &Self::credential_key(provider_id),
+        );
     }
 
     /// Get all saved cookies for UI display
@@ -577,6 +632,7 @@ pub struct ApiKeys {
 /// A single API key entry
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ApiKeyEntry {
+    #[serde(skip_serializing, default)]
     pub api_key: String,
     pub saved_at: String,
     /// Optional label for the key (e.g., "Personal", "Work")
@@ -585,6 +641,28 @@ pub struct ApiKeyEntry {
 }
 
 impl ApiKeys {
+    const CREDENTIAL_SERVICE: &'static str = "CodexBar";
+
+    fn credential_key(provider_id: &str) -> String {
+        format!("api-key-{}", provider_id)
+    }
+
+    fn credential_store() -> WindowsCredentialStore {
+        WindowsCredentialStore::new()
+    }
+
+    fn cleanup_stale_credentials(&self) {
+        let existing = Self::load();
+        for provider_id in existing.keys.keys() {
+            if !self.keys.contains_key(provider_id) {
+                let _ = Self::credential_store().delete(
+                    Self::CREDENTIAL_SERVICE,
+                    &Self::credential_key(provider_id),
+                );
+            }
+        }
+    }
+
     /// Get the API keys file path
     pub fn keys_path() -> Option<PathBuf> {
         dirs::config_dir().map(|p| p.join("CodexBar").join("api_keys.json"))
@@ -596,7 +674,15 @@ impl ApiKeys {
             && path.exists()
             && let Ok(content) = std::fs::read_to_string(&path)
         {
-            return serde_json::from_str(&content).unwrap_or_default();
+            let mut keys: Self = serde_json::from_str(&content).unwrap_or_default();
+            for (provider_id, entry) in &mut keys.keys {
+                if let Ok(secret) = Self::credential_store()
+                    .get(Self::CREDENTIAL_SERVICE, &Self::credential_key(provider_id))
+                {
+                    entry.api_key = secret;
+                }
+            }
+            return keys;
         }
         Self::default()
     }
@@ -608,6 +694,26 @@ impl ApiKeys {
 
         if let Some(parent) = path.parent() {
             std::fs::create_dir_all(parent)?;
+        }
+
+        self.cleanup_stale_credentials();
+
+        for (provider_id, entry) in &self.keys {
+            if entry.api_key.trim().is_empty() {
+                let _ = Self::credential_store().delete(
+                    Self::CREDENTIAL_SERVICE,
+                    &Self::credential_key(provider_id),
+                );
+                continue;
+            }
+
+            Self::credential_store()
+                .set(
+                    Self::CREDENTIAL_SERVICE,
+                    &Self::credential_key(provider_id),
+                    &entry.api_key,
+                )
+                .map_err(|e| anyhow::anyhow!(e.to_string()))?;
         }
 
         let json = serde_json::to_string_pretty(self)?;
@@ -637,6 +743,10 @@ impl ApiKeys {
     /// Remove API key for a provider
     pub fn remove(&mut self, provider_id: &str) {
         self.keys.remove(provider_id);
+        let _ = Self::credential_store().delete(
+            Self::CREDENTIAL_SERVICE,
+            &Self::credential_key(provider_id),
+        );
     }
 
     /// Check if a provider has an API key configured
@@ -957,5 +1067,26 @@ mod tests {
 
         assert_eq!(english, Language::English);
         assert_eq!(chinese, Language::Chinese);
+    }
+
+    #[test]
+    fn test_manual_cookie_entry_serialization_does_not_include_cookie_value() {
+        let entry = ManualCookieEntry {
+            cookie_header: "session=secret".to_string(),
+            saved_at: "2026-04-04 12:00".to_string(),
+        };
+        let json = serde_json::to_string(&entry).unwrap();
+        assert!(!json.contains("session=secret"));
+    }
+
+    #[test]
+    fn test_api_key_entry_serialization_does_not_include_api_key_value() {
+        let entry = ApiKeyEntry {
+            api_key: "sk-secret-123".to_string(),
+            saved_at: "2026-04-04 12:00".to_string(),
+            label: Some("Personal".to_string()),
+        };
+        let json = serde_json::to_string(&entry).unwrap();
+        assert!(!json.contains("sk-secret-123"));
     }
 }

--- a/rust/src/tray/weekly_indicator.rs
+++ b/rust/src/tray/weekly_indicator.rs
@@ -108,7 +108,7 @@ impl WeeklyIndicatorColors {
             ProviderId::Ollama => (255, 255, 255, 255), // Ollama white
             ProviderId::OpenRouter => (110, 65, 226, 255), // OpenRouter purple
             ProviderId::NanoGPT => (59, 130, 246, 255), // Blue
-            ProviderId::Infini => (0, 150, 255, 255),  // Infini blue
+            ProviderId::Infini => (0, 150, 255, 255),   // Infini blue
         }
     }
 


### PR DESCRIPTION
## Summary
- move persisted manual cookies, API keys, cached cookie headers, and token-account secrets into the credential store instead of writing them to JSON
- add non-Windows credential-store support for CI and restore Antigravity's default TLS certificate verification
- enable manual CI dispatch and clean up the remaining fmt/clippy issues so the branch passes GitHub Actions

## Test plan
- [x] GitHub Actions CI passed on `security/fix-secret-storage`
- [x] `rust-quality-linux`
- [x] `windows-build-and-test`
- [x] `linux-cli-smoke` (x64)
- [x] `linux-cli-smoke` (arm64)