### PR TITLE
fix: render Claude reset time in local timezone, honor relative-reset toggle

### DIFF
--- a/apps/desktop-tauri/src/hooks/useFormattedResetTime.test.tsx
+++ b/apps/desktop-tauri/src/hooks/useFormattedResetTime.test.tsx
@@ -1,0 +1,76 @@
+import { act, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { LocaleProvider } from "../i18n/LocaleProvider";
+import { buildBundle } from "../test/localeHarness";
+import { useFormattedResetTime } from "./useFormattedResetTime";
+import * as tauri from "../lib/tauri";
+
+vi.mock("../lib/tauri", () => ({
+  getLocaleStrings: vi.fn(),
+  setUiLanguage: vi.fn(),
+}));
+
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: vi.fn().mockResolvedValue(() => {}),
+}));
+
+function Probe({
+  resetsAt,
+  fallback,
+  relative,
+}: {
+  resetsAt: string | null;
+  fallback: string | null;
+  relative: boolean;
+}) {
+  const text = useFormattedResetTime(resetsAt, fallback, relative);
+  return <span data-testid="reset">{text ?? "null"}</span>;
+}
+
+async function mountWithLocale(ui: React.ReactNode) {
+  (tauri.getLocaleStrings as ReturnType<typeof vi.fn>).mockResolvedValue(
+    buildBundle({
+      MetricResetsIn: "Resets in",
+      ResetsInHoursMinutes: "Resets in {}h {}m",
+      ResetsInDaysHours: "Resets in {}d {}h",
+      TrayResetsDueNow: "Resetting",
+    }),
+  );
+  const rendered = render(<LocaleProvider>{ui}</LocaleProvider>);
+  await act(async () => {});
+  return rendered;
+}
+
+describe("useFormattedResetTime", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2024-06-01T00:00:00Z"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("returns a complete localized countdown in relative mode", async () => {
+    const target = new Date("2024-06-01T03:42:00Z").toISOString();
+    await mountWithLocale(
+      <Probe resetsAt={target} fallback="later" relative={true} />,
+    );
+    expect(screen.getByTestId("reset")).toHaveTextContent("Resets in 3h 42m");
+  });
+
+  it("labels fallback text in relative mode", async () => {
+    await mountWithLocale(
+      <Probe resetsAt={null} fallback="3h" relative={true} />,
+    );
+    expect(screen.getByTestId("reset")).toHaveTextContent("Resets in 3h");
+  });
+
+  it("returns an absolute local time without the reset label", async () => {
+    const target = new Date("2024-06-01T03:42:00Z").toISOString();
+    await mountWithLocale(
+      <Probe resetsAt={target} fallback="later" relative={false} />,
+    );
+    expect(screen.getByTestId("reset")).not.toHaveTextContent("Resets in");
+  });
+});

--- a/apps/desktop-tauri/src/hooks/useFormattedResetTime.ts
+++ b/apps/desktop-tauri/src/hooks/useFormattedResetTime.ts
@@ -5,15 +5,15 @@ import { useLocale } from "./useLocale";
  * Format a provider's reset timestamp for display.
  *
  * When `relative` is true, returns a live "Resets in 3h 42m" style string
- * (matches the tray pop-out countdown used by `useResetCountdown`).
+ * and includes the reset label because the locale strings include it.
  *
  * When `relative` is false, returns the absolute reset time converted to
  * the user's local timezone via `Intl.DateTimeFormat`, fixing the issue
  * where the backend-supplied `reset_description` was pre-formatted as UTC
  * wall time (e.g., `Mar 5 at 3:00PM`).
  *
