### PR TITLE
fix: settings window close button (and programmatic resize) silently failing

### DIFF
--- a/apps/desktop-tauri/src-tauri/capabilities/default.json
+++ b/apps/desktop-tauri/src-tauri/capabilities/default.json
@@ -1,7 +1,7 @@
 {
   "identifier": "default",
   "description": "Default permissions for the CodexBar desktop scaffold.",
-  "windows": ["main"],
+  "windows": ["main", "settings"],
   "permissions": [
     "core:default",
     "core:window:allow-set-size",


### PR DESCRIPTION
## Summary

The custom close button (✕) in the top-right of the detached Settings window does nothing on Windows. Alt+F4 works.

The same silent failure also affects `applySettingsWindowSize` — the frontend calls `getCurrentWindow().setSize(...)` when switching tabs (e.g., widening the window for the Providers tab), and those calls are rejected too.

## Root cause

`apps/desktop-tauri/src-tauri/capabilities/default.json` only scopes its permissions to the `main` window:

```json
"windows": ["main"],
```

The detached Settings window is created with label `"settings"` (see `shell/settings_window.rs::SETTINGS_LABEL`), so it falls outside the capability's scope. Tauri's IPC permission layer rejects `core:window:*` calls from it without surfacing an error to JS.

Alt+F4 bypasses this entirely — Windows dispatches `WM_CLOSE` at the OS level, so the native close path works while the in-app button doesn't. That's the smoking gun for a missing capability scope.

## Fix

Add `"settings"` to the capability's `windows` array so the existing `core:default` (which grants close/show/focus/minimize) and `core:window:allow-set-size` apply to the settings window as well.

```diff
- "windows": ["main"],
+ "windows": ["main", "settings"],
```

No code changes needed — `Settings.tsx` already calls `getCurrentWindow().close()` on the ✕ button; it just wasn't permitted.

## Test plan

- [ ] Rebuild (`npm run tauri:dev` or `tauri:build`) — capability files are compiled into the binary, not runtime-loaded.
- [ ] Open Settings from the tray → click the ✕ in the top-right → window closes.
- [ ] Open Settings on the General tab, switch to Providers → window widens from 496 → 720 logical px (previously silently no-op'd).
- [ ] Alt+F4 still closes the window (unchanged).