### PR TITLE
fix: float bar polish — true transparency, reset-time tooltip, light-bg mode

### DIFF
--- a/apps/desktop-tauri/src-tauri/src/commands/mod.rs
+++ b/apps/desktop-tauri/src-tauri/src/commands/mod.rs
@@ -419,6 +419,7 @@ pub struct SettingsSnapshot {
     float_bar_orientation: String,
     float_bar_click_through: bool,
     float_bar_provider_ids: Vec<String>,
+    float_bar_dark_text: bool,
 }
 
 #[tauri::command]
@@ -493,6 +494,7 @@ impl From<Settings> for SettingsSnapshot {
             float_bar_orientation: settings.float_bar_orientation,
             float_bar_click_through: settings.float_bar_click_through,
             float_bar_provider_ids: settings.float_bar_provider_ids,
+            float_bar_dark_text: settings.float_bar_dark_text,
         }
     }
 }
@@ -940,6 +942,7 @@ pub struct SettingsUpdate {
     pub float_bar_orientation: Option<String>,
     pub float_bar_click_through: Option<bool>,
     pub float_bar_provider_ids: Option<Vec<String>>,
+    pub float_bar_dark_text: Option<bool>,
 }
 
 fn parse_tray_icon_mode(s: &str) -> Option<TrayIconMode> {
@@ -1101,6 +1104,7 @@ pub async fn update_settings(
         orientation: patch.float_bar_orientation,
         click_through: patch.float_bar_click_through,
         provider_ids: patch.float_bar_provider_ids,
+        dark_text: patch.float_bar_dark_text,
     };
     float_bar_patch.apply(&mut settings);
 

--- a/apps/desktop-tauri/src-tauri/src/floatbar/mod.rs
+++ b/apps/desktop-tauri/src-tauri/src/floatbar/mod.rs
@@ -96,6 +96,7 @@ pub struct SettingsPatch {
     pub orientation: Option<String>,
     pub click_through: Option<bool>,
     pub provider_ids: Option<Vec<String>>,
+    pub dark_text: Option<bool>,
 }
 
 impl SettingsPatch {
@@ -105,6 +106,7 @@ impl SettingsPatch {
             && self.orientation.is_none()
             && self.click_through.is_none()
             && self.provider_ids.is_none()
+            && self.dark_text.is_none()
     }
 
     /// Apply this patch to a mutable `Settings`. Values are clamped and
@@ -124,6 +126,9 @@ impl SettingsPatch {
         }
         if let Some(v) = &self.provider_ids {
             settings.float_bar_provider_ids = v.clone();
+        }
+        if let Some(v) = self.dark_text {
+            settings.float_bar_dark_text = v;
         }
     }
 }

--- a/apps/desktop-tauri/src-tauri/src/floatbar/mod.rs
+++ b/apps/desktop-tauri/src-tauri/src/floatbar/mod.rs
@@ -169,17 +169,20 @@ mod tests {
             float_bar_enabled: false,
             float_bar_opacity: 80,
             float_bar_orientation: "horizontal".into(),
+            float_bar_dark_text: false,
             ..Settings::default()
         };
 
         let patch = SettingsPatch {
             enabled: Some(true),
             opacity: Some(45),
+            dark_text: Some(true),
             ..SettingsPatch::default()
         };
         patch.apply(&mut s);
         assert!(s.float_bar_enabled);
         assert_eq!(s.float_bar_opacity, 45);
+        assert!(s.float_bar_dark_text);
         // Orientation untouched by the patch.
         assert_eq!(s.float_bar_orientation, "horizontal");
     }
@@ -205,5 +208,6 @@ mod tests {
         assert_eq!(s.float_bar_enabled, original.float_bar_enabled);
         assert_eq!(s.float_bar_opacity, original.float_bar_opacity);
         assert_eq!(s.float_bar_orientation, original.float_bar_orientation);
+        assert_eq!(s.float_bar_dark_text, original.float_bar_dark_text);
     }
 }

