### PR TITLE
Add Command Palette Dock extension

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,9 @@ tmpclaude-*
 *.swo
 node_modules/
 dist/
+apps/command-palette-extension/**/bin/
+apps/command-palette-extension/**/obj/
+apps/command-palette-extension/**/TestResults/
 nul
 
 # Local scripts and env files

--- a/apps/command-palette-extension/CodexBar.CommandPalette.Tests/CodexBar.CommandPalette.Tests.csproj
+++ b/apps/command-palette-extension/CodexBar.CommandPalette.Tests/CodexBar.CommandPalette.Tests.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0-windows10.0.26100.0</TargetFramework>
+    <TargetPlatformMinVersion>10.0.22000.0</TargetPlatformMinVersion>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <WindowsAppSDKBootstrapInitialize>false</WindowsAppSDKBootstrapInitialize>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.10.5" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.10.5" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\CodexBar.CommandPalette\CodexBar.CommandPalette.csproj" />
+  </ItemGroup>
+</Project>

--- a/apps/command-palette-extension/CodexBar.CommandPalette.Tests/CodexBarCliClientTests.cs
+++ b/apps/command-palette-extension/CodexBar.CommandPalette.Tests/CodexBarCliClientTests.cs
@@ -1,0 +1,161 @@
+using CodexBar.CommandPalette.Models;
+using CodexBar.CommandPalette.Services;
+using CodexBar.CommandPalette.Ui;
+
+namespace CodexBar.CommandPalette.Tests;
+
+[TestClass]
+public sealed class CodexBarCliClientTests
+{
+    [TestMethod]
+    public void ParseSnapshotJson_reads_provider_usage()
+    {
+        const string Json = """
+            {
+              "contractVersion": "cmdpal.snapshot.v1",
+              "generatedAt": "2026-05-18T12:00:00Z",
+              "refreshIntervalSecs": 300,
+              "providers": [
+                {
+                  "providerId": "codex",
+                  "displayName": "Codex",
+                  "primaryLabel": "Session",
+                  "primary": {
+                    "usedPercent": 72.4,
+                    "remainingPercent": 27.6,
+                    "windowMinutes": 300,
+                    "resetsAt": "2026-05-18T14:00:00Z",
+                    "resetDescription": "2h",
+                    "isExhausted": false
+                  },
+                  "source": "oauth",
+                  "updatedAt": "2026-05-18T12:00:00Z",
+                  "dashboardUrl": "https://chatgpt.com/codex/settings/usage"
+                }
+              ]
+            }
+            """;
+
+        var snapshot = CodexBarCliClient.ParseSnapshotJson(Json);
+
+        Assert.AreEqual("cmdpal.snapshot.v1", snapshot.ContractVersion);
+        Assert.AreEqual(300, snapshot.RefreshIntervalSecs);
+        Assert.AreEqual(1, snapshot.Providers.Count);
+        Assert.AreEqual("codex", snapshot.Providers[0].ProviderId);
+        Assert.AreEqual(72.4, snapshot.Providers[0].UsedPercent, 0.0001);
+        Assert.AreEqual("2h", snapshot.Providers[0].Primary?.ResetDescription);
+    }
+
+    [TestMethod]
+    public void ResolveBackendPath_uses_environment_override()
+    {
+        var previous = Environment.GetEnvironmentVariable(CodexBarCliClient.BackendOverrideEnvironmentVariable);
+        try
+        {
+            Environment.SetEnvironmentVariable(CodexBarCliClient.BackendOverrideEnvironmentVariable, @"C:\dev\codexbar.exe");
+
+            Assert.AreEqual(@"C:\dev\codexbar.exe", CodexBarCliClient.ResolveBackendPath());
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(CodexBarCliClient.BackendOverrideEnvironmentVariable, previous);
+        }
+    }
+
+    [TestMethod]
+    public async Task StateService_retains_previous_cache_after_refresh_failure()
+    {
+        var snapshot = new CmdPalSnapshot
+        {
+            ContractVersion = "cmdpal.snapshot.v1",
+            GeneratedAt = DateTimeOffset.UtcNow,
+            RefreshIntervalSecs = 300,
+            Providers = [new ProviderSnapshot { ProviderId = "codex", DisplayName = "Codex" }],
+        };
+        var client = new QueueClient(snapshot, new InvalidOperationException("boom"));
+        var service = new CodexBarStateService(client);
+
+        var first = await service.RefreshAsync();
+        var second = await service.RefreshAsync();
+
+        Assert.AreSame(snapshot, first);
+        Assert.AreSame(snapshot, second);
+        Assert.AreSame(snapshot, service.CachedSnapshot);
+        Assert.AreEqual("boom", service.LastError);
+    }
+
+    [TestMethod]
+    public async Task StateService_does_not_start_parallel_refreshes()
+    {
+        var client = new BlockingClient();
+        var service = new CodexBarStateService(client);
+
+        var first = service.RefreshAsync();
+        await client.Started.Task;
+        var second = await service.RefreshAsync();
+        client.Release.SetResult();
+        await first;
+
+        Assert.AreEqual(1, client.CallCount);
+        Assert.AreEqual(0, second.Providers.Count);
+    }
+
+    [TestMethod]
+    public void ProviderText_five_hour_title_uses_primary_window()
+    {
+        var provider = new ProviderSnapshot
+        {
+            ProviderId = "codex",
+            DisplayName = "Codex",
+            Primary = new RateWindowSnapshot { UsedPercent = 24.6, ResetDescription = "1h 20m" },
+            Secondary = new RateWindowSnapshot { UsedPercent = 91.2, ResetDescription = "tomorrow" },
+        };
+
+        Assert.AreEqual("Codex 5h 25%", ProviderText.FiveHourTitle(provider));
+        Assert.AreEqual("5h reset 1h 20m", ProviderText.FiveHourSubtitle(provider));
+    }
+
+    private sealed class QueueClient : ICodexBarCliClient
+    {
+        private readonly Queue<object> _responses;
+
+        public QueueClient(params object[] responses)
+        {
+            _responses = new Queue<object>(responses);
+        }
+
+        public Task<CmdPalSnapshot> GetSnapshotAsync(CancellationToken cancellationToken)
+        {
+            var next = _responses.Dequeue();
+            if (next is Exception ex)
+            {
+                throw ex;
+            }
+
+            return Task.FromResult((CmdPalSnapshot)next);
+        }
+    }
+
+    private sealed class BlockingClient : ICodexBarCliClient
+    {
+        public TaskCompletionSource Started { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public TaskCompletionSource Release { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public int CallCount { get; private set; }
+
+        public async Task<CmdPalSnapshot> GetSnapshotAsync(CancellationToken cancellationToken)
+        {
+            CallCount++;
+            Started.SetResult();
+            await Release.Task.WaitAsync(cancellationToken);
+            return new CmdPalSnapshot
+            {
+                ContractVersion = "cmdpal.snapshot.v1",
+                GeneratedAt = DateTimeOffset.UtcNow,
+                RefreshIntervalSecs = 300,
+                Providers = [new ProviderSnapshot { ProviderId = "codex", DisplayName = "Codex" }],
+            };
+        }
+    }
+}

--- a/apps/command-palette-extension/CodexBar.CommandPalette/CodexBar.CommandPalette.csproj
+++ b/apps/command-palette-extension/CodexBar.CommandPalette/CodexBar.CommandPalette.csproj
@@ -1,0 +1,46 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>net9.0-windows10.0.26100.0</TargetFramework>
+    <TargetPlatformMinVersion>10.0.22000.0</TargetPlatformMinVersion>
+    <RootNamespace>CodexBar.CommandPalette</RootNamespace>
+    <AssemblyName>CodexBar.CommandPalette</AssemblyName>
+    <ApplicationManifest>app.manifest</ApplicationManifest>
+    <UseWinUI>false</UseWinUI>
+    <EnableMsixTooling>true</EnableMsixTooling>
+    <GenerateAppxPackageOnBuild>false</GenerateAppxPackageOnBuild>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <Platforms>x64;arm64</Platforms>
+    <WindowsAppSDKBootstrapInitialize>false</WindowsAppSDKBootstrapInitialize>
+    <RuntimeIdentifier Condition="'$(Platform)' == 'x64'">win-x64</RuntimeIdentifier>
+    <RuntimeIdentifier Condition="'$(Platform)' == 'arm64'">win-arm64</RuntimeIdentifier>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CommandPalette.Extensions" Version="0.9.260303001" />
+    <PackageReference Include="Shmuelie.WinRTServer" Version="2.2.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Manifest Include="$(ApplicationManifest)" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Content Include="..\..\..\rust\assets\icons\CodexBar-app-icon.png" Link="Assets\StoreLogo.png" />
+    <Content Include="..\..\..\rust\assets\icons\CodexBar-app-icon.png" Link="Assets\Square150x150Logo.png" />
+    <Content Include="..\..\..\rust\assets\icons\CodexBar-app-icon.png" Link="Assets\Square44x44Logo.png" />
+    <Content Include="..\..\..\rust\assets\icons\CodexBar-app-icon.png" Link="Assets\Wide310x150Logo.png" />
+    <Content Include="..\..\..\rust\assets\icons\CodexBar-app-icon.png" Link="Assets\SplashScreen.png" />
+    <Content Include="..\..\..\target\release\codexbar.exe" Condition="Exists('..\..\..\target\release\codexbar.exe')" Link="Backend\codexbar.exe" CopyToOutputDirectory="PreserveNewest" />
+    <Content Include="..\..\..\target\debug\codexbar.exe" Condition="!Exists('..\..\..\target\release\codexbar.exe') And Exists('..\..\..\target\debug\codexbar.exe')" Link="Backend\codexbar.exe" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Folder Include="Public\" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(DisableMsixProjectCapabilityAddedByProject)' != 'true' and '$(EnableMsixTooling)' == 'true'">
+    <ProjectCapability Include="Msix" />
+  </ItemGroup>
+</Project>

--- a/apps/command-palette-extension/CodexBar.CommandPalette/CodexBarCommandsProvider.cs
+++ b/apps/command-palette-extension/CodexBar.CommandPalette/CodexBarCommandsProvider.cs
@@ -1,0 +1,55 @@
+using CodexBar.CommandPalette.Commands;
+using CodexBar.CommandPalette.Dock;
+using CodexBar.CommandPalette.Pages;
+using CodexBar.CommandPalette.Services;
+using Microsoft.CommandPalette.Extensions;
+using Microsoft.CommandPalette.Extensions.Toolkit;
+
+namespace CodexBar.CommandPalette;
+
+public sealed partial class CodexBarCommandsProvider : CommandProvider
+{
+    public const string ProviderId = "com.finesssee.codexbar.commandpalette";
+
+    private readonly CodexBarStateService _state = new(new CodexBarCliClient());
+    private readonly ICommandItem[] _commands;
+
+    public CodexBarCommandsProvider()
+    {
+        DisplayName = "CodexBar";
+        Id = ProviderId;
+        Icon = new IconInfo("\uE950");
+
+        var page = new CodexBarListPage(_state);
+        _commands =
+        [
+            new CommandItem(page)
+            {
+                Title = "CodexBar",
+                Subtitle = "AI provider usage snapshot",
+                Icon = Icon,
+                MoreCommands =
+                [
+                    new CommandContextItem(new RefreshSnapshotCommand(_state))
+                    {
+                        Title = "Refresh",
+                    },
+                    new CommandContextItem(new OpenCodexBarSettingsCommand())
+                    {
+                        Title = "Open CodexBar Settings",
+                    },
+                ],
+            },
+        ];
+    }
+
+    public override ICommandItem[] TopLevelCommands()
+    {
+        return _commands;
+    }
+
+    public override ICommandItem[] GetDockBands()
+    {
+        return [new CodexBarDockBand(_state)];
+    }
+}

--- a/apps/command-palette-extension/CodexBar.CommandPalette/CodexBarExtension.cs
+++ b/apps/command-palette-extension/CodexBar.CommandPalette/CodexBarExtension.cs
@@ -1,0 +1,28 @@
+using System.Runtime.InteropServices;
+using Microsoft.CommandPalette.Extensions;
+
+namespace CodexBar.CommandPalette;
+
+[ComVisible(true)]
+[Guid("C6A683A4-6101-4F13-83FE-EE355BA58FE3")]
+[ComDefaultInterface(typeof(IExtension))]
+public sealed partial class CodexBarExtension : IExtension, IDisposable
+{
+    private readonly ManualResetEvent _extensionDisposedEvent;
+    private readonly CodexBarCommandsProvider _provider = new();
+
+    public CodexBarExtension(ManualResetEvent extensionDisposedEvent)
+    {
+        _extensionDisposedEvent = extensionDisposedEvent;
+    }
+
+    public object? GetProvider(ProviderType providerType)
+    {
+        return providerType == ProviderType.Commands ? _provider : null;
+    }
+
+    public void Dispose()
+    {
+        _extensionDisposedEvent.Set();
+    }
+}

--- a/apps/command-palette-extension/CodexBar.CommandPalette/Commands/OpenCodexBarSettingsCommand.cs
+++ b/apps/command-palette-extension/CodexBar.CommandPalette/Commands/OpenCodexBarSettingsCommand.cs
@@ -1,0 +1,82 @@
+using System.Diagnostics;
+using Microsoft.CommandPalette.Extensions;
+using Microsoft.CommandPalette.Extensions.Toolkit;
+
+namespace CodexBar.CommandPalette.Commands;
+
+internal sealed partial class OpenCodexBarSettingsCommand : InvokableCommand
+{
+    private const string AppOverrideEnvironmentVariable = "CODEXBAR_APP_EXE";
+
+    public OpenCodexBarSettingsCommand()
+    {
+        Name = "Open CodexBar Settings";
+        Icon = new IconInfo("\uE713");
+    }
+
+    public override ICommandResult Invoke()
+    {
+        var appPath = ResolveAppPath();
+        if (appPath is null)
+        {
+            return CommandResult.ShowToast(
+                $"CodexBar desktop app was not found. Set {AppOverrideEnvironmentVariable} to CodexBar.exe or install the Tauri app.");
+        }
+
+        try
+        {
+            Process.Start(new ProcessStartInfo
+            {
+                FileName = appPath,
+                UseShellExecute = true,
+            });
+            return CommandResult.GoHome();
+        }
+        catch (Exception ex)
+        {
+            return CommandResult.ShowToast($"Could not open CodexBar: {ex.Message}");
+        }
+    }
+
+    private static string? ResolveAppPath()
+    {
+        var overridePath = Environment.GetEnvironmentVariable(AppOverrideEnvironmentVariable);
+        if (!string.IsNullOrWhiteSpace(overridePath) && File.Exists(overridePath))
+        {
+            return overridePath;
+        }
+
+        foreach (var candidate in CandidatePaths())
+        {
+            if (File.Exists(candidate))
+            {
+                return candidate;
+            }
+        }
+
+        return null;
+    }
+
+    private static IEnumerable<string> CandidatePaths()
+    {
+        var localAppData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+        var programFiles = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles);
+        var programFilesX86 = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86);
+
+        if (!string.IsNullOrWhiteSpace(localAppData))
+        {
+            yield return Path.Combine(localAppData, "Programs", "CodexBar", "CodexBar.exe");
+            yield return Path.Combine(localAppData, "CodexBar", "CodexBar.exe");
+        }
+
+        if (!string.IsNullOrWhiteSpace(programFiles))
+        {
+            yield return Path.Combine(programFiles, "CodexBar", "CodexBar.exe");
+        }
+
+        if (!string.IsNullOrWhiteSpace(programFilesX86))
+        {
+            yield return Path.Combine(programFilesX86, "CodexBar", "CodexBar.exe");
+        }
+    }
+}

