### PR TITLE
fix: handle overlapping aliases in Claude web usage response

### DIFF
--- a/rust/src/providers/claude/web_api.rs
+++ b/rust/src/providers/claude/web_api.rs
@@ -9,23 +9,60 @@ use crate::core::{
     CostSnapshot, NamedRateWindow, ProviderError, ProviderFetchResult, RateWindow, UsageSnapshot,
 };
 
-/// Read the response body as text, then deserialize as JSON. On failure,
-/// include a snippet of the actual body so we can tell whether the response
-/// was an HTML auth redirect, an unexpected error envelope, or a schema change.
+/// Read the response body as text, then deserialize as JSON. On failure, include
+/// non-sensitive shape metadata so auth redirects, error envelopes, and schema
+/// changes are distinguishable without exposing account data in UI/log output.
 async fn parse_json_with_body<T: serde::de::DeserializeOwned>(
     response: reqwest::Response,
     label: &str,
 ) -> Result<T, ProviderError> {
-    let body = response.text().await.map_err(|e| {
-        ProviderError::Parse(format!("Failed to read {label} response body: {e}"))
-    })?;
+    let content_type = response
+        .headers()
+        .get(header::CONTENT_TYPE)
+        .and_then(|value| value.to_str().ok())
+        .map(str::to_owned);
+    let body = response
+        .text()
+        .await
+        .map_err(|e| ProviderError::Parse(format!("Failed to read {label} response body: {e}")))?;
+
     serde_json::from_str::<T>(&body).map_err(|e| {
-        let snippet: String = body.chars().take(240).collect();
-        let suffix = if body.chars().count() > 240 { "..." } else { "" };
         ProviderError::Parse(format!(
-            "Failed to parse {label}: {e} (body: {snippet}{suffix})"
+            "Failed to parse {label}: {e} ({})",
+            describe_json_body_shape(&body, content_type.as_deref())
         ))
     })
+}
+
+fn describe_json_body_shape(body: &str, content_type: Option<&str>) -> String {
+    let content_type = content_type.unwrap_or("unknown");
+    let body_len = body.len();
+
+    match serde_json::from_str::<serde_json::Value>(body) {
+        Ok(serde_json::Value::Object(map)) => {
+            let mut keys: Vec<&str> = map.keys().map(String::as_str).collect();
+            keys.sort_unstable();
+            let suffix = if keys.len() > 12 { ", ..." } else { "" };
+            let keys = keys.into_iter().take(12).collect::<Vec<_>>().join(", ");
+            format!("content_type={content_type}, body_len={body_len}, json_keys=[{keys}{suffix}]")
+        }
+        Ok(value) => format!(
+            "content_type={content_type}, body_len={body_len}, json_type={}",
+            json_value_kind(&value)
+        ),
+        Err(_) => format!("content_type={content_type}, body_len={body_len}, body_kind=non-json"),
+    }
+}
+
+fn json_value_kind(value: &serde_json::Value) -> &'static str {
+    match value {
+        serde_json::Value::Null => "null",
+        serde_json::Value::Bool(_) => "bool",
+        serde_json::Value::Number(_) => "number",
+        serde_json::Value::String(_) => "string",
+        serde_json::Value::Array(_) => "array",
+        serde_json::Value::Object(_) => "object",
+    }
 }
 
 /// Claude Web API fetcher