--- a/apps/desktop-tauri/src-tauri/src/floatbar/window.rs
+++ b/apps/desktop-tauri/src-tauri/src/floatbar/window.rs
@@ -65,6 +65,7 @@ pub fn show(
         .resizable(false)
         .always_on_top(true)
         .skip_taskbar(true)
+        .transparent(true)
         .background_color(tauri::utils::config::Color(0, 0, 0, 0))
         .visible(false)
         .build()

--- a/apps/desktop-tauri/src-tauri/src/floatbar/window.rs
+++ b/apps/desktop-tauri/src-tauri/src/floatbar/window.rs
@@ -65,7 +65,6 @@ pub fn show(
         .resizable(false)
         .always_on_top(true)
         .skip_taskbar(true)
-        .transparent(true)
         .background_color(tauri::utils::config::Color(0, 0, 0, 0))
         .visible(false)
         .build()

--- a/apps/desktop-tauri/src/floatbar/FloatBar.css
+++ b/apps/desktop-tauri/src/floatbar/FloatBar.css
@@ -108,7 +108,7 @@ body.floatbar-window #root {
 }
 
 /* ── Light-background mode ─────────────────────────────────────────────
- * Inverts the palette: dark glass + dark text for legibility over a
+ * Inverts the palette: light glass + dark text for legibility over a
  * bright desktop. Brand-colored borders still win via --brand.
  */
 .floatbar--light-bg {

--- a/apps/desktop-tauri/src/floatbar/FloatBar.css
+++ b/apps/desktop-tauri/src/floatbar/FloatBar.css
@@ -39,28 +39,34 @@ body.floatbar-window #root {
   align-items: center;
   gap: 3px;
 }
-/* 2-row dot grip — classic drag affordance. */
+/* 2-row dot grip — classic drag affordance. Sits in its own translucent
+ * pill so the user has a clear target to grab; everything else around it
+ * is fully transparent. */
 .floatbar__handle {
-  width: 6px;
-  height: 14px;
+  width: 10px;
+  height: 16px;
   flex-shrink: 0;
   cursor: grab;
+  border-radius: 999px;
+  background-color: rgba(255, 255, 255, 0.10);
+  backdrop-filter: blur(14px) saturate(140%);
+  -webkit-backdrop-filter: blur(14px) saturate(140%);
   background-image:
-    radial-gradient(circle, rgba(255, 255, 255, 0.55) 1px, transparent 1.5px);
+    radial-gradient(circle, rgba(255, 255, 255, 0.7) 1px, transparent 1.5px);
   background-size: 3px 4px;
-  background-position: 0 1px;
+  background-position: center;
   background-repeat: repeat;
-  opacity: 0.7;
-  transition: opacity 120ms ease;
+  opacity: 0.85;
+  transition: opacity 120ms ease, background-color 120ms ease;
 }
 .floatbar__handle:hover {
   opacity: 1;
+  background-color: rgba(255, 255, 255, 0.16);
 }
 .floatbar--vertical .floatbar__handle {
-  width: 14px;
-  height: 6px;
+  width: 16px;
+  height: 10px;
   background-size: 4px 3px;
-  background-position: 1px 0;
 }
 .floatbar__pill {
   display: inline-flex;
@@ -69,10 +75,11 @@ body.floatbar-window #root {
   padding: 1px 5px;
   height: 16px;
   border-radius: 999px;
-  background: rgba(18, 18, 20, 0.55);
-  backdrop-filter: blur(8px);
-  -webkit-backdrop-filter: blur(8px);
-  border: 1px solid var(--brand, rgba(255, 255, 255, 0.25));
+  background: rgba(255, 255, 255, 0.08);
+  backdrop-filter: blur(14px) saturate(140%);
+  -webkit-backdrop-filter: blur(14px) saturate(140%);
+  border: 1px solid var(--brand, rgba(255, 255, 255, 0.22));
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.25);
   white-space: nowrap;
 }
 .floatbar__pill--warn {
@@ -93,9 +100,39 @@ body.floatbar-window #root {
   height: 16px;
   padding: 0 8px;
   border-radius: 999px;
-  background: rgba(18, 18, 20, 0.55);
-  backdrop-filter: blur(8px);
-  -webkit-backdrop-filter: blur(8px);
+  background: rgba(255, 255, 255, 0.08);
+  backdrop-filter: blur(14px) saturate(140%);
+  -webkit-backdrop-filter: blur(14px) saturate(140%);
   opacity: 0.75;
   font-weight: 500;
+}
+
+/* ── Light-background mode ─────────────────────────────────────────────
+ * Inverts the palette: dark glass + dark text for legibility over a
+ * bright desktop. Brand-colored borders still win via --brand.
+ */
+.floatbar--light-bg {
+  color: rgba(20, 22, 26, 0.95);
+}
+.floatbar--light-bg .floatbar__pill,
+.floatbar--light-bg .floatbar__empty {
+  background: rgba(255, 255, 255, 0.55);
+  border-color: var(--brand, rgba(20, 22, 26, 0.25));
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.12);
+}
+.floatbar--light-bg .floatbar__pill--warn {
+  border-color: #b45309;
+  color: #92400e;
+}
+.floatbar--light-bg .floatbar__pill--crit {
+  border-color: #b91c1c;
+  color: #991b1b;
+}
+.floatbar--light-bg .floatbar__handle {
+  background-color: rgba(20, 22, 26, 0.10);
+  background-image:
+    radial-gradient(circle, rgba(20, 22, 26, 0.75) 1px, transparent 1.5px);
+}
+.floatbar--light-bg .floatbar__handle:hover {
+  background-color: rgba(20, 22, 26, 0.18);
 }