--- a/apps/command-palette-extension/CodexBar.CommandPalette/Commands/RefreshSnapshotCommand.cs
+++ b/apps/command-palette-extension/CodexBar.CommandPalette/Commands/RefreshSnapshotCommand.cs
@@ -1,0 +1,29 @@
+using CodexBar.CommandPalette.Services;
+using Microsoft.CommandPalette.Extensions;
+using Microsoft.CommandPalette.Extensions.Toolkit;
+
+namespace CodexBar.CommandPalette.Commands;
+
+internal sealed partial class RefreshSnapshotCommand : InvokableCommand
+{
+    private readonly CodexBarStateService _state;
+    private readonly Action? _afterRefresh;
+
+    public RefreshSnapshotCommand(CodexBarStateService state, Action? afterRefresh = null)
+    {
+        _state = state;
+        _afterRefresh = afterRefresh;
+        Name = "Refresh";
+        Icon = new IconInfo("\uE72C");
+    }
+
+    public override ICommandResult Invoke()
+    {
+        _state.RefreshBlocking();
+        _afterRefresh?.Invoke();
+
+        return string.IsNullOrWhiteSpace(_state.LastError)
+            ? CommandResult.ShowToast("CodexBar refreshed")
+            : CommandResult.ShowToast($"CodexBar refresh failed: {_state.LastError}");
+    }
+}

