### PR TITLE
fix: prevent provider tab label overlap in sparse grid

### DIFF
--- a/apps/desktop-tauri/src/styles.css
+++ b/apps/desktop-tauri/src/styles.css
@@ -4721,6 +4721,21 @@ html:has(.menu-surface--tray) {
   gap: 8px 5px;
 }
 
+/* The 10-column override above also matches the sparse variant (it carries
+   both classes), packing 40px items into ~21px columns so adjacent tab
+   labels overlap. Re-assert the sparse track sizing after it. */
+.menu-surface--tray .provider-grid--sparse {
+  grid-template-columns: repeat(auto-fit, 40px);
+  justify-content: start;
+  gap: 8px 6px;
+}
+
+.menu-surface--popout .provider-grid--sparse {
+  grid-template-columns: repeat(auto-fit, 42px);
+  justify-content: start;
+  gap: 8px 7px;
+}
+
 .provider-grid__item {
   min-height: 42px;
   padding: 2px 1px 3px;


### PR DESCRIPTION
## Summary

Fixes an overlap between provider tab labels in the main bar when only a few providers are configured.

When 6 or fewer providers are shown, the grid uses the `provider-grid--sparse` variant, which sizes columns as `repeat(auto-fit, 40px)`. A later, equal-specificity override block (`.menu-surface--tray .provider-grid`) re-set the columns to `repeat(10, minmax(0, 1fr))`. Because the two rules have equal specificity, the sparse rule lost on source order — so the 40px-wide items were packed into ~21px columns, causing adjacent tab labels to overlap.

The fix re-asserts the sparse column/gap sizing after the override block for both the tray and popout surfaces.

## Testing

Tested locally with two providers (Claude/Codex). Before the fix the "Claude" and "Codex" tab labels overlapped; after the fix they render cleanly with proper spacing.
