### PR TITLE
feat. "Quit" button only closes Settings window.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@
 
 ---
 
+## [Windows] 0.26.2 - 2026-05-16
+
+### Fixed
+- Make the Settings tab's Quit button close only the Settings window so the tray service keeps running.
+- Keep tray panel, pop-out, and native tray menu Quit actions on the app-level exit path.
+
+---
+
 ## [Windows] 0.26.1 - 2026-05-15
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -836,7 +836,7 @@ dependencies = [
 
 [[package]]
 name = "codexbar"
-version = "0.26.1"
+version = "0.26.2"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -888,7 +888,7 @@ dependencies = [
 
 [[package]]
 name = "codexbar-desktop-tauri"
-version = "0.26.1"
+version = "0.26.2"
 dependencies = [
  "chrono",
  "codexbar",

--- a/README.md
+++ b/README.md
@@ -23,11 +23,11 @@ The Windows port of [CodexBar](https://github.com/steipete/CodexBar) — a syste
 - **CLI** — `codexbar usage` and `codexbar cost` for scripting and CI
 - **WSL support** — CLI works out of the box; desktop shell via WSLg
 
-## What's New in v0.26.1
+## What's New in v0.26.2
 
-- Hotfix for Moonshot / Kimi API balance checks introduced in v0.26.0.
-- When `MOONSHOT_API_REGION` is unset, Win-CodexBar now tries both international and China Moonshot API endpoints so existing API keys keep working after upgrade.
-- Users who want a single endpoint can still pin `MOONSHOT_API_REGION=international` or `MOONSHOT_API_REGION=china`.
+- Fixed the Settings tab's Quit button so it closes only the Settings window and leaves CodexBar running in the tray.
+- Tray panel, pop-out, and native tray menu Quit actions still exit the whole app when you actually want to stop CodexBar.
+- This keeps Settings dismissal separate from shutting down the background tray service.
 
 ## Quick Start
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -23,11 +23,11 @@
 - **CLI** — `codexbar usage` 和 `codexbar cost`，便于脚本化和 CI
 - **WSL 支持** — CLI 开箱即用，桌面壳层通过 WSLg 运行
 
-## v0.26.1 更新内容
+## v0.26.2 更新内容
 
-- 修复 v0.26.0 引入的 Moonshot / Kimi API 余额检查区域兼容问题
-- 未设置 `MOONSHOT_API_REGION` 时，Win-CodexBar 现在会同时尝试 Moonshot 国际区与中国区 API 端点，避免升级后已有 API key 失效
-- 如需固定单一区域，仍可设置 `MOONSHOT_API_REGION=international` 或 `MOONSHOT_API_REGION=china`
+- 修复 Settings 选项卡中的 Quit 按钮：现在它只关闭 Settings 窗口，并让 CodexBar 继续留在系统托盘中运行。
+- 托盘面板、弹出窗口和原生托盘菜单中的 Quit 仍会在你确实想停止 CodexBar 时退出整个应用。
+- 这样 Settings 的关闭操作与后台托盘服务的退出保持分离。
 
 ## 快速开始
 

--- a/apps/desktop-tauri/package-lock.json
+++ b/apps/desktop-tauri/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "desktop-tauri",
-  "version": "0.26.1",
+  "version": "0.26.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "desktop-tauri",
-      "version": "0.26.1",
+      "version": "0.26.2",
       "dependencies": {
         "@tauri-apps/api": "2.10.1",
         "react": "18.3.1",

--- a/apps/desktop-tauri/package.json
+++ b/apps/desktop-tauri/package.json
@@ -1,7 +1,7 @@
 {
   "name": "desktop-tauri",
   "private": true,
-  "version": "0.26.1",
+  "version": "0.26.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/apps/desktop-tauri/src-tauri/Cargo.toml
+++ b/apps/desktop-tauri/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codexbar-desktop-tauri"
-version = "0.26.1"
+version = "0.26.2"
 edition = "2024"
 publish = false
 

--- a/apps/desktop-tauri/src-tauri/src/commands/mod.rs
+++ b/apps/desktop-tauri/src-tauri/src/commands/mod.rs
@@ -560,6 +560,10 @@ fn bridge_commands() -> Vec<BridgeCommandDescriptor> {
             description: "Switch the shell to a visible surface using a required typed target.",
         },
         BridgeCommandDescriptor {
+            id: "close_settings_window",
+            description: "Dismiss Settings without exiting the tray application.",
+        },
+        BridgeCommandDescriptor {
             id: "get_current_surface_mode",
             description: "Read the current coarse shell surface mode.",
         },
@@ -1098,6 +1102,14 @@ pub fn set_surface_mode(
 #[tauri::command]
 pub async fn open_settings_window(app: tauri::AppHandle, tab: String) -> Result<(), String> {
     crate::shell::settings_window::open_or_focus(&app, &tab)
+}
+
+#[tauri::command]
+pub fn close_settings_window(
+    app: tauri::AppHandle,
+    window: tauri::WebviewWindow,
+) -> Result<(), String> {
+    crate::shell::settings_window::dismiss(&app, &window)
 }
 
 #[tauri::command]

--- a/apps/desktop-tauri/src-tauri/src/main.rs
+++ b/apps/desktop-tauri/src-tauri/src/main.rs
@@ -53,6 +53,7 @@ fn main() {
             commands::update_settings,
             commands::set_surface_mode,
             commands::open_settings_window,
+            commands::close_settings_window,
             commands::get_current_surface_mode,
             commands::get_current_surface_state,
             commands::get_proof_state,

--- a/apps/desktop-tauri/src-tauri/src/shell/settings_window.rs
+++ b/apps/desktop-tauri/src-tauri/src/shell/settings_window.rs
@@ -13,6 +13,7 @@ const SETTINGS_HEIGHT: f64 = 580.0;
 /// frontend can switch to the requested tab without a full reload.
 pub fn open_or_focus(app: &tauri::AppHandle, tab: &str) -> Result<(), String> {
     if let Some(window) = app.get_webview_window(SETTINGS_LABEL) {
+        window.show().map_err(|e| e.to_string())?;
         window.set_focus().map_err(|e| e.to_string())?;
         app.emit_to(SETTINGS_LABEL, "settings-change-tab", tab)
             .map_err(|e| e.to_string())?;
@@ -47,5 +48,21 @@ pub fn open_or_focus(app: &tauri::AppHandle, tab: &str) -> Result<(), String> {
         let _ = win.set_position(PhysicalPosition::new(x, y));
     }
 
+    Ok(())
+}
+
+/// Dismiss Settings without exiting CodexBar.
+///
+/// The detached Settings window is hidden instead of closed so Tauri's
+/// process/window lifecycle cannot interpret this as an app quit. If Settings
+/// is rendered in the main shell surface, hide that surface back to tray.
+pub fn dismiss(app: &tauri::AppHandle, window: &tauri::WebviewWindow) -> Result<(), String> {
+    if window.label() == SETTINGS_LABEL {
+        return window.hide().map_err(|e| e.to_string());
+    }
+
+    crate::shell::hide_to_tray_if_current(app, |mode| {
+        mode == crate::surface::SurfaceMode::Settings
+    })?;
     Ok(())
 }

--- a/apps/desktop-tauri/src-tauri/tauri.conf.json
+++ b/apps/desktop-tauri/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "CodexBar Desktop",
-  "version": "0.26.1",
+  "version": "0.26.2",
   "identifier": "com.codexbar.desktop",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/apps/desktop-tauri/src/App.tsx
+++ b/apps/desktop-tauri/src/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { listen } from "@tauri-apps/api/event";
 import { getCurrentWebviewWindow } from "@tauri-apps/api/webviewWindow";
 import { checkForUpdates, getBootstrapState, getSettingsSnapshot, setSurfaceMode } from "./lib/tauri";
@@ -38,15 +38,22 @@ function AppInner() {
 
   useTheme(themePreference);
 
+  const reloadBootstrapState = useCallback(
+    () => getBootstrapState(),
+    [],
+  );
+
   useEffect(() => {
     let cancelled = false;
 
-    getBootstrapState()
+    reloadBootstrapState()
       .then((bootstrap) => {
-        if (!cancelled) {
-          setState(bootstrap);
-          setThemePreference(bootstrap.settings.theme);
+        if (cancelled) {
+          return;
         }
+        setState(bootstrap);
+        setThemePreference(bootstrap.settings.theme);
+        setError(null);
       })
       .catch((cause: unknown) => {
         if (!cancelled) {
@@ -64,6 +71,18 @@ function AppInner() {
     const unlistenPromise = listen<string>("global-shortcut-triggered", () => {
       void setSurfaceMode("trayPanel", { kind: "summary" }).catch(() => {});
     });
+
+    const unlistenSettingsChangePromise = isSettingsWindow()
+      ? listen<string>("settings-change-tab", () => {
+          void reloadBootstrapState()
+            .then((bootstrap) => {
+              setState(bootstrap);
+              setThemePreference(bootstrap.settings.theme);
+              setError(null);
+            })
+            .catch(() => {});
+        })
+      : Promise.resolve(null);
 
     // Keep the theme in sync when mutations happen inside other surfaces
     // (e.g., Settings → Appearance). `useSettings` dispatches this event
@@ -83,9 +102,12 @@ function AppInner() {
     return () => {
       cancelled = true;
       void unlistenPromise.then((unlisten) => unlisten()).catch(() => {});
+      void unlistenSettingsChangePromise
+        .then((unlisten) => unlisten?.())
+        .catch(() => {});
       window.removeEventListener("codexbar:settings-updated", onSettingsUpdated);
     };
-  }, []);
+  }, [reloadBootstrapState]);
 
   if (error) {
     return (

--- a/apps/desktop-tauri/src/lib/tauri.ts
+++ b/apps/desktop-tauri/src/lib/tauri.ts
@@ -63,6 +63,10 @@ export function openSettingsWindow(tab: string): Promise<void> {
   return invoke<void>("open_settings_window", { tab });
 }
 
+export function closeSettingsWindow(): Promise<void> {
+  return invoke<void>("close_settings_window");
+}
+
 export function getCurrentSurfaceMode(): Promise<SurfaceMode> {
   return invoke<SurfaceMode>("get_current_surface_mode");
 }

--- a/apps/desktop-tauri/src/surfaces/PopOutPanel.tsx
+++ b/apps/desktop-tauri/src/surfaces/PopOutPanel.tsx
@@ -1,7 +1,6 @@
 import { useCallback, useEffect, useMemo } from "react";
-import { getCurrentWindow } from "@tauri-apps/api/window";
 import type { BootstrapState, ProviderUsageSnapshot } from "../types/bridge";
-import { setSurfaceMode, openSettingsWindow } from "../lib/tauri";
+import { setSurfaceMode, openSettingsWindow, quitApp as quitApplication } from "../lib/tauri";
 import { useProviders } from "../hooks/useProviders";
 import { useSettings } from "../hooks/useSettings";
 import { useUpdateState } from "../hooks/useUpdateState";
@@ -66,7 +65,7 @@ export default function PopOutPanel({
     openSettingsWindow("about");
   }, []);
   const quitApp = useCallback(() => {
-    void getCurrentWindow().close();
+    void quitApplication();
   }, []);
 
   const headerActions = [

--- a/apps/desktop-tauri/src/surfaces/Settings.tsx
+++ b/apps/desktop-tauri/src/surfaces/Settings.tsx
@@ -10,7 +10,7 @@ import { useSettings } from "../hooks/useSettings";
 import { useSurfaceTarget } from "../hooks/useSurfaceMode";
 import { useLocale } from "../hooks/useLocale";
 import type { LocaleKey } from "../i18n/keys";
-import { setSurfaceMode } from "../lib/tauri";
+import { closeSettingsWindow, setSurfaceMode } from "../lib/tauri";
 import GeneralTab from "./settings/tabs/GeneralTab";
 import DisplayTab from "./settings/tabs/DisplayTab";
 import AdvancedTab from "./settings/tabs/AdvancedTab";
@@ -175,7 +175,7 @@ export default function Settings({ state, initialTab: propTab }: { state: Bootst
           <span className="settings-titlebar__title" data-tauri-drag-region>CodexBar Settings</span>
           <button
             className="settings-titlebar__close"
-            onClick={() => void getCurrentWindow().close()}
+            onClick={() => void closeSettingsWindow()}
             aria-label="Close"
           >
             ✕

--- a/apps/desktop-tauri/src/surfaces/TrayPanel.tsx
+++ b/apps/desktop-tauri/src/surfaces/TrayPanel.tsx
@@ -1,7 +1,7 @@
 import { Fragment, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { getCurrentWindow, LogicalSize } from "@tauri-apps/api/window";
 import type { BootstrapState, ProviderUsageSnapshot } from "../types/bridge";
-import { setSurfaceMode, openSettingsWindow } from "../lib/tauri";
+import { setSurfaceMode, openSettingsWindow, quitApp as quitApplication } from "../lib/tauri";
 import { reanchorTrayPanel } from "../lib/tauri";
 import { useProviders } from "../hooks/useProviders";
 import { useSettings } from "../hooks/useSettings";
@@ -224,7 +224,7 @@ export default function TrayPanel({ state }: { state: BootstrapState }) {
     });
   }, []);
   const quitApp = useCallback(() => {
-    void getCurrentWindow().close();
+    void quitApplication();
   }, []);
 
   const headerActions = [

--- a/apps/desktop-tauri/src/surfaces/settings/tabs/GeneralTab.tsx
+++ b/apps/desktop-tauri/src/surfaces/settings/tabs/GeneralTab.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useState } from "react";
 import { useLocale } from "../../../hooks/useLocale";
-import { playNotificationSound, quitApp } from "../../../lib/tauri";
+import { closeSettingsWindow, playNotificationSound } from "../../../lib/tauri";
 import { Field, NumberInput, Select, Toggle } from "../../../components/FormControls";
 import type { TabProps } from "../../Settings";
 
@@ -24,7 +24,7 @@ export default function GeneralTab({ settings, set, saving }: TabProps) {
   }, []);
 
   const handleQuit = useCallback(() => {
-    void quitApp().catch(() => window.close());
+    void closeSettingsWindow();
   }, []);
 
   return (

--- a/rust/CHANGELOG.md
+++ b/rust/CHANGELOG.md
@@ -11,6 +11,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ---
 
+## [0.26.2] — 2026-05-16
+
+### Fixed
+- Made the Settings tab's Quit button close only the Settings window so the tray service keeps running.
+- Kept tray panel, pop-out, and native tray menu Quit actions on the app-level exit path.
+
+---
+
 ## [0.26.1] — 2026-05-15
 
 ### Fixed

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codexbar"
-version = "0.26.1"
+version = "0.26.2"
 edition = "2024"
 authors = ["CodexBar Contributors"]
 description = "Windows and WSL system tray app for monitoring AI provider usage limits"


### PR DESCRIPTION
This pull request updates CodexBar Desktop to version 0.26.2, focusing on improving the Settings window behavior on Windows. The main change ensures that clicking the Quit button in the Settings tab now only closes the Settings window, leaving the tray service running, while quit actions in the tray and pop-out panels still exit the entire app. This provides a clearer separation between dismissing Settings and fully quitting CodexBar. The update also includes version bumps and documentation updates.

**Settings Window Behavior Improvements:**

* Added a new backend command (`close_settings_window`) and corresponding Rust implementation to hide the Settings window instead of closing the entire app, preventing unintended app exits when dismissing Settings. (`apps/desktop-tauri/src-tauri/src/commands/mod.rs`, `apps/desktop-tauri/src-tauri/src/shell/settings_window.rs`, [[1]](diffhunk://#diff-4ad7209185c5f33ffe4e190d1386d5dc101ac33d083d1b400e978869247759dcR562-R565) [[2]](diffhunk://#diff-4ad7209185c5f33ffe4e190d1386d5dc101ac33d083d1b400e978869247759dcR1107-R1114) [[3]](diffhunk://#diff-c3b43adf3dbe33b656650cdc31d820991fe1617324a8bec929fae0018d017dd9R53-R68)
* Updated the Settings UI and related frontend logic to use the new `closeSettingsWindow` function, ensuring the Quit button only dismisses the Settings window. (`apps/desktop-tauri/src/lib/tauri.ts`, `apps/desktop-tauri/src/surfaces/Settings.tsx`, `apps/desktop-tauri/src/surfaces/settings/tabs/GeneralTab.tsx`, [[1]](diffhunk://#diff-5928df72b248347ada54ccf861cce04e264d5e64300b1e7ce9b3614726f60fafR66-R69) [[2]](diffhunk://#diff-18359d250087afc4a9cde1ac1fac551f0eed2777908ca42d68241de2b4bef1c2L13-R13) [[3]](diffhunk://#diff-18359d250087afc4a9cde1ac1fac551f0eed2777908ca42d68241de2b4bef1c2L178-R178) [[4]](diffhunk://#diff-50e9e3a9b75179c74b90ab594758e7c7f2c735fc0549c9543821695bf5285271L3-R3) [[5]](diffhunk://#diff-50e9e3a9b75179c74b90ab594758e7c7f2c735fc0549c9543821695bf5285271L27-R27)

**App Quit Logic Consistency:**

* Ensured that quit actions from the tray panel and pop-out panel continue to exit the entire application, maintaining expected behavior for users who want to fully stop CodexBar. (`apps/desktop-tauri/src/surfaces/TrayPanel.tsx`, `apps/desktop-tauri/src/surfaces/PopOutPanel.tsx`, [[1]](diffhunk://#diff-0d21cd90a13849d1a226cc774d9a59741c90ee183075939c22d2b4b85171684dL4-R4) [[2]](diffhunk://#diff-0d21cd90a13849d1a226cc774d9a59741c90ee183075939c22d2b4b85171684dL227-R227) [[3]](diffhunk://#diff-236812d936a91776254777ae8adaf3c4841239af67fef4f37de2a0cac3920f32L2-R3) [[4]](diffhunk://#diff-236812d936a91776254777ae8adaf3c4841239af67fef4f37de2a0cac3920f32L69-R68)

**Version and Documentation Updates:**

* Bumped version numbers to 0.26.2 in all relevant files and updated changelogs and README files (including Chinese translation) to reflect the new Settings window behavior. (`apps/desktop-tauri/package.json`, `apps/desktop-tauri/package-lock.json`, `apps/desktop-tauri/src-tauri/Cargo.toml`, `apps/desktop-tauri/src-tauri/tauri.conf.json`, `rust/Cargo.toml`, `CHANGELOG.md`, `rust/CHANGELOG.md`, `README.md`, `README.zh-CN.md`, [[1]](diffhunk://#diff-9b06033168f0aa570edc761debb40e42dd292bc3cf0ce48be0dc673cb9967d84L4-R4) [[2]](diffhunk://#diff-ed466de7e5cebf5961f69ab42dc7aed2f146a1d2cad81d7fa46587d47c282b09L3-R9) [[3]](diffhunk://#diff-e7cc6a6db76d8dcc533741806c57752ccf27dd5f0d4690802084a735dd5dc857L3-R3) [[4]](diffhunk://#diff-92f1d66a188d04417516678b256f39ee1ffd3e5ea14a0b93a74472d6d64e0179L4-R4) [[5]](diffhunk://#diff-74eb46d64310c0817ed15b2389cf81183c18cdebbaa256a4198057855ecf14d7L3-R3) [[6]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR7-R14) [[7]](diffhunk://#diff-9f0bc9212c4e423973a1e88a1ba3af413d42b4935ca6e2e42de677a8cf2fa4b6R14-R21) [[8]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L26-R30) [[9]](diffhunk://#diff-13f564fa6ce92394f8423bbcea359aef7e9ebc4f79763efc0d791d9ce5b6f987L26-R30)

**Miscellaneous:**

* Minor adjustment to ensure the Settings window is shown before focusing when opened. (`apps/desktop-tauri/src-tauri/src/shell/settings_window.rs`, [apps/desktop-tauri/src-tauri/src/shell/settings_window.rsR16](diffhunk://#diff-c3b43adf3dbe33b656650cdc31d820991fe1617324a8bec929fae0018d017dd9R16))

Closes #54 