--- a/apps/desktop-tauri/src/floatbar/FloatBar.test.tsx
+++ b/apps/desktop-tauri/src/floatbar/FloatBar.test.tsx
@@ -7,6 +7,8 @@ const tauriMocks = vi.hoisted(() => ({
   refreshProvidersIfStale: vi.fn(),
   getSettingsSnapshot: vi.fn(),
   updateSettings: vi.fn(),
+  getLocaleStrings: vi.fn(),
+  setUiLanguage: vi.fn(),
 }));
 
 const eventMocks = vi.hoisted(() => ({
@@ -24,16 +26,25 @@ vi.mock("@tauri-apps/api/event", () => eventMocks);
 vi.mock("@tauri-apps/api/window", () => windowMocks);
 
 import FloatBar from "./FloatBar";
+import { LocaleProvider } from "../i18n/LocaleProvider";
+import { buildBundle } from "../test/localeHarness";
 import type { BootstrapState, ProviderUsageSnapshot, SettingsSnapshot } from "../types/bridge";
 
-function rateWindow(used: number, exhausted = false) {
+function rateWindow(
+  used: number,
+  opts: {
+    exhausted?: boolean;
+    resetsAt?: string | null;
+    resetDescription?: string | null;
+  } = {},
+) {
   return {
     usedPercent: used,
     remainingPercent: 100 - used,
     windowMinutes: null,
-    resetsAt: null,
-    resetDescription: null,
-    isExhausted: exhausted,
+    resetsAt: opts.resetsAt ?? null,
+    resetDescription: opts.resetDescription ?? null,
+    isExhausted: opts.exhausted ?? false,
     reservePercent: null,
     reserveDescription: null,
   };
@@ -43,12 +54,17 @@ function snapshot(
   id: string,
   display: string,
   used: number,
-  opts: { exhausted?: boolean; error?: string | null } = {},
+  opts: {
+    exhausted?: boolean;
+    error?: string | null;
+    resetsAt?: string | null;
+    resetDescription?: string | null;
+  } = {},
 ): ProviderUsageSnapshot {
   return {
     providerId: id,
     displayName: display,
-    primary: rateWindow(used, opts.exhausted),
+    primary: rateWindow(used, opts),
     secondary: null,
     modelSpecific: null,
     tertiary: null,
@@ -119,11 +135,26 @@ function bootstrap(settingsOverrides: Partial<SettingsSnapshot> = {}): Bootstrap
   };
 }
 
+function renderFloatBar(state: BootstrapState) {
+  return render(
+    <LocaleProvider>
+      <FloatBar state={state} />
+    </LocaleProvider>,
+  );
+}
+
 describe("FloatBar", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     tauriMocks.refreshProviders.mockResolvedValue(undefined);
     tauriMocks.refreshProvidersIfStale.mockResolvedValue(undefined);
+    tauriMocks.getLocaleStrings.mockResolvedValue(
+      buildBundle({
+        ResetsInHoursMinutes: "Resets in {}h {}m",
+        ResetsInDaysHours: "Resets in {}d {}h",
+        TrayResetsDueNow: "Resetting",
+      }),
+    );
     eventMocks.listen.mockResolvedValue(() => {});
   });
 
@@ -134,7 +165,7 @@ describe("FloatBar", () => {
     ]);
     tauriMocks.getSettingsSnapshot.mockResolvedValue(settings());
 
-    const { container } = render(<FloatBar state={bootstrap()} />);
+    const { container } = renderFloatBar(bootstrap());
     await waitFor(() => {
       const pills = container.querySelectorAll(".floatbar__pill");
       expect(pills.length).toBe(2);
@@ -155,7 +186,7 @@ describe("FloatBar", () => {
     tauriMocks.getCachedProviders.mockResolvedValue([snapshot("claude", "Claude", 75)]);
     tauriMocks.getSettingsSnapshot.mockResolvedValue(settings());
 
-    const { container } = render(<FloatBar state={bootstrap()} />);
+    const { container } = renderFloatBar(bootstrap());
     await waitFor(() => {
       expect(container.querySelector(".floatbar__pill--warn")).not.toBeNull();
     });
@@ -167,7 +198,7 @@ describe("FloatBar", () => {
     ]);
     tauriMocks.getSettingsSnapshot.mockResolvedValue(settings());
 
-    const { container } = render(<FloatBar state={bootstrap()} />);
+    const { container } = renderFloatBar(bootstrap());
     await waitFor(() => {
       expect(container.querySelector(".floatbar__pill--crit")).not.toBeNull();
     });
@@ -182,8 +213,8 @@ describe("FloatBar", () => {
       settings({ floatBarProviderIds: ["codex"] }),
     );
 
-    const { container } = render(
-      <FloatBar state={bootstrap({ floatBarProviderIds: ["codex"] })} />,
+    const { container } = renderFloatBar(
+      bootstrap({ floatBarProviderIds: ["codex"] }),
     );
     await waitFor(() => {
       const pills = container.querySelectorAll(".floatbar__pill");
@@ -201,9 +232,7 @@ describe("FloatBar", () => {
       settings({ enabledProviders: [] }),
     );
 
-    const { container } = render(
-      <FloatBar state={bootstrap({ enabledProviders: [] })} />,
-    );
+    const { container } = renderFloatBar(bootstrap({ enabledProviders: [] }));
     await waitFor(() => {
       expect(container.querySelectorAll(".floatbar__pill").length).toBe(0);
       expect(container.querySelector(".floatbar__empty")).not.toBeNull();
@@ -214,9 +243,46 @@ describe("FloatBar", () => {
     tauriMocks.getCachedProviders.mockResolvedValue([]);
     tauriMocks.getSettingsSnapshot.mockResolvedValue(settings());
 
-    const { container } = render(<FloatBar state={bootstrap()} />);
+    const { container } = renderFloatBar(bootstrap());
     await waitFor(() => {
       expect(container.querySelector(".floatbar__empty")).not.toBeNull();
+    });
+  });
+
+  it("applies the light-background class and CSS opacity", async () => {
+    tauriMocks.getCachedProviders.mockResolvedValue([]);
+    tauriMocks.getSettingsSnapshot.mockResolvedValue(
+      settings({ floatBarDarkText: true, floatBarOpacity: 45 }),
+    );
+
+    const { container } = renderFloatBar(
+      bootstrap({ floatBarDarkText: true, floatBarOpacity: 45 }),
+    );
+
+    await waitFor(() => {
+      const bar = container.querySelector<HTMLElement>(".floatbar");
+      expect(bar).not.toBeNull();
+      expect(bar?.classList.contains("floatbar--light-bg")).toBe(true);
+      expect(bar?.style.opacity).toBe("0.45");
+    });
+  });
+
+  it("uses the localized reset formatter in pill tooltips", async () => {
+    const resetsAt = new Date(Date.now() + 3 * 60 * 60_000 + 42 * 60_000).toISOString();
+    tauriMocks.getCachedProviders.mockResolvedValue([
+      snapshot("claude", "Claude", 20, { resetsAt }),
+    ]);
+    tauriMocks.getSettingsSnapshot.mockResolvedValue(settings());
+
+    const { container } = renderFloatBar(bootstrap());
+
+    await waitFor(() => {
+      const title = container
+        .querySelector(".floatbar__pill")
+        ?.getAttribute("title");
+      expect(title).toContain("Claude: 80% remaining");
+      expect(title).toMatch(/Resets in 3h 4[12]m/);
+      expect(title).not.toContain("Resets in due now");
     });
   });
 
@@ -226,7 +292,7 @@ describe("FloatBar", () => {
       tauriMocks.getCachedProviders.mockResolvedValue([]);
       tauriMocks.getSettingsSnapshot.mockResolvedValue(settings());
       // 60s minimum is enforced in FloatBar.tsx; use the floor here.
-      render(<FloatBar state={bootstrap({ refreshIntervalSecs: 60 })} />);
+      renderFloatBar(bootstrap({ refreshIntervalSecs: 60 }));
 
       // Initial tick fires synchronously on mount (+ the useProviders
       // hook's own initial call) — wait for the first to complete.

--- a/apps/desktop-tauri/src/floatbar/FloatBar.test.tsx
+++ b/apps/desktop-tauri/src/floatbar/FloatBar.test.tsx
@@ -103,6 +103,7 @@ function settings(overrides: Partial<SettingsSnapshot> = {}): SettingsSnapshot {
     floatBarOrientation: "horizontal",
     floatBarClickThrough: false,
     floatBarProviderIds: [],
+    floatBarDarkText: false,
     ...overrides,
   };
 }

--- a/apps/desktop-tauri/src/floatbar/FloatBar.tsx
+++ b/apps/desktop-tauri/src/floatbar/FloatBar.tsx
@@ -20,6 +20,21 @@ import "./FloatBar.css";
  * high-usage threshold, red when remaining is below the critical threshold
  * or the provider is exhausted.
  */
+function formatResetIn(resetsAt: string | null): string | null {
+  if (!resetsAt) return null;
+  const target = Date.parse(resetsAt);
+  if (Number.isNaN(target)) return null;
+  const diffMs = target - Date.now();
+  if (diffMs <= 0) return "due now";
+  const totalMinutes = Math.floor(diffMs / 60_000);
+  const days = Math.floor(totalMinutes / 1440);
+  const hours = Math.floor((totalMinutes % 1440) / 60);
+  const minutes = totalMinutes % 60;
+  if (days > 0) return `${days}d ${hours}h`;
+  if (hours > 0) return `${hours}h ${minutes}m`;
+  return `${minutes}m`;
+}
+
 function ProviderPill({
   provider,
   highRemaining,
@@ -37,11 +52,17 @@ function ProviderPill({
 
   const brand = getProviderIcon(provider.providerId).brandColor;
   const label = provider.error ? "—" : `${Math.round(remaining)}%`;
+  const resetIn = formatResetIn(provider.primary.resetsAt);
+  const resetSuffix = resetIn
+    ? `\nResets in ${resetIn}`
+    : provider.primary.resetDescription
+      ? `\nResets ${provider.primary.resetDescription}`
+      : "";
 
   return (
     <div
       className={`floatbar__pill floatbar__pill--${tone}`}
-      title={`${provider.displayName}: ${label} remaining`}
+      title={`${provider.displayName}: ${label} remaining${resetSuffix}`}
       style={{ "--brand": brand } as React.CSSProperties}
     >
       <ProviderIcon providerId={provider.providerId} size={11} />
@@ -129,11 +150,13 @@ export default function FloatBar({ state }: { state: BootstrapState }) {
 
   const highRemaining = 100 - settings.highUsageThreshold;
   const critRemaining = 100 - settings.criticalUsageThreshold;
+  const opacityFraction = Math.max(0.3, Math.min(1, settings.floatBarOpacity / 100));
 
   return (
     <div
-      className={`floatbar floatbar--${orientation}`}
+      className={`floatbar floatbar--${orientation}${settings.floatBarDarkText ? " floatbar--light-bg" : ""}`}
       data-tauri-drag-region
+      style={{ opacity: opacityFraction }}
     >
       <div className="floatbar__handle" data-tauri-drag-region aria-hidden />
       {visible.length === 0 ? (

--- a/apps/desktop-tauri/src/floatbar/FloatBar.tsx
+++ b/apps/desktop-tauri/src/floatbar/FloatBar.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from "react";
 import { listen } from "@tauri-apps/api/event";
 import { getCurrentWindow } from "@tauri-apps/api/window";
+import { useFormattedResetTime } from "../hooks/useFormattedResetTime";
 import { useProviders } from "../hooks/useProviders";
 import { getSettingsSnapshot, refreshProvidersIfStale } from "../lib/tauri";
 import { ProviderIcon } from "../components/providers/ProviderIcon";
@@ -20,21 +21,6 @@ import "./FloatBar.css";
  * high-usage threshold, red when remaining is below the critical threshold
  * or the provider is exhausted.
  */
-function formatResetIn(resetsAt: string | null): string | null {
-  if (!resetsAt) return null;
-  const target = Date.parse(resetsAt);
-  if (Number.isNaN(target)) return null;
-  const diffMs = target - Date.now();
-  if (diffMs <= 0) return "due now";
-  const totalMinutes = Math.floor(diffMs / 60_000);
-  const days = Math.floor(totalMinutes / 1440);
-  const hours = Math.floor((totalMinutes % 1440) / 60);
-  const minutes = totalMinutes % 60;
-  if (days > 0) return `${days}d ${hours}h`;
-  if (hours > 0) return `${hours}h ${minutes}m`;
-  return `${minutes}m`;
-}
-
 function ProviderPill({
   provider,
   highRemaining,
@@ -52,12 +38,12 @@ function ProviderPill({
 
   const brand = getProviderIcon(provider.providerId).brandColor;
   const label = provider.error ? "—" : `${Math.round(remaining)}%`;
-  const resetIn = formatResetIn(provider.primary.resetsAt);
-  const resetSuffix = resetIn
-    ? `\nResets in ${resetIn}`
-    : provider.primary.resetDescription
-      ? `\nResets ${provider.primary.resetDescription}`
-      : "";
+  const resetText = useFormattedResetTime(
+    provider.primary.resetsAt,
+    provider.primary.resetDescription,
+    true,
+  );
+  const resetSuffix = resetText ? `\n${resetText}` : "";
 
   return (
     <div

--- a/apps/desktop-tauri/src/floatbar/SettingsSection.tsx
+++ b/apps/desktop-tauri/src/floatbar/SettingsSection.tsx
@@ -62,6 +62,17 @@ export default function FloatBarSettingsSection({ settings, saving, set }: Props
           />
         </Field>
         <Field
+          label="Light Background Mode"
+          description="Inverts contrast — use when the bar sits over a light desktop background."
+          leading
+        >
+          <Toggle
+            checked={settings.floatBarDarkText}
+            disabled={saving || !settings.floatBarEnabled}
+            onChange={(v) => set({ floatBarDarkText: v })}
+          />
+        </Field>
+        <Field
           label="Click-Through"
           description="Mouse clicks pass through to the window underneath — pure overlay mode."
           leading

--- a/apps/desktop-tauri/src/types/bridge.ts
+++ b/apps/desktop-tauri/src/types/bridge.ts
@@ -194,6 +194,8 @@ export interface SettingsSnapshot {
   floatBarClickThrough: boolean;
   /** Empty array = show all enabled providers. */
   floatBarProviderIds: string[];
+  /** When true, render with dark text/glass for light desktops. */
+  floatBarDarkText: boolean;
 }
 
 /** Partial settings object — only include fields you want to change. */
@@ -235,6 +237,7 @@ export interface SettingsUpdate {
   floatBarOrientation?: FloatBarOrientation;
   floatBarClickThrough?: boolean;
   floatBarProviderIds?: string[];
+  floatBarDarkText?: boolean;
 }
 
 export interface BootstrapState {

--- a/rust/src/settings.rs
+++ b/rust/src/settings.rs
@@ -365,6 +365,12 @@ pub struct Settings {
     /// Provider CLI names to display in the floating bar. Empty = all enabled.
     #[serde(default)]
     pub float_bar_provider_ids: Vec<String>,
+
+    /// When true, the floating bar uses a dark-on-light palette so it
+    /// stays legible on light desktop backgrounds. Defaults to false
+    /// (light-on-dark, the original look).
+    #[serde(default)]
+    pub float_bar_dark_text: bool,
 }
 
 fn default_float_bar_opacity() -> u8 {
@@ -544,6 +550,8 @@ struct RawSettings {
     float_bar_click_through: bool,
     #[serde(default)]
     float_bar_provider_ids: Vec<String>,
+    #[serde(default)]
+    float_bar_dark_text: bool,
 }
 
 impl Default for RawSettings {
@@ -616,6 +624,7 @@ impl Default for RawSettings {
             float_bar_orientation: s.float_bar_orientation,
             float_bar_click_through: s.float_bar_click_through,
             float_bar_provider_ids: s.float_bar_provider_ids,
+            float_bar_dark_text: s.float_bar_dark_text,
         }
     }
 }
@@ -865,6 +874,7 @@ impl From<RawSettings> for Settings {
             float_bar_orientation: normalize_float_bar_orientation(&raw.float_bar_orientation),
             float_bar_click_through: raw.float_bar_click_through,
             float_bar_provider_ids: raw.float_bar_provider_ids,
+            float_bar_dark_text: raw.float_bar_dark_text,
         }
     }
 }
@@ -915,6 +925,7 @@ impl Default for Settings {
             float_bar_orientation: default_float_bar_orientation(),
             float_bar_click_through: false,
             float_bar_provider_ids: Vec::new(),
+            float_bar_dark_text: false,
         }
     }
 }

--- a/rust/src/settings.rs
+++ b/rust/src/settings.rs
@@ -1940,6 +1940,7 @@ mod tests {
         assert_eq!(settings.float_bar_orientation, "horizontal");
         assert!(!settings.float_bar_click_through);
         assert!(settings.float_bar_provider_ids.is_empty());
+        assert!(!settings.float_bar_dark_text);
     }
 
     #[test]
@@ -1977,6 +1978,7 @@ mod tests {
             float_bar_orientation: "vertical".to_string(),
             float_bar_click_through: true,
             float_bar_provider_ids: vec!["claude".into(), "codex".into()],
+            float_bar_dark_text: true,
             ..Settings::default()
         };
 
@@ -1987,6 +1989,7 @@ mod tests {
         assert_eq!(back.float_bar_orientation, "vertical");
         assert!(back.float_bar_click_through);
         assert_eq!(back.float_bar_provider_ids, vec!["claude", "codex"]);
+        assert!(back.float_bar_dark_text);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- True window transparency on the floatbar (only pills + drag handle visible).
- Opacity slider now also drives CSS opacity so it takes visible effect regardless of WS_EX_LAYERED + DirectComposition interaction in WebView2.
- Pill hover tooltip now shows time-to-reset (e.g. \"Resets in 2h 14m\").
- New \"Light Background Mode\" toggle that inverts the palette (white-glass + dark text) for legibility on light desktops. Persisted end-to-end.
- Drag handle moved into its own small translucent pill so the grab target stays clear once the surrounding background is gone.

## Test plan
- [x] cargo test floatbar (codexbar-desktop-tauri) — 9/9 passed
- [x] cargo test settings::tests::float_bar (codexbar) — 5/5 passed
- [x] vitest — 40/40 passed (FloatBar.test.tsx 7/7)
- [x] cargo fmt --check clean in both crates
- [x] tsc --noEmit clean
- [ ] Manual: verify the floatbar is fully transparent except for pills on Windows 11
- [ ] Manual: drag the bar by the dot grip on both dark and light desktop backgrounds
- [ ] Manual: toggle Light Background Mode in Settings → Display → Floating Bar
- [ ] Manual: hover a pill and confirm reset countdown appears