@@ -657,5 +694,33 @@ mod tests {
 
         assert!((design.used_percent - 26.0).abs() < f64::EPSILON);
         assert!((routines.used_percent - 11.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn parses_duplicate_design_and_routines_aliases_with_preferred_key() {
+        let usage: super::UsageResponse = serde_json::from_str(
+            r#"{
+                "seven_day_design": { "utilization": 31 },
+                "seven_day_omelette": { "utilization": 26 },
+                "seven_day_routines": { "utilization": 19 },
+                "seven_day_cowork": { "utilization": 11 }
+            }"#,
+        )
+        .unwrap();
+
+        let fetcher = ClaudeWebApiFetcher::new();
+        let design = usage
+            .seven_day_design
+            .as_ref()
+            .map(|w| fetcher.to_rate_window(w, Some(10080)))
+            .expect("design window");
+        let routines = usage
+            .seven_day_routines
+            .as_ref()
+            .map(|w| fetcher.to_rate_window(w, Some(10080)))
+            .expect("routines window");
+
+        assert!((design.used_percent - 31.0).abs() < f64::EPSILON);
+        assert!((routines.used_percent - 19.0).abs() < f64::EPSILON);
     }
 }

--- a/rust/src/providers/claude/web_api.rs
+++ b/rust/src/providers/claude/web_api.rs
@@ -9,6 +9,25 @@ use crate::core::{
     CostSnapshot, NamedRateWindow, ProviderError, ProviderFetchResult, RateWindow, UsageSnapshot,
 };
 
+/// Read the response body as text, then deserialize as JSON. On failure,
+/// include a snippet of the actual body so we can tell whether the response
+/// was an HTML auth redirect, an unexpected error envelope, or a schema change.
+async fn parse_json_with_body<T: serde::de::DeserializeOwned>(
+    response: reqwest::Response,
+    label: &str,
+) -> Result<T, ProviderError> {
+    let body = response.text().await.map_err(|e| {
+        ProviderError::Parse(format!("Failed to read {label} response body: {e}"))
+    })?;
+    serde_json::from_str::<T>(&body).map_err(|e| {
+        let snippet: String = body.chars().take(240).collect();
+        let suffix = if body.chars().count() > 240 { "..." } else { "" };
+        ProviderError::Parse(format!(
+            "Failed to parse {label}: {e} (body: {snippet}{suffix})"
+        ))
+    })
+}
+
 /// Claude Web API fetcher
 pub struct ClaudeWebApiFetcher {
     client: Client,
@@ -22,42 +41,75 @@ struct Organization {
     name: Option<String>,
 }
 
-/// Usage response from Claude API
-#[derive(Debug, Deserialize)]
+/// Usage response from Claude API.
+///
+/// Anthropic ships overlapping field names for the design and routines
+/// windows (e.g. both `seven_day_design` and `seven_day_omelette` may appear
+/// in the same payload). Serde aliases can't accept that — it errors with
+/// "duplicate field" if more than one alias is present. We deserialize into
+/// a generic map and pick the first alias that yields a non-null value.
+#[derive(Debug)]
 struct UsageResponse {
-    #[serde(rename = "five_hour")]
     five_hour: Option<UsageWindow>,
-
-    #[serde(rename = "seven_day")]
     seven_day: Option<UsageWindow>,
-
-    #[serde(rename = "seven_day_opus")]
     seven_day_opus: Option<UsageWindow>,
-
-    #[serde(rename = "seven_day_sonnet")]
     seven_day_sonnet: Option<UsageWindow>,
-
-    #[serde(
-        rename = "seven_day_design",
-        alias = "seven_day_claude_design",
-        alias = "claude_design",
-        alias = "design",
-        alias = "seven_day_omelette",
-        alias = "omelette",
-        alias = "omelette_promotional"
-    )]
     seven_day_design: Option<UsageWindow>,
-
-    #[serde(
-        rename = "seven_day_routines",
-        alias = "seven_day_claude_routines",
-        alias = "claude_routines",
-        alias = "routines",
-        alias = "routine",
-        alias = "seven_day_cowork",
-        alias = "cowork"
-    )]
     seven_day_routines: Option<UsageWindow>,
