### PR TITLE
fix: honor relative reset toggle and local tz in tray/pop-out cards

### DIFF
--- a/apps/desktop-tauri/src/components/MenuCard.tsx
+++ b/apps/desktop-tauri/src/components/MenuCard.tsx
@@ -7,6 +7,7 @@ import type {
 } from "../types/bridge";
 import { getProviderChartData } from "../lib/tauri";
 import { useLocale } from "../hooks/useLocale";
+import { useFormattedResetTime } from "../hooks/useFormattedResetTime";
 import type { LocaleKey } from "../i18n/keys";
 import { paceCategory } from "../surfaces/tray/paceCategory";
 import { SimpleBarChart, StackedBarChart } from "./MiniBarChart";
@@ -41,6 +42,7 @@ function CopyIconButton({ text }: { text: string }) {
 interface MenuCardProps {
   provider: ProviderUsageSnapshot;
   hideEmail: boolean;
+  resetTimeRelative: boolean;
 }
 
 function maskEmail(email: string): string {
@@ -123,14 +125,21 @@ function MetricRow({
   title,
   snap,
   exhaustedLabel,
+  resetTimeRelative,
 }: {
   title: string;
   snap: RateWindowSnapshot;
   exhaustedLabel: string;
+  resetTimeRelative: boolean;
 }) {
   const pct = Math.min(100, Math.max(0, snap.usedPercent));
   const remain = 100 - pct;
   const level = levelOf(remain, snap.isExhausted);
+  const resetText = useFormattedResetTime(
+    snap.resetsAt,
+    snap.resetDescription,
+    resetTimeRelative,
+  );
   return (
     <div className="menu-metric">
       <span className="menu-metric__title">{title}</span>
@@ -139,8 +148,8 @@ function MetricRow({
       </div>
       <div className="menu-metric__row">
         <span className="menu-metric__pct">{Math.round(100 - pct)}% left</span>
-        {snap.resetDescription && (
-          <span className="menu-metric__reset">{snap.resetDescription}</span>
+        {resetText && (
+          <span className="menu-metric__reset">{resetText}</span>
         )}
       </div>
       {snap.isExhausted && (
@@ -174,9 +183,14 @@ function MetricRow({
  *
  * Padding: horizontal 16, vertical 2 (matches upstream UsageMenuCardView).
  */
-export default function MenuCard({ provider, hideEmail }: MenuCardProps) {
+export default function MenuCard({ provider, hideEmail, resetTimeRelative }: MenuCardProps) {
   const { t } = useLocale();
   const [chartData, setChartData] = useState<ProviderChartData | null>(null);
+  const formattedCostReset = useFormattedResetTime(
+    provider.cost?.resetsAt ?? null,
+    null,
+    resetTimeRelative,
+  );
 
   useEffect(() => {
     if (DEMO_ENABLED) return; // skip chart fetch in demo mode
@@ -267,6 +281,7 @@ export default function MenuCard({ provider, hideEmail }: MenuCardProps) {
                   title={m.label}
                   snap={m.snap}
                   exhaustedLabel={t("DetailWindowExhausted")}
+                  resetTimeRelative={resetTimeRelative}
                 />
               ))}
             </section>
@@ -297,9 +312,9 @@ export default function MenuCard({ provider, hideEmail }: MenuCardProps) {
                   {formatCurrency(provider.cost.remaining, provider.cost.currencyCode)}
                 </div>
               )}
-              {provider.cost.resetsAt && (
+              {formattedCostReset && (
                 <div className="menu-card__cost-line menu-card__cost-line--muted">
-                  {t("DetailCostResets")}: {provider.cost.resetsAt}
+                  {t("DetailCostResets")}: {formattedCostReset}
                 </div>
               )}
             </section>

--- a/apps/desktop-tauri/src/hooks/useFormattedResetTime.test.tsx
+++ b/apps/desktop-tauri/src/hooks/useFormattedResetTime.test.tsx
@@ -59,11 +59,11 @@ describe("useFormattedResetTime", () => {
     expect(screen.getByTestId("reset")).toHaveTextContent("Resets in 3h 42m");
   });
 
-  it("labels fallback text in relative mode", async () => {
+  it("leaves fallback text unlabelled in relative mode", async () => {
     await mountWithLocale(
       <Probe resetsAt={null} fallback="3h" relative={true} />,
     );
-    expect(screen.getByTestId("reset")).toHaveTextContent("Resets in 3h");
+    expect(screen.getByTestId("reset")).toHaveTextContent("3h");
   });
 
   it("returns an absolute local time without the reset label", async () => {

--- a/apps/desktop-tauri/src/hooks/useFormattedResetTime.ts
+++ b/apps/desktop-tauri/src/hooks/useFormattedResetTime.ts
@@ -12,8 +12,9 @@ import { useLocale } from "./useLocale";
  * where the backend-supplied `reset_description` was pre-formatted as UTC
  * wall time (e.g., `Mar 5 at 3:00PM`).
  *
- * Falls back to a labeled `fallback` (typically the backend's
- * `resetDescription`) when `resetsAt` is absent or unparseable.
+ * Falls back to `fallback` (typically the backend's `resetDescription`) when
+ * `resetsAt` is absent or unparseable. Some providers use that fallback for
+ * non-time details, so callers should not assume it is safe to prefix.
  */
 export function useFormattedResetTime(
   resetsAt: string | null,
@@ -30,11 +31,11 @@ export function useFormattedResetTime(
   }, [resetsAt, relative]);
 
   if (!resetsAt) {
-    return relative && fallback ? `${t("MetricResetsIn")} ${fallback}` : fallback;
+    return fallback;
   }
   const target = Date.parse(resetsAt);
   if (Number.isNaN(target)) {
-    return relative && fallback ? `${t("MetricResetsIn")} ${fallback}` : fallback;
+    return fallback;
   }
 
   if (relative) {

--- a/apps/desktop-tauri/src/surfaces/PopOutPanel.tsx
+++ b/apps/desktop-tauri/src/surfaces/PopOutPanel.tsx
@@ -147,7 +147,11 @@ export default function PopOutPanel({
             data-deeplinked={p.providerId === providerId || undefined}
           >
             {idx > 0 && <div className="menu-stack__sep" />}
-            <MenuCard provider={p} hideEmail={settings.hidePersonalInfo} />
+            <MenuCard
+              provider={p}
+              hideEmail={settings.hidePersonalInfo}
+              resetTimeRelative={settings.resetTimeRelative}
+            />
           </div>
         ))}
       </div>

--- a/apps/desktop-tauri/src/surfaces/TrayPanel.tsx
+++ b/apps/desktop-tauri/src/surfaces/TrayPanel.tsx
@@ -349,7 +349,11 @@ export default function TrayPanel({ state }: { state: BootstrapState }) {
                 className={`menu-stack__item${isSelected ? " menu-stack__item--selected" : ""}`}
                 id={`card-${p.providerId}`}
               >
-                <MenuCard provider={p} hideEmail={settings.hidePersonalInfo} />
+                <MenuCard
+                  provider={p}
+                  hideEmail={settings.hidePersonalInfo}
+                  resetTimeRelative={settings.resetTimeRelative}
+                />
               </div>
             </Fragment>
           );


### PR DESCRIPTION
## Summary
- #37 fixed reset-time formatting in Settings → Providers, but the **tray icon popup** and **pop-out window** render through `MenuCard`, which still displayed `snap.resetDescription` verbatim (backend pre-formats Claude's `DateTime<Utc>` as UTC wall time) and ignored the Display → "Relative Reset Time" toggle.
- Thread `resetTimeRelative` through `TrayPanel` and `PopOutPanel` into `MenuCard`, and route both metric resets and `cost.resetsAt` through the existing `useFormattedResetTime` hook so the same local-tz / countdown logic applies in every surface.

## Test plan
- [x] Toggle Display → "Relative Reset Time" off; tray popup shows reset time in local timezone (verified with Claude account on a UTC+8 machine).
- [x] Toggle on; tray popup shows live "Resets in Xh Ym" countdown.
- [x] Pop-out window mirrors the tray behavior.
- [x] Cost section's "Resets" line reformats correctly.
- [x] `tsc --noEmit` and `tauri build` pass.