### PR TITLE
Remove shared caches from release workflows

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -48,8 +48,6 @@ jobs:
         with:
           targets: ${{ matrix.target }}
 
-      - uses: Swatinem/rust-cache@v2
-
       - name: Build Linux CLI
         run: cargo build --manifest-path rust/Cargo.toml --release --target ${{ matrix.target }} --bin codexbar
 

--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -18,8 +18,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20
-          cache: npm
-          cache-dependency-path: apps/desktop-tauri/package-lock.json
 
       - name: Read app version
         shell: bash
@@ -36,8 +34,6 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           targets: x86_64-pc-windows-msvc
-
-      - uses: Swatinem/rust-cache@v2
 
       - name: Install frontend dependencies
         shell: bash


### PR DESCRIPTION
## Summary
- remove npm and Rust cache usage from release workflows
- keep release builds and asset upload behavior intact while avoiding shared cache reuse in privileged release paths

## Why
Recent supply-chain incidents, including the TanStack compromise, are a reminder that privileged PR/release/publish workflows should minimize shared mutable state. Caches can cross trust boundaries or preserve attacker-influenced artifacts longer than intended, and `pull_request_target` runs with elevated context compared with normal PR workflows.

## Validation
- parsed the touched workflow YAML successfully after the edit
- confirmed the touched workflows no longer reference `pull_request_target` or shared cache directives