+}
+
+impl<'de> Deserialize<'de> for UsageResponse {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let mut map: std::collections::HashMap<String, serde_json::Value> =
+            std::collections::HashMap::deserialize(deserializer)?;
+
+        let take = |map: &mut std::collections::HashMap<String, serde_json::Value>,
+                    keys: &[&str]|
+         -> Result<Option<UsageWindow>, D::Error> {
+            for key in keys {
+                if let Some(value) = map.remove(*key) {
+                    if value.is_null() {
+                        continue;
+                    }
+                    let window: UsageWindow =
+                        serde_json::from_value(value).map_err(serde::de::Error::custom)?;
+                    return Ok(Some(window));
+                }
+            }
+            Ok(None)
+        };
+
+        Ok(UsageResponse {
+            five_hour: take(&mut map, &["five_hour"])?,
+            seven_day: take(&mut map, &["seven_day"])?,
+            seven_day_opus: take(&mut map, &["seven_day_opus"])?,
+            seven_day_sonnet: take(&mut map, &["seven_day_sonnet"])?,
+            seven_day_design: take(
+                &mut map,
+                &[
+                    "seven_day_design",
+                    "seven_day_claude_design",
+                    "claude_design",
+                    "design",
+                    "seven_day_omelette",
+                    "omelette",
+                    "omelette_promotional",
+                ],
+            )?,
+            seven_day_routines: take(
+                &mut map,
+                &[
+                    "seven_day_routines",
+                    "seven_day_claude_routines",
+                    "claude_routines",
+                    "routines",
+                    "routine",
+                    "seven_day_cowork",
+                    "cowork",
+                ],
+            )?,
+        })
+    }
 }
 
 /// A usage window from the API
@@ -325,10 +377,7 @@ impl ClaudeWebApiFetcher {
             )));
         }
 
-        let orgs: Vec<Organization> = response
-            .json()
-            .await
-            .map_err(|e| ProviderError::Parse(format!("Failed to parse organizations: {}", e)))?;
+        let orgs: Vec<Organization> = parse_json_with_body(response, "organizations").await?;
 
         orgs.into_iter()
             .next()
@@ -358,10 +407,7 @@ impl ClaudeWebApiFetcher {
             )));
         }
 
-        response
-            .json()
-            .await
-            .map_err(|e| ProviderError::Parse(format!("Failed to parse usage: {}", e)))
+        parse_json_with_body(response, "usage").await
     }
 
     /// Get extra usage (credits)
@@ -390,10 +436,7 @@ impl ClaudeWebApiFetcher {
             )));
         }
 
-        response
-            .json()
-            .await
-            .map_err(|e| ProviderError::Parse(format!("Failed to parse extra usage: {}", e)))
+        parse_json_with_body(response, "extra usage").await
     }
 
     /// Get account info
@@ -417,10 +460,7 @@ impl ClaudeWebApiFetcher {
             )));
         }
 
-        response
-            .json()
-            .await
-            .map_err(|e| ProviderError::Parse(format!("Failed to parse account: {}", e)))
+        parse_json_with_body(response, "account").await
     }
 
     /// Convert a usage window to a RateWindow


### PR DESCRIPTION
## Summary

The Claude **Web** fetch path (Settings → Providers → Claude, manual cookie / session source) was failing with:

```
Parse error: Failed to parse usage: duplicate field `seven_day_design`
```

Root cause: `claude.ai`'s `/organizations/{id}/usage` response now ships two aliased keys for the same logical window in a single payload (e.g. `seven_day_design` *and* `seven_day_omelette`). Our `UsageResponse` struct used `#[serde(alias = ...)]` to accept either name — but serde rejects more than one matching alias with a "duplicate field" error. The Web/Cookies/Session usage fetcher therefore returned no data.

## Changes

`rust/src/providers/claude/web_api.rs`:

- **Replace alias-based `UsageResponse` with a manual `Deserialize` impl.** It deserializes into a `HashMap<String, Value>`, then for each logical field walks an ordered list of accepted keys and picks the first non-null one. Order matches the previous alias precedence, so any payload that worked before still works; payloads that contain *two* aliased keys now also work instead of erroring.
- **Add a `parse_json_with_body` helper** used by the four web JSON fetches (organizations, usage, extra usage, account). On parse failure it appends a 240-char snippet of the actual response body to the error message — this is how the duplicate-field issue was diagnosed in a single round trip, and it future-proofs us against further upstream schema changes.

No behavior change on the happy path; same field shape; same error path on success.

## Test plan

- [x] Manual repro on the affected account: Claude usage now refreshes cleanly via Web/manual-cookie source.
- [x] `cargo` build green via `tauri:dev` hot-reload.
- [ ] Sanity-check OAuth and CLI fetch paths still work (untouched, but worth a click).

🤖 Generated with [Claude Code](https://claude.com/claude-code)