--- a/apps/command-palette-extension/CodexBar.CommandPalette/Dock/CodexBarDockBand.cs
+++ b/apps/command-palette-extension/CodexBar.CommandPalette/Dock/CodexBarDockBand.cs
@@ -1,0 +1,91 @@
+using CodexBar.CommandPalette.Commands;
+using CodexBar.CommandPalette.Models;
+using CodexBar.CommandPalette.Pages;
+using CodexBar.CommandPalette.Services;
+using CodexBar.CommandPalette.Ui;
+using Microsoft.CommandPalette.Extensions.Toolkit;
+
+namespace CodexBar.CommandPalette.Dock;
+
+internal sealed partial class CodexBarDockBand : CommandItem
+{
+    private readonly CodexBarStateService _state;
+    private readonly CodexBarDockHomePage _page;
+
+    public CodexBarDockBand(CodexBarStateService state)
+        : this(state, new CodexBarDockHomePage(state))
+    {
+    }
+
+    private CodexBarDockBand(CodexBarStateService state, CodexBarDockHomePage page)
+        : base(page)
+    {
+        _state = state;
+        _page = page;
+        Icon = new IconInfo("\uE950");
+        MoreCommands =
+        [
+            new CommandContextItem(new RefreshSnapshotCommand(_state, RefreshDock))
+            {
+                Title = "Refresh",
+            },
+            new CommandContextItem(new CodexBarListPage(_state))
+            {
+                Title = "Open CodexBar Home",
+            },
+            new CommandContextItem(new OpenCodexBarSettingsCommand())
+            {
+                Title = "Open CodexBar Settings",
+            },
+        ];
+        RebuildDockText();
+    }
+
+    private void RefreshDock()
+    {
+        _page.RefreshContent();
+        RebuildDockText();
+    }
+
+    private void RebuildDockText()
+    {
+        var snapshot = _state.RefreshBlocking();
+        var dockProvider = PickDockProvider(snapshot.Providers);
+        var dockTitle = dockProvider is null ? "CodexBar" : ProviderText.FiveHourTitle(dockProvider);
+        var dockSubtitle = dockProvider is null
+            ? DockSubtitle(snapshot.Providers.Count)
+            : DockSubtitle(snapshot.Providers.Count, ProviderText.FiveHourSubtitle(dockProvider));
+
+        Title = dockTitle;
+        Subtitle = dockSubtitle;
+        Icon = dockProvider?.HasError == true ? new IconInfo("\uE783") : new IconInfo("\uE950");
+    }
+
+    private string DockSubtitle(int providerCount, string? currentStatus = null)
+    {
+        if (!string.IsNullOrWhiteSpace(_state.LastError))
+        {
+            return _state.LastError;
+        }
+
+        if (!string.IsNullOrWhiteSpace(currentStatus))
+        {
+            return currentStatus;
+        }
+
+        return providerCount == 0 ? "No enabled providers" : $"{providerCount} enabled providers";
+    }
+
+    private static ProviderSnapshot? PickDockProvider(IReadOnlyCollection<ProviderSnapshot> providers)
+    {
+        return providers
+            .Where(provider => provider.Primary is not null && !provider.HasError)
+            .OrderByDescending(provider => provider.Primary?.UsedPercent ?? -1)
+            .ThenBy(provider => provider.DisplayName, StringComparer.OrdinalIgnoreCase)
+            .FirstOrDefault()
+            ?? providers
+                .OrderByDescending(provider => provider.Primary?.UsedPercent ?? provider.UsedPercent)
+                .ThenBy(provider => provider.DisplayName, StringComparer.OrdinalIgnoreCase)
+                .FirstOrDefault();
+    }
+}

--- a/apps/command-palette-extension/CodexBar.CommandPalette/Models/CmdPalSnapshot.cs
+++ b/apps/command-palette-extension/CodexBar.CommandPalette/Models/CmdPalSnapshot.cs
@@ -1,0 +1,60 @@
+using System.Text.Json.Serialization;
+
+namespace CodexBar.CommandPalette.Models;
+
+public sealed record CmdPalSnapshot
+{
+    public string ContractVersion { get; init; } = string.Empty;
+
+    public DateTimeOffset GeneratedAt { get; init; }
+
+    public int RefreshIntervalSecs { get; init; }
+
+    public IReadOnlyList<ProviderSnapshot> Providers { get; init; } = [];
+}
+
+public sealed record ProviderSnapshot
+{
+    public string ProviderId { get; init; } = string.Empty;
+
+    public string DisplayName { get; init; } = string.Empty;
+
+    public string? PrimaryLabel { get; init; }
+
+    public RateWindowSnapshot? Primary { get; init; }
+
+    public string? SecondaryLabel { get; init; }
+
+    public RateWindowSnapshot? Secondary { get; init; }
+
+    public string? Source { get; init; }
+
+    public DateTimeOffset? UpdatedAt { get; init; }
+
+    public string? Error { get; init; }
+
+    public string? DashboardUrl { get; init; }
+
+    public string? StatusPageUrl { get; init; }
+
+    [JsonIgnore]
+    public double UsedPercent => Math.Max(Primary?.UsedPercent ?? 0, Secondary?.UsedPercent ?? 0);
+
+    [JsonIgnore]
+    public bool HasError => !string.IsNullOrWhiteSpace(Error);
+}
+
+public sealed record RateWindowSnapshot
+{
+    public double UsedPercent { get; init; }
+
+    public double RemainingPercent { get; init; }
+
+    public int? WindowMinutes { get; init; }
+
+    public DateTimeOffset? ResetsAt { get; init; }
+
+    public string? ResetDescription { get; init; }
+
+    public bool IsExhausted { get; init; }
+}

