### PR TITLE
fix Windows tray launch and Claude detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Fixed
+- Reopen the tray panel from Windows shortcut/tray activation when the app is hidden, and keep Claude usage detection on the current OAuth API path instead of falling back to unsupported CLI output.
+
 ---
 
 ## [Windows] 0.27.4 - 2026-05-23

--- a/apps/desktop-tauri/src-tauri/src/commands/mod.rs
+++ b/apps/desktop-tauri/src-tauri/src/commands/mod.rs
@@ -1251,11 +1251,16 @@ fn build_fetch_context(
     } else {
         match cookie_source {
             _ if active_token_env.is_some() => (SourceMode::OAuth, None),
+            "off" if id == ProviderId::Claude && usage_source != SourceMode::Cli => {
+                (SourceMode::OAuth, None)
+            }
             "off" => (SourceMode::Cli, None),
             "manual" => {
                 let cookie_header = active_token_cookie.or(stored_cookie);
                 let source_mode = if cookie_header.is_some() {
                     SourceMode::Web
+                } else if id == ProviderId::Claude && usage_source != SourceMode::Cli {
+                    SourceMode::OAuth
                 } else {
                     SourceMode::Cli
                 };
@@ -3315,6 +3320,45 @@ mod tests {
 
         let ctx = super::build_fetch_context(
             ProviderId::Cursor,
+            &settings,
+            &cookies,
+            &api_keys,
+            &token_accounts,
+        );
+
+        assert_eq!(ctx.source_mode, SourceMode::Cli);
+        assert!(ctx.manual_cookie_header.is_none());
+    }
+
+    #[test]
+    fn fetch_context_claude_uses_oauth_without_manual_cookie() {
+        let settings = Settings::default();
+        let cookies = ManualCookies::default();
+        let api_keys = ApiKeys::default();
+        let token_accounts = HashMap::new();
+
+        let ctx = super::build_fetch_context(
+            ProviderId::Claude,
+            &settings,
+            &cookies,
+            &api_keys,
+            &token_accounts,
+        );
+
+        assert_eq!(ctx.source_mode, SourceMode::OAuth);
+        assert!(ctx.manual_cookie_header.is_none());
+    }
+
+    #[test]
+    fn fetch_context_claude_explicit_cli_source_still_uses_cli() {
+        let mut settings = Settings::default();
+        settings.set_usage_source(ProviderId::Claude, "cli");
+        let cookies = ManualCookies::default();
+        let api_keys = ApiKeys::default();
+        let token_accounts = HashMap::new();
+
+        let ctx = super::build_fetch_context(
+            ProviderId::Claude,
             &settings,
             &cookies,
             &api_keys,

--- a/apps/desktop-tauri/src-tauri/src/main.rs
+++ b/apps/desktop-tauri/src-tauri/src/main.rs
@@ -30,12 +30,29 @@ fn should_hide_close_request(mode: SurfaceMode) -> bool {
     )
 }
 
+fn should_open_tray_panel_from_args<I, S>(args: I) -> bool
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<str>,
+{
+    args.into_iter().any(|arg| {
+        let normalized = arg
+            .as_ref()
+            .trim()
+            .trim_start_matches(['-', '/'])
+            .replace(['-', '_'], "")
+            .to_ascii_lowercase();
+        matches!(normalized.as_str(), "menubar" | "traypanel" | "tray")
+    })
+}
+
 fn main() {
     codexbar::logging::init(false, false).expect("failed to initialize logging");
 
     let proof_config = proof_harness::ProofConfig::from_env();
     let is_proof_mode = proof_config.is_some();
-    let force_start_visible = std::env::var_os("CODEXBAR_START_VISIBLE").is_some();
+    let force_start_visible = std::env::var_os("CODEXBAR_START_VISIBLE").is_some()
+        || should_open_tray_panel_from_args(std::env::args().skip(1));
 
     let mut initial_state = AppState::new();
     initial_state.proof_config = proof_config;
@@ -43,9 +60,15 @@ fn main() {
     tauri::Builder::default()
         .manage(Mutex::new(initial_state))
         .plugin(shortcut_bridge::plugin())
-        .plugin(tauri_plugin_single_instance::init(|app, _args, _cwd| {
-            let _ =
-                shell::reopen_to_target(app, SurfaceMode::TrayPanel, SurfaceTarget::Summary, None);
+        .plugin(tauri_plugin_single_instance::init(|app, args, _cwd| {
+            if args.len() <= 1 || should_open_tray_panel_from_args(args.iter().skip(1)) {
+                let _ = shell::reopen_to_target(
+                    app,
+                    SurfaceMode::TrayPanel,
+                    SurfaceTarget::Summary,
+                    None,
+                );
+            }
         }))
         .invoke_handler(tauri::generate_handler![
             commands::get_bootstrap_state,
@@ -221,5 +244,17 @@ mod tests {
     #[test]
     fn close_request_leaves_hidden_surface_alone() {
         assert!(!should_hide_close_request(SurfaceMode::Hidden));
+    }
+
+    #[test]
+    fn menubar_launch_arg_opens_tray_panel() {
+        assert!(should_open_tray_panel_from_args(["menubar"]));
+        assert!(should_open_tray_panel_from_args(["--tray-panel"]));
+        assert!(should_open_tray_panel_from_args(["/tray_panel"]));
+    }
+
+    #[test]
+    fn unrelated_launch_args_do_not_open_tray_panel() {
+        assert!(!should_open_tray_panel_from_args(["usage", "-p", "claude"]));
     }
 }

--- a/apps/desktop-tauri/src-tauri/src/shell/tests.rs
+++ b/apps/desktop-tauri/src-tauri/src/shell/tests.rs
@@ -9,7 +9,7 @@ use super::transition::{
     monitor_for_preserved_visible_position, reclamp_preserved_visible_position,
     recovery_snapshot_for_failed_transition, resolve_transition_position,
     resolve_transition_request, restore_recovery_surface, restore_surface_snapshot,
-    should_synthesize_default_position,
+    should_hide_tray_panel_on_toggle, should_synthesize_default_position,
 };
 use super::window::{hide_to_tray_state, prepare_hide_to_tray_if_current};
 
@@ -55,6 +55,19 @@ fn conditional_hide_to_tray_leaves_non_matching_surface_alone() {
     assert!(plan.is_none());
     assert_eq!(state.surface_machine.current(), SurfaceMode::PopOut);
     assert_eq!(state.current_target, SurfaceTarget::Dashboard);
+}
+
+#[test]
+fn tray_toggle_hides_only_when_panel_window_is_visible() {
+    assert!(should_hide_tray_panel_on_toggle(
+        SurfaceMode::TrayPanel,
+        true
+    ));
+    assert!(!should_hide_tray_panel_on_toggle(
+        SurfaceMode::TrayPanel,
+        false
+    ));
+    assert!(!should_hide_tray_panel_on_toggle(SurfaceMode::Hidden, true));
 }
 
 #[test]

--- a/apps/desktop-tauri/src-tauri/src/shell/transition.rs
+++ b/apps/desktop-tauri/src-tauri/src/shell/transition.rs
@@ -501,15 +501,26 @@ pub fn toggle_tray_panel(app: &AppHandle, position: Option<(i32, i32)>) {
         let st = app.state::<Mutex<AppState>>();
         st.lock().unwrap().surface_machine.current()
     };
+    let main_window_visible = app
+        .get_webview_window("main")
+        .and_then(|window| window.is_visible().ok())
+        .unwrap_or(false);
 
-    if current == SurfaceMode::TrayPanel {
+    if should_hide_tray_panel_on_toggle(current, main_window_visible) {
         let _ = super::window::hide_to_tray(app);
     } else {
-        let _ = transition_to_target(
+        let _ = reopen_to_target(
             app,
             SurfaceMode::TrayPanel,
             SurfaceTarget::Summary,
             position,
         );
     }
+}
+
+pub(super) fn should_hide_tray_panel_on_toggle(
+    current: SurfaceMode,
+    main_window_visible: bool,
+) -> bool {
+    current == SurfaceMode::TrayPanel && main_window_visible
 }

--- a/rust/src/cli/tty_runner.rs
+++ b/rust/src/cli/tty_runner.rs
@@ -8,6 +8,8 @@
 use regex_lite::Regex;
 use std::collections::HashMap;
 use std::io::{Read, Write};
+#[cfg(windows)]
+use std::os::windows::process::CommandExt;
 use std::path::PathBuf;
 #[cfg(windows)]
 use std::process::{Command, Stdio};
@@ -269,12 +271,15 @@ impl TtyCommandRunner {
     fn run_where(tool: &str) -> Option<PathBuf> {
         #[cfg(windows)]
         {
-            let output = Command::new("where")
+            const CREATE_NO_WINDOW: u32 = 0x08000000;
+
+            let mut command = Command::new("where");
+            command
                 .arg(tool)
                 .stdout(Stdio::piped())
                 .stderr(Stdio::null())
-                .output()
-                .ok()?;
+                .creation_flags(CREATE_NO_WINDOW);
+            let output = command.output().ok()?;
 
             if !output.status.success() {
                 return None;

--- a/rust/src/providers/claude/mod.rs
+++ b/rust/src/providers/claude/mod.rs
@@ -198,7 +198,17 @@ impl Provider for ClaudeProvider {
             }
             SourceMode::OAuth => self.fetch_via_oauth(ctx).await,
             SourceMode::Web => self.fetch_via_web(ctx).await,
-            SourceMode::Cli => self.fetch_via_cli(ctx).await,
+            SourceMode::Cli => match self.fetch_via_cli(ctx).await {
+                Ok(result) => Ok(result),
+                Err(error) if should_fallback_from_claude_cli_error(&error) => {
+                    tracing::debug!(
+                        error = %error,
+                        "Claude CLI usage probe failed with a fallback-safe error; trying OAuth"
+                    );
+                    self.fetch_via_oauth(ctx).await
+                }
+                Err(error) => Err(error),
+            },
         }
     }
 
@@ -476,6 +486,22 @@ fn claude_auto_fetch_error(failures: Vec<(&'static str, ProviderError)>) -> Prov
     ))
 }
 
+fn should_fallback_from_claude_cli_error(error: &ProviderError) -> bool {
+    match error {
+        ProviderError::Parse(message) => {
+            matches!(
+                message.as_str(),
+                "Claude CLI did not return usage data" | "Empty output from Claude CLI"
+            )
+        }
+        ProviderError::Other(message) => {
+            message.contains("returned local activity stats")
+                || message.contains("treated /usage as a normal prompt")
+        }
+        _ => false,
+    }
+}
+
 /// Try to find the claude CLI binary
 fn which_claude() -> Option<std::path::PathBuf> {
     #[cfg(windows)]
@@ -521,12 +547,15 @@ fn which_claude() -> Option<std::path::PathBuf> {
 
 #[cfg(windows)]
 fn find_windows_claude_in_path() -> Option<std::path::PathBuf> {
-    let output = StdCommand::new("where")
+    const CREATE_NO_WINDOW: u32 = 0x08000000;
+
+    let mut command = StdCommand::new("where");
+    command
         .arg("claude")
         .stdout(Stdio::piped())
         .stderr(Stdio::null())
-        .output()
-        .ok()?;
+        .creation_flags(CREATE_NO_WINDOW);
+    let output = command.output().ok()?;
 
     if !output.status.success() {
         return None;
@@ -1048,6 +1077,20 @@ Resets Dec 24 at 3:59pm (Europe/Paris)
             err.to_string(),
             "Claude usage failed from all configured sources. OAuth: OAuth error: token expired; Web: No cookies available for web API; CLI: Parse error: Empty output from Claude CLI"
         );
+    }
+
+    #[test]
+    fn cli_parse_usage_error_can_fallback_to_oauth() {
+        let err = ProviderError::Parse("Claude CLI did not return usage data".to_string());
+
+        assert!(should_fallback_from_claude_cli_error(&err));
+    }
+
+    #[test]
+    fn cli_auth_error_does_not_fallback_to_oauth() {
+        assert!(!should_fallback_from_claude_cli_error(
+            &ProviderError::AuthRequired
+        ));
     }
 
     #[test]

--- a/rust/src/providers/claude/oauth.rs
+++ b/rust/src/providers/claude/oauth.rs
@@ -60,25 +60,33 @@ struct OAuthData {
 /// OAuth usage response from Claude API
 #[derive(Debug, Deserialize)]
 pub struct OAuthUsageResponse {
-    #[serde(rename = "fiveHour")]
+    #[serde(rename = "fiveHour", alias = "five_hour")]
     pub five_hour: Option<UsageWindow>,
 
-    #[serde(rename = "sevenDay")]
+    #[serde(rename = "sevenDay", alias = "seven_day")]
     pub seven_day: Option<UsageWindow>,
 
-    #[serde(rename = "sevenDaySonnet")]
+    #[serde(rename = "sevenDaySonnet", alias = "seven_day_sonnet")]
     pub seven_day_sonnet: Option<UsageWindow>,
 
-    #[serde(rename = "sevenDayOpus")]
+    #[serde(rename = "sevenDayOpus", alias = "seven_day_opus")]
     pub seven_day_opus: Option<UsageWindow>,
 
-    #[serde(rename = "sevenDayDesign")]
+    #[serde(
+        rename = "sevenDayDesign",
+        alias = "seven_day_design",
+        alias = "seven_day_oauth_apps"
+    )]
     pub seven_day_design: Option<UsageWindow>,
 
-    #[serde(rename = "sevenDayRoutines")]
+    #[serde(
+        rename = "sevenDayRoutines",
+        alias = "seven_day_routines",
+        alias = "seven_day_omelette"
+    )]
     pub seven_day_routines: Option<UsageWindow>,
 
-    #[serde(rename = "extraUsage")]
+    #[serde(rename = "extraUsage", alias = "extra_usage")]
     pub extra_usage: Option<ExtraUsage>,
 }
 
@@ -87,20 +95,20 @@ pub struct OAuthUsageResponse {
 pub struct UsageWindow {
     pub utilization: Option<f64>,
 
-    #[serde(rename = "resetsAt")]
+    #[serde(rename = "resetsAt", alias = "resets_at")]
     pub resets_at: Option<String>,
 }
 
 /// Extra usage (credits) info
 #[derive(Debug, Deserialize)]
 pub struct ExtraUsage {
-    #[serde(rename = "isEnabled")]
+    #[serde(rename = "isEnabled", alias = "is_enabled")]
     pub is_enabled: Option<bool>,
 
-    #[serde(rename = "usedCredits")]
+    #[serde(rename = "usedCredits", alias = "used_credits")]
     pub used_credits: Option<f64>,
 
-    #[serde(rename = "monthlyLimit")]
+    #[serde(rename = "monthlyLimit", alias = "monthly_limit")]
     pub monthly_limit: Option<f64>,
 
     pub currency: Option<String>,
@@ -112,7 +120,7 @@ pub struct ClaudeOAuthFetcher {
 }
 
 impl ClaudeOAuthFetcher {
-    const USAGE_URL: &'static str = "https://api.claude.ai/api/usage";
+    const USAGE_URL: &'static str = "https://api.anthropic.com/api/oauth/usage";
     const CREDENTIALS_PATH: &'static str = ".claude/.credentials.json";
     const ENV_TOKEN_KEY: &'static str = "CODEXBAR_CLAUDE_OAUTH_TOKEN";
     const ENV_SCOPES_KEY: &'static str = "CODEXBAR_CLAUDE_OAUTH_SCOPES";
@@ -282,6 +290,8 @@ impl ClaudeOAuthFetcher {
                 "Authorization",
                 format!("Bearer {}", credentials.access_token),
             )
+            .header("Accept", "application/json")
+            .header("anthropic-beta", "oauth-2025-04-20")
             .timeout(std::time::Duration::from_secs(10))
             .send()
             .await?;
@@ -447,7 +457,7 @@ fn format_reset_date(date: DateTime<Utc>) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::{ClaudeOAuthFetcher, UsageWindow};
+    use super::{ClaudeOAuthCredentials, ClaudeOAuthFetcher, OAuthUsageResponse, UsageWindow};
 
     #[test]
     fn converts_fractional_utilization_to_percent() {
@@ -471,5 +481,31 @@ mod tests {
         let rate = ClaudeOAuthFetcher::to_rate_window(&window, Some(300)).expect("rate window");
 
         assert!((rate.used_percent - 23.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn parses_current_snake_case_oauth_usage_response() {
+        let response: OAuthUsageResponse = serde_json::from_str(
+            r#"{
+                "five_hour": {"utilization": 1.0, "resets_at": "2026-05-22T22:10:00Z"},
+                "seven_day": {"utilization": 0.14, "resets_at": "2026-05-29T10:00:00Z"},
+                "seven_day_oauth_apps": {"utilization": 0.0},
+                "extra_usage": {"is_enabled": true, "used_credits": 0, "monthly_limit": 1000, "currency": "USD"}
+            }"#,
+        )
+        .expect("snake_case OAuth response should parse");
+
+        let credentials = ClaudeOAuthCredentials {
+            access_token: "token".to_string(),
+            refresh_token: None,
+            expires_at: None,
+            scopes: vec!["user:profile".to_string()],
+            rate_limit_tier: Some("default_claude_ai".to_string()),
+        };
+        let usage = ClaudeOAuthFetcher::new().build_usage_snapshot(&response, &credentials);
+
+        assert_eq!(usage.primary.used_percent, 100.0);
+        assert!((usage.secondary.expect("weekly").used_percent - 14.0).abs() < 0.001);
+        assert_eq!(usage.extra_rate_windows[0].id, "claude-design");
     }
 }


### PR DESCRIPTION
### Summary
- Honor Windows shortcut `menubar` / tray launch args on cold start.
- Reopen the tray panel when state says tray panel is active but the window is hidden.
- Keep Claude desktop detection on OAuth when no manual Claude cookie is configured.
- Fall back from unsupported Claude CLI usage output to OAuth.
- Use the current Claude OAuth usage endpoint and parse snake_case usage fields.
- Hide Windows `where.exe` probes to avoid flashing a console window.

### Tests
- `cargo fmt --manifest-path Cargo.toml --all --check`
- `cargo test --manifest-path rust/Cargo.toml providers::claude::oauth::tests --lib`
- `cargo test --manifest-path rust/Cargo.toml providers::claude::tests --lib`
- `cargo test --manifest-path apps/desktop-tauri/src-tauri/Cargo.toml fetch_context_claude`
- `cargo test --manifest-path apps/desktop-tauri/src-tauri/Cargo.toml tray_toggle_hides_only_when_panel_window_is_visible`
- `cargo test --manifest-path apps/desktop-tauri/src-tauri/Cargo.toml launch_arg -- close_request`
- `cargo run -p codexbar -- usage -p claude --source cli --json`