- * Falls back to `fallback` (typically the backend's `resetDescription`)
- * when `resetsAt` is absent or unparseable.
+ * Falls back to a labeled `fallback` (typically the backend's
+ * `resetDescription`) when `resetsAt` is absent or unparseable.
  */
 export function useFormattedResetTime(
   resetsAt: string | null,
@@ -29,9 +29,13 @@ export function useFormattedResetTime(
     return () => window.clearInterval(id);
   }, [resetsAt, relative]);
 
-  if (!resetsAt) return fallback;
+  if (!resetsAt) {
+    return relative && fallback ? `${t("MetricResetsIn")} ${fallback}` : fallback;
+  }
   const target = Date.parse(resetsAt);
-  if (Number.isNaN(target)) return fallback;
+  if (Number.isNaN(target)) {
+    return relative && fallback ? `${t("MetricResetsIn")} ${fallback}` : fallback;
+  }
 
   if (relative) {
     const diffMs = target - now;

--- a/apps/desktop-tauri/src/hooks/useFormattedResetTime.ts
+++ b/apps/desktop-tauri/src/hooks/useFormattedResetTime.ts
@@ -1,0 +1,63 @@
+import { useEffect, useState } from "react";
+import { useLocale } from "./useLocale";
+
+/**
+ * Format a provider's reset timestamp for display.
+ *
+ * When `relative` is true, returns a live "Resets in 3h 42m" style string
+ * (matches the tray pop-out countdown used by `useResetCountdown`).
+ *
+ * When `relative` is false, returns the absolute reset time converted to
+ * the user's local timezone via `Intl.DateTimeFormat`, fixing the issue
+ * where the backend-supplied `reset_description` was pre-formatted as UTC
+ * wall time (e.g., `Mar 5 at 3:00PM`).
+ *
+ * Falls back to `fallback` (typically the backend's `resetDescription`)
+ * when `resetsAt` is absent or unparseable.
+ */
+export function useFormattedResetTime(
+  resetsAt: string | null,
+  fallback: string | null,
+  relative: boolean,
+): string | null {
+  const { t } = useLocale();
+  const [now, setNow] = useState(() => Date.now());
+
+  useEffect(() => {
+    if (!resetsAt || !relative) return;
+    const id = window.setInterval(() => setNow(Date.now()), 30_000);
+    return () => window.clearInterval(id);
+  }, [resetsAt, relative]);
+
+  if (!resetsAt) return fallback;
+  const target = Date.parse(resetsAt);
+  if (Number.isNaN(target)) return fallback;
+
+  if (relative) {
+    const diffMs = target - now;
+    if (diffMs <= 0) return t("TrayResetsDueNow");
+    const totalMinutes = Math.floor(diffMs / 60_000);
+    const days = Math.floor(totalMinutes / 1440);
+    const hours = Math.floor((totalMinutes % 1440) / 60);
+    const minutes = totalMinutes % 60;
+    if (days > 0) {
+      return t("ResetsInDaysHours")
+        .replace("{}", String(days))
+        .replace("{}", String(hours));
+    }
+    return t("ResetsInHoursMinutes")
+      .replace("{}", String(hours))
+      .replace("{}", String(minutes));
+  }
+
+  try {
+    return new Intl.DateTimeFormat(undefined, {
+      month: "short",
+      day: "numeric",
+      hour: "numeric",
+      minute: "2-digit",
+    }).format(new Date(target));
+  } catch {
+    return fallback;
+  }
+}

--- a/apps/desktop-tauri/src/surfaces/settings/providers/ProviderDetailPane.tsx
+++ b/apps/desktop-tauri/src/surfaces/settings/providers/ProviderDetailPane.tsx
@@ -38,6 +38,7 @@ import { CookieSection } from "./CookieSection";
 interface Props {
   providerId: string | null;
   cookieDomain?: string | null;
+  resetTimeRelative: boolean;
 }
 
 /**
@@ -50,7 +51,11 @@ interface Props {
  * credential detection UIs (6d), inline token accounts (6e) and charts
  * (6f) are wired in as sub-sections below.
  */
-export function ProviderDetailPane({ providerId, cookieDomain = null }: Props) {
+export function ProviderDetailPane({
+  providerId,
+  cookieDomain = null,
+  resetTimeRelative,
+}: Props) {
   const { t } = useLocale();
   const [detail, setDetail] = useState<ProviderDetail | null>(null);
   const [cookieOptions, setCookieOptions] = useState<CookieSourceOption[]>([]);
@@ -224,7 +229,11 @@ export function ProviderDetailPane({ providerId, cookieDomain = null }: Props) {
         </div>
       )}
 
-      <UsageSection provider={detail} t={t} />
+      <UsageSection
+        provider={detail}
+        resetTimeRelative={resetTimeRelative}
+        t={t}
+      />
       <PaceSection pace={detail.pace} t={t} />
       <CostSection cost={detail.cost} t={t} />
 

--- a/apps/desktop-tauri/src/surfaces/settings/providers/sections/UsageSection.tsx
+++ b/apps/desktop-tauri/src/surfaces/settings/providers/sections/UsageSection.tsx
@@ -3,9 +3,11 @@ import type {
   RateWindowSnapshot,
 } from "../../../../types/bridge";
 import type { LocaleKey } from "../../../../i18n/keys";
+import { useFormattedResetTime } from "../../../../hooks/useFormattedResetTime";
 
 interface Props {
   provider: ProviderDetail;
+  resetTimeRelative: boolean;
   t: (key: LocaleKey) => string;
 }
 
@@ -20,7 +22,7 @@ interface BarSpec {
  * Mirrors the bars in
  * `rust/src/native_ui/preferences.rs::render_provider_detail_panel`.
  */
-export function UsageSection({ provider, t }: Props) {
+export function UsageSection({ provider, resetTimeRelative, t }: Props) {
   const bars: BarSpec[] = [];
   if (provider.session) {
     bars.push({
@@ -59,7 +61,13 @@ export function UsageSection({ provider, t }: Props) {
     <section className="provider-detail-section">
       <h4>{t("ProviderUsage")}</h4>
       {bars.map((b) => (
-        <UsageBar key={b.key} label={b.label} rate={b.rate} t={t} />
+        <UsageBar
+          key={b.key}
+          label={b.label}
+          rate={b.rate}
+          resetTimeRelative={resetTimeRelative}
+          t={t}
+        />
       ))}
     </section>
   );
@@ -68,15 +76,22 @@ export function UsageSection({ provider, t }: Props) {
 function UsageBar({
   label,
   rate,
+  resetTimeRelative,
   t,
 }: {
   label: string;
   rate: RateWindowSnapshot;
+  resetTimeRelative: boolean;
   t: (key: LocaleKey) => string;
 }) {
   const pct = rate.isExhausted ? 100 : Math.min(100, rate.usedPercent);
-  const resetHint = rate.resetDescription
-    ? `${t("MetricResetsIn")} ${rate.resetDescription}`
+  const formattedReset = useFormattedResetTime(
+    rate.resetsAt,
+    rate.resetDescription,
+    resetTimeRelative,
+  );
+  const resetHint = formattedReset
+    ? `${t("MetricResetsIn")} ${formattedReset}`
     : null;
 
   return (

--- a/apps/desktop-tauri/src/surfaces/settings/providers/sections/UsageSection.tsx
+++ b/apps/desktop-tauri/src/surfaces/settings/providers/sections/UsageSection.tsx
@@ -91,7 +91,9 @@ function UsageBar({
     resetTimeRelative,
   );
   const resetHint = formattedReset
-    ? `${t("MetricResetsIn")} ${formattedReset}`
+    ? resetTimeRelative
+      ? formattedReset
+      : `${t("MetricResetsIn")} ${formattedReset}`
     : null;
 
   return (

--- a/apps/desktop-tauri/src/surfaces/settings/tabs/ProvidersTab.tsx
+++ b/apps/desktop-tauri/src/surfaces/settings/tabs/ProvidersTab.tsx
@@ -97,6 +97,7 @@ export default function ProvidersTab({
       <ProviderDetailPane
         providerId={selectedId}
         cookieDomain={selectedEntry?.cookieDomain ?? null}
+        resetTimeRelative={settings.resetTimeRelative}
       />
     </div>
   );


### PR DESCRIPTION
## Summary

Settings → Providers → Claude shows the "Resets in …" line as a UTC wall time (e.g. `Mar 5 at 3:00PM`) regardless of the user's timezone, and the `Display → Relative Reset Time` toggle has no effect on it. This PR makes the provider detail pane format reset times in the user's local timezone and respect the toggle.

## Root cause

1. **UTC rendered verbatim.** `rust/src/providers/claude/web_api.rs::format_reset_time` formats `DateTime<Utc>` directly with no `.with_timezone(&Local)`, and the string is shipped to the frontend as `reset_description`. (Same pattern in `providers/claude/oauth.rs::format_reset_date`.)
2. **`reset_time_relative` never consumed.** The toggle is plumbed end-to-end through `settings.rs`, the Tauri commands, the bridge type, and `DisplayTab.tsx`, but `UsageSection.tsx` just prints `rate.resetDescription` verbatim. A repo-wide grep shows zero renderer-side consumers of the flag.

## Fix

- **New hook** `apps/desktop-tauri/src/hooks/useFormattedResetTime.ts` takes `(resetsAt, fallback, relative)`:
  - `relative = true` → live `Resets in 3h 42m` style countdown (matches the existing tray `useResetCountdown`).
  - `relative = false` → parses the ISO-8601 `resets_at` that the bridge already exposes on `RateWindowSnapshot` and formats it via `Intl.DateTimeFormat` in the user's local timezone. This is what fixes the UTC bug.
  - Falls back to the backend's `resetDescription` when `resets_at` is missing or unparseable, so providers that only ship a descriptive string (e.g., Abacus `"X/Y cp"`) are unaffected.
- **`UsageSection.tsx`** accepts a `resetTimeRelative` prop and uses the new hook per bar.
- Flag threaded through `ProvidersTab.tsx` → `ProviderDetailPane.tsx` → `UsageSection.tsx`.

No Rust changes — the raw `resets_at: Option<DateTime<Utc>>` is already serialized on `RateWindowSnapshot`, so the frontend has everything it needs.

## Scope / deliberate non-goals

- Tray pop-out (`useResetCountdown`) is already relative-only and unaffected.
- `components/MenuCard.tsx` still renders `resetDescription` verbatim. That surface was outside the reported issue; happy to drop the same hook in as a follow-up if you'd like the menu-bar card to follow the toggle too.

## Test plan

- [ ] `npm run build` under `apps/desktop-tauri` (runs `tsc --noEmit` + vite). Type check passes locally.
- [ ] In a non-UTC timezone (e.g., UTC+8), open Settings → Providers → Claude:
  - Relative Reset Time **off** → line shows local wall-clock (e.g., `Mar 5, 11:00 PM` instead of `Mar 5 at 3:00PM`).
  - Relative Reset Time **on** → live countdown (`Resets in 3h 42m`), updates every 30s.
- [ ] Toggle updates the display without needing a provider refresh.
- [ ] Providers without a parseable `resets_at` still show their original descriptive string unchanged.