--- a/apps/command-palette-extension/CodexBar.CommandPalette/Package.appxmanifest
+++ b/apps/command-palette-extension/CodexBar.CommandPalette/Package.appxmanifest
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Package
+  xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10"
+  xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10"
+  xmlns:uap3="http://schemas.microsoft.com/appx/manifest/uap/windows10/3"
+  xmlns:com="http://schemas.microsoft.com/appx/manifest/com/windows10"
+  xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities"
+  IgnorableNamespaces="uap uap3 rescap">
+
+  <Identity
+    Name="CodexBar.CommandPalette"
+    Publisher="CN=CodexBar"
+    Version="0.1.0.0" />
+
+  <Properties>
+    <DisplayName>CodexBar Command Palette</DisplayName>
+    <PublisherDisplayName>CodexBar</PublisherDisplayName>
+    <Logo>Assets\StoreLogo.png</Logo>
+  </Properties>
+
+  <Dependencies>
+    <TargetDeviceFamily Name="Windows.Universal" MinVersion="10.0.19041.0" MaxVersionTested="10.0.26200.0" />
+    <TargetDeviceFamily Name="Windows.Desktop" MinVersion="10.0.19041.0" MaxVersionTested="10.0.26200.0" />
+  </Dependencies>
+
+  <Resources>
+    <Resource Language="en-us"/>
+  </Resources>
+
+  <Applications>
+    <Application Id="App"
+      Executable="$targetnametoken$.exe"
+      EntryPoint="$targetentrypoint$">
+      <uap:VisualElements
+        DisplayName="CodexBar"
+        Description="CodexBar Command Palette and Dock extension"
+        AppListEntry="none"
+        BackgroundColor="transparent"
+        Square150x150Logo="Assets\Square150x150Logo.png"
+        Square44x44Logo="Assets\Square44x44Logo.png">
+        <uap:DefaultTile Wide310x150Logo="Assets\Wide310x150Logo.png" />
+        <uap:SplashScreen Image="Assets\SplashScreen.png" />
+      </uap:VisualElements>
+      <Extensions>
+        <com:Extension Category="windows.comServer">
+          <com:ComServer>
+            <com:ExeServer Executable="CodexBar.CommandPalette.exe" Arguments="-RegisterProcessAsComServer" DisplayName="CodexBarCommandPalette">
+              <com:Class Id="C6A683A4-6101-4F13-83FE-EE355BA58FE3" DisplayName="CodexBar Command Palette" />
+            </com:ExeServer>
+          </com:ComServer>
+        </com:Extension>
+        <uap3:Extension Category="windows.appExtension">
+          <uap3:AppExtension Name="com.microsoft.commandpalette"
+            Id="CodexBarCommandPalette"
+            PublicFolder="Public"
+            DisplayName="CodexBar"
+            Description="Read-only CodexBar provider usage for Command Palette and Dock">
+            <uap3:Properties>
+              <CmdPalProvider>
+                <Activation>
+                  <CreateInstance ClassId="C6A683A4-6101-4F13-83FE-EE355BA58FE3" />
+                </Activation>
+                <SupportedInterfaces>
+                  <Commands/>
+                </SupportedInterfaces>
+              </CmdPalProvider>
+            </uap3:Properties>
+          </uap3:AppExtension>
+        </uap3:Extension>
+      </Extensions>
+    </Application>
+  </Applications>
+
+  <Capabilities>
+    <Capability Name="internetClient" />
+    <rescap:Capability Name="runFullTrust" />
+  </Capabilities>
+</Package>

--- a/apps/command-palette-extension/CodexBar.CommandPalette/Pages/CodexBarDockHomePage.cs
+++ b/apps/command-palette-extension/CodexBar.CommandPalette/Pages/CodexBarDockHomePage.cs
@@ -1,0 +1,134 @@
+using CodexBar.CommandPalette.Commands;
+using CodexBar.CommandPalette.Models;
+using CodexBar.CommandPalette.Services;
+using CodexBar.CommandPalette.Ui;
+using Microsoft.CommandPalette.Extensions;
+using Microsoft.CommandPalette.Extensions.Toolkit;
+
+namespace CodexBar.CommandPalette.Pages;
+
+internal sealed partial class CodexBarDockHomePage : ContentPage
+{
+    public const string DockCommandId = "com.finesssee.codexbar.commandpalette.dock";
+
+    private readonly CodexBarStateService _state;
+
+    public CodexBarDockHomePage(CodexBarStateService state)
+    {
+        _state = state;
+        Id = DockCommandId;
+        Name = "CodexBar";
+        Title = "CodexBar";
+        Icon = new IconInfo("\uE950");
+        Commands =
+        [
+            new CommandContextItem(new RefreshSnapshotCommand(_state, RefreshContent))
+            {
+                Title = "Refresh",
+            },
+            new CommandContextItem(new CodexBarListPage(_state))
+            {
+                Title = "Open CodexBar Home",
+            },
+            new CommandContextItem(new OpenCodexBarSettingsCommand())
+            {
+                Title = "Open CodexBar Settings",
+            },
+        ];
+    }
+
+    public override IContent[] GetContent()
+    {
+        var snapshot = _state.RefreshBlocking();
+        var providers = snapshot.Providers
+            .OrderByDescending(provider => provider.Primary?.UsedPercent ?? -1)
+            .ThenByDescending(provider => provider.UsedPercent)
+            .ThenBy(provider => provider.DisplayName, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        var body = BuildBody(snapshot, providers);
+        Details = null;
+
+        return [new MarkdownContent(body)];
+    }
+
+    public void RefreshContent()
+    {
+        RaiseItemsChanged(1);
+    }
+
+    private string BuildBody(CmdPalSnapshot snapshot, IReadOnlyCollection<ProviderSnapshot> providers)
+    {
+        if (!string.IsNullOrWhiteSpace(_state.LastError))
+        {
+            return $"### CodexBar\n\nRefresh failed: `{_state.LastError}`";
+        }
+
+        if (providers.Count == 0)
+        {
+            return "### CodexBar\n\nNo enabled providers.\n\nUse **Open CodexBar Settings** to configure providers.";
+        }
+
+        var primaryProvider = providers.First();
+        var fiveHour = primaryProvider.Primary;
+        var weekly = primaryProvider.Secondary;
+        var reset = fiveHour?.ResetDescription ?? "unknown";
+        var source = primaryProvider.Source ?? "unknown";
+        var lines = new List<string>
+        {
+            "## CodexBar",
+            string.Empty,
+            $"**{primaryProvider.DisplayName}**  5h `{PercentText(fiveHour)}`   Weekly `{PercentText(weekly)}`",
+            string.Empty,
+        };
+
+        if (fiveHour is not null)
+        {
+            lines.Add($"`{ProgressBar(fiveHour.UsedPercent)}`");
+            lines.Add($"{fiveHour.RemainingPercent:0}% remaining  -  reset {reset}");
+            lines.Add(string.Empty);
+        }
+
+        lines.Add($"Updated `{FormatTime(snapshot.GeneratedAt)}`  -  source `{source}`");
+        lines.Add(string.Empty);
+
+        foreach (var provider in providers.Take(3))
+        {
+            lines.Add(ProviderCard(provider));
+            lines.Add(string.Empty);
+        }
+
+        return string.Join(Environment.NewLine, lines).TrimEnd();
+    }
+
+    private static string ProviderCard(ProviderSnapshot provider)
+    {
+        var fiveHour = PercentText(provider.Primary);
+        var weekly = PercentText(provider.Secondary);
+        var reset = provider.Primary?.ResetDescription ?? "-";
+        var status = provider.HasError ? "error" : "ok";
+
+        return string.Join(Environment.NewLine, [
+            $"### {provider.DisplayName}",
+            $"5h `{fiveHour}`   Weekly `{weekly}`   Reset `{reset}`   `{status}`",
+        ]);
+    }
+
+    private static string PercentText(RateWindowSnapshot? window)
+    {
+        return window is null ? "-" : $"{window.UsedPercent:0}%";
+    }
+
+    private static string ProgressBar(double usedPercent)
+    {
+        var clamped = Math.Clamp(usedPercent, 0, 100);
+        var filled = (int)Math.Round(clamped / 5, MidpointRounding.AwayFromZero);
+        filled = Math.Clamp(filled, 0, 20);
+        return $"[{new string('=', filled)}{new string('-', 20 - filled)}] {clamped:0}%";
+    }
+
+    private static string FormatTime(DateTimeOffset? value)
+    {
+        return value?.ToString("HH:mm:ss") ?? "unknown";
+    }
+}

--- a/apps/command-palette-extension/CodexBar.CommandPalette/Pages/CodexBarListPage.cs
+++ b/apps/command-palette-extension/CodexBar.CommandPalette/Pages/CodexBarListPage.cs
@@ -1,0 +1,85 @@
+using CodexBar.CommandPalette.Commands;
+using CodexBar.CommandPalette.Services;
+using CodexBar.CommandPalette.Ui;
+using Microsoft.CommandPalette.Extensions;
+using Microsoft.CommandPalette.Extensions.Toolkit;
+
+namespace CodexBar.CommandPalette.Pages;
+
+internal sealed partial class CodexBarListPage : ListPage
+{
+    private readonly CodexBarStateService _state;
+
+    public CodexBarListPage(CodexBarStateService state)
+    {
+        _state = state;
+        Name = "CodexBar";
+        Icon = new IconInfo("\uE950");
+    }
+
+    public override IListItem[] GetItems()
+    {
+        var snapshot = _state.RefreshBlocking();
+        var items = snapshot.Providers
+            .OrderByDescending(provider => provider.UsedPercent)
+            .Select(provider => new ListItem(new ProviderDetailPage(_state, provider.ProviderId))
+            {
+                Title = ProviderText.Title(provider),
+                Subtitle = ProviderText.Subtitle(provider),
+                Icon = provider.HasError ? new IconInfo("\uE783") : new IconInfo("\uE9D9"),
+                MoreCommands = ProviderCommands(provider),
+            })
+            .Cast<IListItem>()
+            .ToList();
+
+        if (items.Count == 0)
+        {
+            items.Add(new ListItem(new NoOpCommand())
+            {
+                Title = "No enabled providers",
+                Subtitle = string.IsNullOrWhiteSpace(_state.LastError)
+                    ? "Enable providers in CodexBar settings."
+                    : _state.LastError,
+                Icon = new IconInfo("\uE946"),
+            });
+        }
+
+        items.Add(new ListItem(new RefreshSnapshotCommand(_state))
+        {
+            Title = "Refresh",
+            Subtitle = "Reload the read-only snapshot from codexbar.exe",
+            Icon = new IconInfo("\uE72C"),
+        });
+        items.Add(new ListItem(new OpenCodexBarSettingsCommand())
+        {
+            Title = "Open CodexBar Settings",
+            Subtitle = "Launch the desktop app for provider credentials and preferences",
+            Icon = new IconInfo("\uE713"),
+        });
+
+        return items.ToArray();
+    }
+
+    private static IContextItem[] ProviderCommands(Models.ProviderSnapshot provider)
+    {
+        var commands = new List<IContextItem>();
+
+        if (!string.IsNullOrWhiteSpace(provider.DashboardUrl))
+        {
+            commands.Add(new CommandContextItem(new OpenUrlCommand(provider.DashboardUrl))
+            {
+                Title = "Open Dashboard",
+            });
+        }
+
+        if (!string.IsNullOrWhiteSpace(provider.StatusPageUrl))
+        {
+            commands.Add(new CommandContextItem(new OpenUrlCommand(provider.StatusPageUrl))
+            {
+                Title = "Open Status Page",
+            });
+        }
+
+        return commands.ToArray();
+    }
+}

--- a/apps/command-palette-extension/CodexBar.CommandPalette/Pages/ProviderDetailPage.cs
+++ b/apps/command-palette-extension/CodexBar.CommandPalette/Pages/ProviderDetailPage.cs
@@ -1,0 +1,93 @@
+using CodexBar.CommandPalette.Models;
+using CodexBar.CommandPalette.Services;
+using CodexBar.CommandPalette.Ui;
+using Microsoft.CommandPalette.Extensions;
+using Microsoft.CommandPalette.Extensions.Toolkit;
+
+namespace CodexBar.CommandPalette.Pages;
+
+internal sealed partial class ProviderDetailPage : ListPage
+{
+    private readonly CodexBarStateService _state;
+    private readonly string _providerId;
+
+    public ProviderDetailPage(CodexBarStateService state, string providerId)
+    {
+        _state = state;
+        _providerId = providerId;
+        Name = "Provider";
+        Icon = new IconInfo("\uE9D9");
+    }
+
+    public override IListItem[] GetItems()
+    {
+        var provider = _state.FindProvider(_providerId)
+            ?? _state.RefreshBlocking().Providers.FirstOrDefault(item =>
+                string.Equals(item.ProviderId, _providerId, StringComparison.OrdinalIgnoreCase));
+
+        if (provider is null)
+        {
+            return
+            [
+                new ListItem(new NoOpCommand())
+                {
+                    Title = "Provider unavailable",
+                    Subtitle = _providerId,
+                    Icon = new IconInfo("\uE783"),
+                },
+            ];
+        }
+
+        Title = provider.DisplayName;
+        var items = new List<IListItem>
+        {
+            InfoItem(provider.DisplayName, ProviderText.Title(provider)),
+            InfoItem(provider.PrimaryLabel ?? "Session", ProviderText.WindowLine(provider.PrimaryLabel ?? "Session", provider.Primary)),
+            InfoItem(provider.SecondaryLabel ?? "Weekly", ProviderText.WindowLine(provider.SecondaryLabel ?? "Weekly", provider.Secondary)),
+            InfoItem("Source", provider.Source ?? "Unavailable"),
+            InfoItem("Updated", provider.UpdatedAt?.ToString("yyyy-MM-dd HH:mm:ss zzz") ?? "Unknown"),
+        };
+
+        if (!string.IsNullOrWhiteSpace(provider.Error))
+        {
+            items.Add(InfoItem("Error", provider.Error, "\uE783"));
+        }
+
+        AddLinkItems(provider, items);
+
+        return items.ToArray();
+    }
+
+    private static ListItem InfoItem(string title, string subtitle, string icon = "\uE946")
+    {
+        return new ListItem(new NoOpCommand())
+        {
+            Title = title,
+            Subtitle = subtitle,
+            Icon = new IconInfo(icon),
+        };
+    }
+
+    private static void AddLinkItems(ProviderSnapshot provider, List<IListItem> items)
+    {
+        if (!string.IsNullOrWhiteSpace(provider.DashboardUrl))
+        {
+            items.Add(new ListItem(new OpenUrlCommand(provider.DashboardUrl))
+            {
+                Title = "Open Dashboard",
+                Subtitle = provider.DashboardUrl,
+                Icon = new IconInfo("\uE774"),
+            });
+        }
+
+        if (!string.IsNullOrWhiteSpace(provider.StatusPageUrl))
+        {
+            items.Add(new ListItem(new OpenUrlCommand(provider.StatusPageUrl))
+            {
+                Title = "Open Status Page",
+                Subtitle = provider.StatusPageUrl,
+                Icon = new IconInfo("\uE946"),
+            });
+        }
+    }
+}

--- a/apps/command-palette-extension/CodexBar.CommandPalette/Program.cs
+++ b/apps/command-palette-extension/CodexBar.CommandPalette/Program.cs
@@ -1,0 +1,29 @@
+using Microsoft.CommandPalette.Extensions;
+using Shmuelie.WinRTServer;
+using Shmuelie.WinRTServer.CsWinRT;
+
+namespace CodexBar.CommandPalette;
+
+public static class Program
+{
+    [MTAThread]
+    public static void Main(string[] args)
+    {
+        if (args.Length == 0 || args[0] != "-RegisterProcessAsComServer")
+        {
+            Console.WriteLine("CodexBar Command Palette extension must be launched by Command Palette.");
+            return;
+        }
+
+        ManualResetEvent extensionDisposedEvent = new(false);
+        var server = new ComServer();
+        var extensionInstance = new CodexBarExtension(extensionDisposedEvent);
+
+        server.RegisterClass<CodexBarExtension, IExtension>(() => extensionInstance);
+        server.Start();
+        extensionDisposedEvent.WaitOne();
+        server.Stop();
+        server.UnsafeDispose();
+        extensionDisposedEvent.Dispose();
+    }
+}

--- a/apps/command-palette-extension/CodexBar.CommandPalette/Properties/AssemblyInfo.cs
+++ b/apps/command-palette-extension/CodexBar.CommandPalette/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("CodexBar.CommandPalette.Tests")]

--- a/apps/command-palette-extension/CodexBar.CommandPalette/Services/CodexBarCliClient.cs
+++ b/apps/command-palette-extension/CodexBar.CommandPalette/Services/CodexBarCliClient.cs
@@ -1,0 +1,114 @@
+using System.Diagnostics;
+using System.Text.Json;
+using CodexBar.CommandPalette.Models;
+
+namespace CodexBar.CommandPalette.Services;
+
+public sealed class CodexBarCliClient : ICodexBarCliClient
+{
+    public const string BackendOverrideEnvironmentVariable = "CODEXBAR_BACKEND_EXE";
+    private static readonly TimeSpan CliTimeout = TimeSpan.FromSeconds(30);
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+    };
+
+    private readonly string _backendPath;
+
+    public CodexBarCliClient()
+        : this(ResolveBackendPath())
+    {
+    }
+
+    public CodexBarCliClient(string backendPath)
+    {
+        _backendPath = backendPath;
+    }
+
+    public static string ResolveBackendPath()
+    {
+        var overridePath = Environment.GetEnvironmentVariable(BackendOverrideEnvironmentVariable);
+        if (!string.IsNullOrWhiteSpace(overridePath))
+        {
+            return overridePath;
+        }
+
+        return Path.Combine(AppContext.BaseDirectory, "Backend", "codexbar.exe");
+    }
+
+    public static CmdPalSnapshot ParseSnapshotJson(string json)
+    {
+        var snapshot = JsonSerializer.Deserialize<CmdPalSnapshot>(json, JsonOptions);
+        if (snapshot is null)
+        {
+            throw new InvalidDataException("codexbar returned an empty Command Palette snapshot.");
+        }
+
+        return snapshot;
+    }
+
+    public async Task<CmdPalSnapshot> GetSnapshotAsync(CancellationToken cancellationToken)
+    {
+        if (!File.Exists(_backendPath))
+        {
+            throw new FileNotFoundException(
+                $"CodexBar backend was not found at '{_backendPath}'. Set {BackendOverrideEnvironmentVariable} to a local codexbar.exe while developing.",
+                _backendPath);
+        }
+
+        using var timeout = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        timeout.CancelAfter(CliTimeout);
+
+        using var process = new Process
+        {
+            StartInfo = new ProcessStartInfo
+            {
+                FileName = _backendPath,
+                Arguments = "cmdpal snapshot --json",
+                UseShellExecute = false,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                CreateNoWindow = true,
+            },
+        };
+
+        process.Start();
+        var stdoutTask = process.StandardOutput.ReadToEndAsync(timeout.Token);
+        var stderrTask = process.StandardError.ReadToEndAsync(timeout.Token);
+
+        try
+        {
+            await process.WaitForExitAsync(timeout.Token).ConfigureAwait(false);
+            var stdout = await stdoutTask.ConfigureAwait(false);
+            var stderr = await stderrTask.ConfigureAwait(false);
+
+            if (process.ExitCode != 0)
+            {
+                var message = string.IsNullOrWhiteSpace(stderr) ? stdout : stderr;
+                throw new InvalidOperationException($"codexbar exited with code {process.ExitCode}: {message.Trim()}");
+            }
+
+            return ParseSnapshotJson(stdout);
+        }
+        catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+        {
+            TryKill(process);
+            throw new TimeoutException($"codexbar cmdpal snapshot exceeded {CliTimeout.TotalSeconds:0}s.");
+        }
+    }
+
+    private static void TryKill(Process process)
+    {
+        try
+        {
+            if (!process.HasExited)
+            {
+                process.Kill(entireProcessTree: true);
+            }
+        }
+        catch (InvalidOperationException)
+        {
+        }
+    }
+}

--- a/apps/command-palette-extension/CodexBar.CommandPalette/Services/CodexBarStateService.cs
+++ b/apps/command-palette-extension/CodexBar.CommandPalette/Services/CodexBarStateService.cs
@@ -1,0 +1,68 @@
+using CodexBar.CommandPalette.Models;
+
+namespace CodexBar.CommandPalette.Services;
+
+public sealed class CodexBarStateService
+{
+    private static readonly CmdPalSnapshot EmptySnapshot = new()
+    {
+        ContractVersion = "cmdpal.snapshot.v1",
+        GeneratedAt = DateTimeOffset.MinValue,
+        RefreshIntervalSecs = 300,
+        Providers = [],
+    };
+
+    private readonly ICodexBarCliClient _client;
+    private readonly SemaphoreSlim _refreshGate = new(1, 1);
+
+    private CmdPalSnapshot _cachedSnapshot = EmptySnapshot;
+
+    public CodexBarStateService(ICodexBarCliClient client)
+    {
+        _client = client;
+    }
+
+    public string? LastError { get; private set; }
+
+    public bool IsRefreshing { get; private set; }
+
+    public CmdPalSnapshot CachedSnapshot => _cachedSnapshot;
+
+    public async Task<CmdPalSnapshot> RefreshAsync(CancellationToken cancellationToken = default)
+    {
+        if (!await _refreshGate.WaitAsync(0, cancellationToken).ConfigureAwait(false))
+        {
+            return _cachedSnapshot;
+        }
+
+        try
+        {
+            IsRefreshing = true;
+            var snapshot = await _client.GetSnapshotAsync(cancellationToken).ConfigureAwait(false);
+            _cachedSnapshot = snapshot;
+            LastError = null;
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException || !cancellationToken.IsCancellationRequested)
+        {
+            LastError = ex.Message;
+        }
+        finally
+        {
+            IsRefreshing = false;
+            _refreshGate.Release();
+        }
+
+        return _cachedSnapshot;
+    }
+
+    public CmdPalSnapshot RefreshBlocking()
+    {
+        return RefreshAsync().GetAwaiter().GetResult();
+    }
+
+    public ProviderSnapshot? FindProvider(string providerId)
+    {
+        return _cachedSnapshot.Providers.FirstOrDefault(
+            provider => string.Equals(provider.ProviderId, providerId, StringComparison.OrdinalIgnoreCase));
+    }
+}

--- a/apps/command-palette-extension/CodexBar.CommandPalette/Services/ICodexBarCliClient.cs
+++ b/apps/command-palette-extension/CodexBar.CommandPalette/Services/ICodexBarCliClient.cs
@@ -1,0 +1,8 @@
+using CodexBar.CommandPalette.Models;
+
+namespace CodexBar.CommandPalette.Services;
+
+public interface ICodexBarCliClient
+{
+    Task<CmdPalSnapshot> GetSnapshotAsync(CancellationToken cancellationToken);
+}

--- a/apps/command-palette-extension/CodexBar.CommandPalette/Ui/ProviderText.cs
+++ b/apps/command-palette-extension/CodexBar.CommandPalette/Ui/ProviderText.cs
@@ -1,0 +1,77 @@
+using CodexBar.CommandPalette.Models;
+
+namespace CodexBar.CommandPalette.Ui;
+
+internal static class ProviderText
+{
+    public static string Title(ProviderSnapshot provider)
+    {
+        return provider.HasError
+            ? $"{provider.DisplayName} error"
+            : $"{provider.DisplayName} {provider.UsedPercent:0}%";
+    }
+
+    public static string FiveHourTitle(ProviderSnapshot provider)
+    {
+        if (provider.HasError)
+        {
+            return $"{provider.DisplayName} error";
+        }
+
+        return provider.Primary is null
+            ? $"{provider.DisplayName} --"
+            : $"{provider.DisplayName} 5h {provider.Primary.UsedPercent:0}%";
+    }
+
+    public static string FiveHourSubtitle(ProviderSnapshot provider)
+    {
+        if (!string.IsNullOrWhiteSpace(provider.Error))
+        {
+            return Shorten(provider.Error, 90);
+        }
+
+        var reset = provider.Primary?.ResetDescription;
+        if (!string.IsNullOrWhiteSpace(reset))
+        {
+            return $"5h reset {reset}";
+        }
+
+        return string.IsNullOrWhiteSpace(provider.Source)
+            ? "No 5h reset status"
+            : provider.Source;
+    }
+
+    public static string Subtitle(ProviderSnapshot provider)
+    {
+        if (!string.IsNullOrWhiteSpace(provider.Error))
+        {
+            return Shorten(provider.Error, 90);
+        }
+
+        var reset = provider.Primary?.ResetDescription
+            ?? provider.Secondary?.ResetDescription
+            ?? provider.Source;
+
+        return string.IsNullOrWhiteSpace(reset)
+            ? "No reset status"
+            : reset;
+    }
+
+    public static string WindowLine(string label, RateWindowSnapshot? window)
+    {
+        if (window is null)
+        {
+            return $"{label}: unavailable";
+        }
+
+        var reset = string.IsNullOrWhiteSpace(window.ResetDescription)
+            ? "reset unknown"
+            : $"reset {window.ResetDescription}";
+        return $"{label}: {window.UsedPercent:0}% used, {window.RemainingPercent:0}% remaining, {reset}";
+    }
+
+    private static string Shorten(string value, int maxLength)
+    {
+        return value.Length <= maxLength ? value : value[..(maxLength - 1)] + "...";
+    }
+}

--- a/apps/command-palette-extension/CodexBar.CommandPalette/app.manifest
+++ b/apps/command-palette-extension/CodexBar.CommandPalette/app.manifest
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
+  <assemblyIdentity version="1.0.0.0" name="CodexBar.CommandPalette.app"/>
+
+  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+    <application>
+      <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}" />
+    </application>
+  </compatibility>
+
+  <application xmlns="urn:schemas-microsoft-com:asm.v3">
+    <windowsSettings>
+      <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true/PM</dpiAware>
+      <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2</dpiAwareness>
+    </windowsSettings>
+  </application>
+</assembly>

--- a/rust/src/cli/cmdpal.rs
+++ b/rust/src/cli/cmdpal.rs
@@ -1,0 +1,378 @@
+//! Command Palette integration snapshot endpoint.
+//!
+//! This module is intentionally read-only. It exposes a small, stable JSON
+//! contract for external shells such as PowerToys Command Palette without
+//! leaking account identifiers or credential material.
+
+use std::collections::{HashMap, HashSet};
+
+use anyhow::Context;
+use chrono::Utc;
+use clap::{Args, Subcommand};
+use serde::Serialize;
+
+use crate::core::{
+    FetchContext, ProviderAccountData, ProviderFetchResult, ProviderId, ProviderMetadata,
+    RateWindow, SourceMode, TokenAccountOverride, TokenAccountStore, instantiate_provider,
+};
+use crate::settings::{ApiKeys, ManualCookies, Settings};
+
+const CONTRACT_VERSION: &str = "cmdpal.snapshot.v1";
+const PROVIDER_FETCH_TIMEOUT_SECS: u64 = 30;
+
+#[derive(Args, Debug)]
+pub struct CmdPalArgs {
+    #[command(subcommand)]
+    pub command: CmdPalCommand,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum CmdPalCommand {
+    /// Emit a safe, read-only JSON snapshot for Command Palette.
+    Snapshot(SnapshotArgs),
+}
+
+#[derive(Args, Debug)]
+pub struct SnapshotArgs {
+    /// Emit JSON. Kept explicit so the CLI contract is self-documenting.
+    #[arg(long)]
+    pub json: bool,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CmdPalSnapshotPayload {
+    pub contract_version: &'static str,
+    pub generated_at: String,
+    pub refresh_interval_secs: u64,
+    pub providers: Vec<CmdPalProviderSnapshot>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CmdPalProviderSnapshot {
+    pub provider_id: String,
+    pub display_name: String,
+    pub primary_label: Option<String>,
+    pub primary: Option<CmdPalRateWindow>,
+    pub secondary_label: Option<String>,
+    pub secondary: Option<CmdPalRateWindow>,
+    pub source: Option<String>,
+    pub updated_at: Option<String>,
+    pub error: Option<String>,
+    pub dashboard_url: Option<String>,
+    pub status_page_url: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CmdPalRateWindow {
+    pub used_percent: f64,
+    pub remaining_percent: f64,
+    pub window_minutes: Option<u32>,
+    pub resets_at: Option<String>,
+    pub reset_description: Option<String>,
+    pub is_exhausted: bool,
+}
+
+impl CmdPalRateWindow {
+    fn from_rate_window(window: &RateWindow) -> Self {
+        Self {
+            used_percent: window.used_percent,
+            remaining_percent: window.remaining_percent(),
+            window_minutes: window.window_minutes,
+            resets_at: window.resets_at.map(|dt| dt.to_rfc3339()),
+            reset_description: window.reset_description.clone(),
+            is_exhausted: window.is_exhausted(),
+        }
+    }
+}
+
+impl CmdPalProviderSnapshot {
+    fn from_fetch_result(
+        id: ProviderId,
+        metadata: &ProviderMetadata,
+        result: &ProviderFetchResult,
+    ) -> Self {
+        let usage = &result.usage;
+
+        Self {
+            provider_id: id.cli_name().to_string(),
+            display_name: id.display_name().to_string(),
+            primary_label: Some(metadata.session_label.to_string()),
+            primary: Some(CmdPalRateWindow::from_rate_window(&usage.primary)),
+            secondary_label: usage
+                .secondary
+                .as_ref()
+                .map(|_| metadata.weekly_label.to_string()),
+            secondary: usage
+                .secondary
+                .as_ref()
+                .map(CmdPalRateWindow::from_rate_window),
+            source: Some(result.source_label.clone()),
+            updated_at: Some(usage.updated_at.to_rfc3339()),
+            error: None,
+            dashboard_url: metadata.dashboard_url.map(ToString::to_string),
+            status_page_url: metadata.status_page_url.map(ToString::to_string),
+        }
+    }
+
+    fn from_error(id: ProviderId, metadata: &ProviderMetadata, error: String) -> Self {
+        Self {
+            provider_id: id.cli_name().to_string(),
+            display_name: id.display_name().to_string(),
+            primary_label: Some(metadata.session_label.to_string()),
+            primary: None,
+            secondary_label: None,
+            secondary: None,
+            source: None,
+            updated_at: Some(Utc::now().to_rfc3339()),
+            error: Some(error),
+            dashboard_url: metadata.dashboard_url.map(ToString::to_string),
+            status_page_url: metadata.status_page_url.map(ToString::to_string),
+        }
+    }
+}
+
+pub async fn run(args: CmdPalArgs) -> anyhow::Result<()> {
+    match args.command {
+        CmdPalCommand::Snapshot(snapshot_args) => snapshot(snapshot_args).await,
+    }
+}
+
+async fn snapshot(_args: SnapshotArgs) -> anyhow::Result<()> {
+    let settings = Settings::load();
+    let payload = build_snapshot_payload(settings).await;
+    let json =
+        serde_json::to_string_pretty(&payload).context("serialize Command Palette snapshot")?;
+    println!("{json}");
+    Ok(())
+}
+
+async fn build_snapshot_payload(settings: Settings) -> CmdPalSnapshotPayload {
+    let enabled_ids = ordered_enabled_provider_ids(&settings);
+    let manual_cookies = ManualCookies::load();
+    let api_keys = ApiKeys::load();
+    let token_accounts = TokenAccountStore::new().load().unwrap_or_else(|e| {
+        tracing::warn!("failed to load token accounts for Command Palette snapshot: {e}");
+        HashMap::new()
+    });
+
+    let mut handles = Vec::with_capacity(enabled_ids.len());
+
+    for id in enabled_ids {
+        let ctx = build_fetch_context(id, &settings, &manual_cookies, &api_keys, &token_accounts);
+        handles.push(tokio::spawn(async move {
+            let provider = instantiate_provider(id);
+            let metadata = provider.metadata().clone();
+            match tokio::time::timeout(
+                std::time::Duration::from_secs(PROVIDER_FETCH_TIMEOUT_SECS),
+                provider.fetch_usage(&ctx),
+            )
+            .await
+            {
+                Ok(Ok(result)) => CmdPalProviderSnapshot::from_fetch_result(id, &metadata, &result),
+                Ok(Err(e)) => CmdPalProviderSnapshot::from_error(
+                    id,
+                    &metadata,
+                    crate::logging::safe_error_message(e),
+                ),
+                Err(_) => CmdPalProviderSnapshot::from_error(
+                    id,
+                    &metadata,
+                    format!("Timeout after {PROVIDER_FETCH_TIMEOUT_SECS}s"),
+                ),
+            }
+        }));
+    }
+
+    let mut providers = Vec::with_capacity(handles.len());
+    for handle in handles {
+        if let Ok(provider) = handle.await {
+            providers.push(provider);
+        }
+    }
+
+    CmdPalSnapshotPayload {
+        contract_version: CONTRACT_VERSION,
+        generated_at: Utc::now().to_rfc3339(),
+        refresh_interval_secs: settings.refresh_interval_secs,
+        providers,
+    }
+}
+
+fn ordered_enabled_provider_ids(settings: &Settings) -> Vec<ProviderId> {
+    let enabled: HashSet<ProviderId> = settings
+        .enabled_providers
+        .iter()
+        .filter_map(|name| ProviderId::from_cli_name(name))
+        .collect();
+    if enabled.is_empty() {
+        return Vec::new();
+    }
+
+    let mut ordered = Vec::with_capacity(enabled.len());
+    for name in &settings.provider_order {
+        if let Some(id) = ProviderId::from_cli_name(name)
+            && enabled.contains(&id)
+            && !ordered.contains(&id)
+        {
+            ordered.push(id);
+        }
+    }
+
+    for &id in ProviderId::all() {
+        if enabled.contains(&id) && !ordered.contains(&id) {
+            ordered.push(id);
+        }
+    }
+
+    ordered
+}
+
+fn build_fetch_context(
+    id: ProviderId,
+    settings: &Settings,
+    cookies: &ManualCookies,
+    api_keys: &ApiKeys,
+    token_accounts: &HashMap<ProviderId, ProviderAccountData>,
+) -> FetchContext {
+    let cookie_source = settings.cookie_source(id);
+    let stored_cookie = cookies.get(id.cli_name()).map(ToString::to_string);
+    let token_override = token_accounts
+        .get(&id)
+        .and_then(|data| data.active_account())
+        .cloned()
+        .map(|account| TokenAccountOverride::from_account(id, account));
+    let active_token_cookie = token_override
+        .as_ref()
+        .and_then(|override_data| override_data.cookie_header.clone());
+    let active_token_env = token_override
+        .as_ref()
+        .and_then(|override_data| override_data.env_override.as_ref());
+    let active_token_api_key = active_token_env.and_then(|env| env.values().next().cloned());
+    let usage_source = SourceMode::parse(settings.usage_source(id)).unwrap_or_default();
+
+    let (source_mode, cookie_header) = if id.cookie_domain().is_none() {
+        let source_mode = if active_token_env.is_some() {
+            SourceMode::OAuth
+        } else {
+            usage_source
+        };
+        (source_mode, None)
+    } else {
+        match cookie_source {
+            _ if active_token_env.is_some() => (SourceMode::OAuth, None),
+            "off" => (SourceMode::Cli, None),
+            "manual" => {
+                let cookie_header = active_token_cookie.or(stored_cookie);
+                let source_mode = if cookie_header.is_some() {
+                    SourceMode::Web
+                } else {
+                    SourceMode::Cli
+                };
+                (source_mode, cookie_header)
+            }
+            "auto" | "browser" | "web" => {
+                let cookie_header = active_token_cookie.or(stored_cookie).or_else(|| {
+                    id.cookie_domain().and_then(|domain| {
+                        crate::browser::cookies::get_cookie_header(domain)
+                            .ok()
+                            .filter(|h| !h.is_empty())
+                    })
+                });
+                (usage_source, cookie_header)
+            }
+            _ => (usage_source, stored_cookie),
+        }
+    };
+
+    let api_key = api_keys
+        .get(id.cli_name())
+        .map(ToString::to_string)
+        .or(active_token_api_key);
+
+    FetchContext {
+        source_mode,
+        include_credits: false,
+        web_timeout: PROVIDER_FETCH_TIMEOUT_SECS,
+        verbose: false,
+        manual_cookie_header: cookie_header,
+        api_key,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use chrono::{TimeZone, Utc};
+
+    use super::*;
+    use crate::core::{ProviderFetchResult, RateWindow, UsageSnapshot};
+
+    #[test]
+    fn ordered_enabled_provider_ids_filters_unknown_and_honors_provider_order() {
+        let mut settings = Settings::default();
+        settings.enabled_providers = [
+            "cursor".to_string(),
+            "claude".to_string(),
+            "unknown".to_string(),
+            "codex".to_string(),
+        ]
+        .into_iter()
+        .collect();
+        settings.provider_order = vec![
+            "cursor".to_string(),
+            "missing".to_string(),
+            "claude".to_string(),
+            "cursor".to_string(),
+        ];
+
+        assert_eq!(
+            ordered_enabled_provider_ids(&settings),
+            vec![ProviderId::Cursor, ProviderId::Claude, ProviderId::Codex]
+        );
+    }
+
+    #[test]
+    fn rate_window_snapshot_preserves_reset_fields() {
+        let resets_at = Utc.with_ymd_and_hms(2026, 5, 18, 12, 0, 0).unwrap();
+        let window =
+            RateWindow::with_details(72.4, Some(300), Some(resets_at), Some("2h 10m".to_string()));
+
+        let snapshot = CmdPalRateWindow::from_rate_window(&window);
+
+        assert_eq!(snapshot.used_percent, 72.4);
+        assert!((snapshot.remaining_percent - 27.6).abs() < 1e-9);
+        assert_eq!(snapshot.window_minutes, Some(300));
+        assert_eq!(
+            snapshot.resets_at.as_deref(),
+            Some("2026-05-18T12:00:00+00:00")
+        );
+        assert_eq!(snapshot.reset_description.as_deref(), Some("2h 10m"));
+        assert!(!snapshot.is_exhausted);
+    }
+
+    #[test]
+    fn provider_snapshot_json_excludes_personal_identity_fields() {
+        let provider = instantiate_provider(ProviderId::Codex);
+        let metadata = provider.metadata().clone();
+        let usage = UsageSnapshot::new(RateWindow::new(41.0))
+            .with_email("person@example.com")
+            .with_organization("Example Org")
+            .with_login_method("Team");
+        let result = ProviderFetchResult::new(usage, "oauth");
+
+        let snapshot =
+            CmdPalProviderSnapshot::from_fetch_result(ProviderId::Codex, &metadata, &result);
+        let json = serde_json::to_string(&snapshot).unwrap();
+
+        assert!(!json.contains("person@example.com"));
+        assert!(!json.contains("Example Org"));
+        assert!(!json.contains("account"));
+        assert!(!json.contains("organization"));
+        assert!(!json.contains("email"));
+        assert!(!json.contains("token"));
+        assert!(!json.contains("apiKey"));
+        assert!(!json.contains("cookie"));
+    }
+}

--- a/rust/src/cli/mod.rs
+++ b/rust/src/cli/mod.rs
@@ -10,6 +10,7 @@
 
 pub mod account;
 pub mod autostart;
+pub mod cmdpal;
 pub mod config;
 pub mod cost;
 pub mod tty_runner;
@@ -112,6 +113,9 @@ pub enum Commands {
 
     /// Configuration utilities
     Config(config::ConfigArgs),
+
+    /// Command Palette integration endpoints
+    Cmdpal(cmdpal::CmdPalArgs),
 }
 
 impl Cli {

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -121,6 +121,15 @@ fn run(log_path: &Path) -> i32 {
                 }
             }
         }),
+        Some(Commands::Cmdpal(args)) => rt.block_on(async {
+            match cli::cmdpal::run(args).await {
+                Ok(()) => exit_codes::SUCCESS,
+                Err(e) => {
+                    eprintln!("Error: {}", e);
+                    categorize_error(&e)
+                }
+            }
+        }),
         None => {
             // The egui menubar shell has been retired; the desktop UI lives in
             // apps/desktop-tauri. The CLI binary now requires an explicit subcommand.


### PR DESCRIPTION
## Summary

Adds a PowerToys Command Palette / Dock extension for CodexBar and a stable read-only backend CLI snapshot endpoint.

## What changed

- Added `codexbar cmdpal snapshot --json` in the Rust backend for safe provider usage snapshots.
- Added a packaged C# Command Palette extension under `apps/command-palette-extension/`.
- Added Dock support with a compact 5h usage flyout and Command Palette provider/list/detail pages.
- Added CLI client caching, timeout/error handling, settings launch fallback, and unit tests.
- Ignored C# build/test output directories.

## Notes

This is not a pure wrapper-only change: the new Windows extension is a wrapper app, but it depends on a small Rust CLI integration point so provider logic remains reused instead of being reimplemented in C#.

## Validation

- `cargo +stable test --manifest-path rust\Cargo.toml cmdpal -- --nocapture`
- `dotnet test apps\command-palette-extension\CodexBar.CommandPalette.Tests\CodexBar.CommandPalette.Tests.csproj -p:Platform=x64`
- Local loose-package registration with PowerToys Command Palette
