### PR TITLE
Fix current Codex token log parsing

### DIFF
--- a/apps/desktop-tauri/src-tauri/src/commands/system.rs
+++ b/apps/desktop-tauri/src-tauri/src/commands/system.rs
@@ -264,10 +264,17 @@ pub fn quit_app(app: tauri::AppHandle) {
 }
 
 fn dashboard_url_for_provider(provider_id: &str) -> Option<String> {
-    codexbar::settings::get_api_key_providers()
+    if let Some(url) = codexbar::settings::get_api_key_providers()
         .into_iter()
         .find(|p| p.id.cli_name() == provider_id)
         .and_then(|p| p.dashboard_url.map(|s| s.to_string()))
+    {
+        return Some(url);
+    }
+
+    let id = ProviderId::from_cli_name(provider_id)?;
+    let provider = instantiate_provider(id);
+    provider.metadata().dashboard_url.map(|s| s.to_string())
 }
 
 fn status_page_url_for_provider(provider_id: &str) -> Option<String> {
@@ -376,4 +383,17 @@ async fn run_copilot_device_login(app: &tauri::AppHandle) -> Result<(), String> 
         serde_json::json!({ "providerId": "copilot" }),
     );
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn dashboard_url_resolves_from_codex_provider_metadata() {
+        assert_eq!(
+            dashboard_url_for_provider("codex").as_deref(),
+            Some("https://chatgpt.com/codex/settings/usage")
+        );
+    }
 }

--- a/apps/desktop-tauri/src/components/MenuCard.test.tsx
+++ b/apps/desktop-tauri/src/components/MenuCard.test.tsx
@@ -123,11 +123,27 @@ describe("MenuCard", () => {
     expect(fill?.style.width).toBe("35%");
   });
 
+  it("notifies the tray panel after async local usage data loads", async () => {
+    const listener = vi.fn();
+    window.addEventListener("codexbar:menu-card-layout-change", listener);
+
+    renderCard(provider(null));
+
+    await waitFor(() => {
+      expect(listener).toHaveBeenCalled();
+    });
+
+    window.removeEventListener("codexbar:menu-card-layout-change", listener);
+  });
+
   it("keeps local token and cost totals visible in the tray panel", () => {
     const styles = readFileSync("src/styles.css", "utf8");
 
     expect(styles).not.toMatch(
       /\.menu-surface--tray\s+\.menu-card__local-usage\s*\{[^}]*display:\s*none/s,
+    );
+    expect(styles).toMatch(
+      /\.menu-surface--tray\s+\.menu-stack\s*\{[^}]*flex:\s*0\s+0\s+auto/s,
     );
     expect(styles).toMatch(
       /\.menu-surface--tray\s+\.menu-card__local-chart\s*\{[^}]*display:\s*none/s,

--- a/apps/desktop-tauri/src/components/MenuCard.test.tsx
+++ b/apps/desktop-tauri/src/components/MenuCard.test.tsx
@@ -1,4 +1,6 @@
 import { render, screen, waitFor } from "@testing-library/react";
+// @ts-expect-error Vitest runs this test in Node; the app tsconfig omits Node types.
+import { readFileSync } from "node:fs";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const tauriMocks = vi.hoisted(() => ({
@@ -119,5 +121,16 @@ describe("MenuCard", () => {
 
     const fill = document.querySelector<HTMLElement>(".menu-metric__bar-fill");
     expect(fill?.style.width).toBe("35%");
+  });
+
+  it("keeps local token and cost totals visible in the tray panel", () => {
+    const styles = readFileSync("src/styles.css", "utf8");
+
+    expect(styles).not.toMatch(
+      /\.menu-surface--tray\s+\.menu-card__local-usage\s*\{[^}]*display:\s*none/s,
+    );
+    expect(styles).toMatch(
+      /\.menu-surface--tray\s+\.menu-card__local-chart\s*\{[^}]*display:\s*none/s,
+    );
   });
 });

--- a/apps/desktop-tauri/src/components/MenuCard.tsx
+++ b/apps/desktop-tauri/src/components/MenuCard.tsx
@@ -93,6 +93,14 @@ const DEMO_LOCAL_USAGE: Record<string, ProviderLocalUsageSummary> = {
   },
 };
 
+const MENU_CARD_LAYOUT_CHANGE_EVENT = "codexbar:menu-card-layout-change";
+
+function notifyMenuCardLayoutChange() {
+  requestAnimationFrame(() => {
+    window.dispatchEvent(new Event(MENU_CARD_LAYOUT_CHANGE_EVENT));
+  });
+}
+
 function formatCompactCount(value: number | null): string {
   if (value == null || value <= 0) return "—";
   return new Intl.NumberFormat("en-US", {
@@ -337,7 +345,10 @@ export default function MenuCard({
       provider.accountEmail ?? undefined,
     )
       .then((data) => {
-        if (!cancelled) setChartData(data);
+        if (!cancelled) {
+          setChartData(data);
+          notifyMenuCardLayoutChange();
+        }
       })
       .catch(() => {
         /* chart data is best-effort */

--- a/apps/desktop-tauri/src/styles.css
+++ b/apps/desktop-tauri/src/styles.css
@@ -3124,6 +3124,7 @@ html:has(.menu-surface--tray) {
 }
 .menu-surface--tray .menu-stack {
   gap: 2px;
+  flex: 0 0 auto;
   max-height: none;
   overflow: visible;
   min-width: 0;
@@ -3291,6 +3292,8 @@ html:has(.menu-surface--tray) {
   display: flex;
   flex-direction: column;
   gap: 1px;
+  flex: 0 0 auto;
+  margin-top: 4px;
   padding: 0 10px;
 }
 .context-actions__divider {
@@ -3373,10 +3376,14 @@ html:has(.menu-surface--tray) {
   display: none;
 }
 .menu-surface--tray .menu-card__local-grid {
-  gap: 8px 18px;
+  gap: 9px 20px;
+}
+.menu-surface--tray .menu-card__local-usage {
+  padding-top: 2px;
 }
 .menu-surface--tray .menu-card__local-note {
   font-size: 10px;
+  line-height: 1.25;
 }
 /* Hide cost section in tray — macOS compact popover only shows usage metrics */
 .menu-surface--tray .menu-card__cost,

--- a/apps/desktop-tauri/src/styles.css
+++ b/apps/desktop-tauri/src/styles.css
@@ -3367,12 +3367,16 @@ html:has(.menu-surface--tray) {
 .menu-surface--tray .menu-card__content > .menu-card__divider:has(+ .menu-card__pace) {
   display: none;
 }
-/* Hide charts in tray — macOS shows charts only in the detail/dashboard view */
-.menu-surface--tray .menu-card__charts {
+/* Hide large charts in tray; keep the compact local token/cost summary visible. */
+.menu-surface--tray .menu-card__charts,
+.menu-surface--tray .menu-card__local-chart {
   display: none;
 }
-.menu-surface--tray .menu-card__local-usage {
-  display: none;
+.menu-surface--tray .menu-card__local-grid {
+  gap: 8px 18px;
+}
+.menu-surface--tray .menu-card__local-note {
+  font-size: 10px;
 }
 /* Hide cost section in tray — macOS compact popover only shows usage metrics */
 .menu-surface--tray .menu-card__cost,

--- a/apps/desktop-tauri/src/surfaces/TrayPanel.tsx
+++ b/apps/desktop-tauri/src/surfaces/TrayPanel.tsx
@@ -95,6 +95,7 @@ export default function TrayPanel({ state }: { state: BootstrapState }) {
   // Hide panel during the initial resize+reposition dance so the user
   // doesn't see the window jump around.  Revealed after first layout pass.
   const [layoutReady, setLayoutReady] = useState(false);
+  const [layoutRevision, setLayoutRevision] = useState(0);
   const layoutReadyRef = useRef(false);
   const resizeRunRef = useRef(0);
 
@@ -125,6 +126,26 @@ export default function TrayPanel({ state }: { state: BootstrapState }) {
     }
     return [match];
   }, [sorted, selectedProviderId, gridExpanded]);
+
+  useEffect(() => {
+    let timer: number | undefined;
+    const scheduleResize = () => {
+      if (timer !== undefined) {
+        window.clearTimeout(timer);
+      }
+      timer = window.setTimeout(() => {
+        setLayoutRevision((current) => current + 1);
+      }, 50);
+    };
+
+    window.addEventListener("codexbar:menu-card-layout-change", scheduleResize);
+    return () => {
+      if (timer !== undefined) {
+        window.clearTimeout(timer);
+      }
+      window.removeEventListener("codexbar:menu-card-layout-change", scheduleResize);
+    };
+  }, []);
 
   // Dynamically size the Tauri window to fit content, capped at 800px.
   // The first pass can grow the hidden window for a complete measurement.
@@ -249,7 +270,7 @@ export default function TrayPanel({ state }: { state: BootstrapState }) {
       clearTimeout(t0);
       resizeRunRef.current += 1;
     };
-  }, [visibleProviders, providers]);
+  }, [visibleProviders, providers, layoutRevision]);
 
   const openSettings = useCallback(() => {
     void openSettingsWindow("general").finally(() => {

--- a/rust/src/core/cost_pricing.rs
+++ b/rust/src/core/cost_pricing.rs
@@ -551,19 +551,19 @@ impl CostUsagePricing {
     /// Calculate cost for Codex usage in USD
     pub fn codex_cost_usd(
         model: &str,
-        input_tokens: i32,
-        cached_input_tokens: i32,
-        output_tokens: i32,
+        input_tokens: u64,
+        cached_input_tokens: u64,
+        output_tokens: u64,
     ) -> Option<f64> {
         let key = Self::normalize_codex_model(model);
         let pricing = CODEX_PRICING.get(key.as_str())?;
 
-        let cached = cached_input_tokens.max(0).min(input_tokens.max(0));
-        let non_cached = (input_tokens.max(0) - cached).max(0);
+        let cached = cached_input_tokens.min(input_tokens);
+        let non_cached = input_tokens.saturating_sub(cached);
 
         let cost = (non_cached as f64) * pricing.input_cost_per_token
             + (cached as f64) * pricing.cache_read_input_cost_per_token
-            + (output_tokens.max(0) as f64) * pricing.output_cost_per_token;
+            + (output_tokens as f64) * pricing.output_cost_per_token;
 
         Some(cost)
     }

--- a/rust/src/cost_scanner.rs
+++ b/rust/src/cost_scanner.rs
@@ -50,6 +50,19 @@ impl ModelTokenCounts {
     }
 }
 
+#[derive(Debug, Clone, Copy, Default)]
+struct TokenCounts {
+    input: u64,
+    cached: u64,
+    output: u64,
+}
+
+impl TokenCounts {
+    fn total(&self) -> u64 {
+        self.input + self.cached + self.output
+    }
+}
+
 impl CostSummary {
     pub fn format_total(&self) -> String {
         format!("${:.2}", self.total_cost_usd)
@@ -271,62 +284,64 @@ impl CostScanner {
 
         let reader = BufReader::new(file);
         let mut current_model = String::from("gpt-4o");
+        let mut previous_totals: Option<TokenCounts> = None;
         let mut session_cost = 0.0;
         let mut has_tokens = false;
 
         for line in reader.lines().map_while(Result::ok) {
             if let Ok(event) = serde_json::from_str::<serde_json::Value>(&line) {
-                // Check for model in turn_context
                 if let Some(model) = event.get("model").and_then(|m| m.as_str()) {
                     current_model = model.to_string();
                 }
-
-                // Check for token_count events
-                if let Some(event_msg) = event.get("event_msg")
-                    && event_msg.get("type").and_then(|t| t.as_str()) == Some("token_count")
+                if event.get("type").and_then(|t| t.as_str()) == Some("turn_context")
+                    && let Some(model) = event
+                        .get("payload")
+                        .and_then(|payload| payload.get("model"))
+                        .or_else(|| {
+                            event
+                                .get("payload")
+                                .and_then(|payload| payload.get("info"))
+                                .and_then(|info| info.get("model"))
+                        })
+                        .and_then(|m| m.as_str())
                 {
-                    let input = event_msg
-                        .get("input_tokens")
-                        .and_then(|t| t.as_u64())
-                        .unwrap_or(0);
-                    let cached = event_msg
-                        .get("cached_input_tokens")
-                        .and_then(|t| t.as_u64())
-                        .unwrap_or(0);
-                    let output = event_msg
-                        .get("output_tokens")
-                        .and_then(|t| t.as_u64())
-                        .unwrap_or(0);
+                    current_model = model.to_string();
+                }
 
-                    summary.input_tokens += input;
+                if let Some((tokens, model)) =
+                    codex_token_counts_from_event(&event, &current_model, &mut previous_totals)
+                {
+                    if tokens.total() == 0 {
+                        continue;
+                    }
+
+                    let cached = tokens.cached.min(tokens.input);
+                    summary.input_tokens += tokens.input;
                     summary.cached_tokens += cached;
-                    summary.output_tokens += output;
+                    summary.output_tokens += tokens.output;
 
-                    let cost = CodexPricing::cost_usd(&current_model, input, cached, output);
+                    let cost = CodexPricing::cost_usd(&model, tokens.input, cached, tokens.output);
                     session_cost += cost;
                     has_tokens = true;
 
-                    *summary.by_model.entry(current_model.clone()).or_insert(0.0) += cost;
-                    let speed_bucket = codex_speed_bucket(&current_model);
+                    *summary.by_model.entry(model.clone()).or_insert(0.0) += cost;
+                    let speed_bucket = codex_speed_bucket(&model);
                     *summary
                         .by_speed
                         .entry(speed_bucket.to_string())
                         .or_insert(0.0) += cost;
 
-                    let model_tokens = summary
-                        .by_model_tokens
-                        .entry(current_model.clone())
-                        .or_default();
-                    model_tokens.input_tokens += input;
-                    model_tokens.output_tokens += output;
+                    let model_tokens = summary.by_model_tokens.entry(model).or_default();
+                    model_tokens.input_tokens += tokens.input;
+                    model_tokens.output_tokens += tokens.output;
                     model_tokens.cached_tokens += cached;
 
                     let speed_tokens = summary
                         .by_speed_tokens
                         .entry(speed_bucket.to_string())
                         .or_default();
-                    speed_tokens.input_tokens += input;
-                    speed_tokens.output_tokens += output;
+                    speed_tokens.input_tokens += tokens.input;
+                    speed_tokens.output_tokens += tokens.output;
                     speed_tokens.cached_tokens += cached;
                 }
             }
@@ -431,6 +446,72 @@ impl CostScanner {
     }
 }
 
+fn codex_token_counts_from_event(
+    event: &serde_json::Value,
+    current_model: &str,
+    previous_totals: &mut Option<TokenCounts>,
+) -> Option<(TokenCounts, String)> {
+    let token_payload =
+        current_codex_token_payload(event).or_else(|| legacy_codex_token_payload(event))?;
+    let info = token_payload.get("info");
+    let model = info
+        .and_then(|value| value.get("model").or_else(|| value.get("model_name")))
+        .or_else(|| token_payload.get("model"))
+        .or_else(|| event.get("model"))
+        .and_then(|value| value.as_str())
+        .unwrap_or(current_model)
+        .to_string();
+
+    if let Some(total) = info.and_then(|value| value.get("total_token_usage")) {
+        let totals = token_counts_from_value(total);
+        let previous = previous_totals.unwrap_or_default();
+        *previous_totals = Some(totals);
+        return Some((
+            TokenCounts {
+                input: totals.input.saturating_sub(previous.input),
+                cached: totals.cached.saturating_sub(previous.cached),
+                output: totals.output.saturating_sub(previous.output),
+            },
+            model,
+        ));
+    }
+
+    if let Some(last) = info.and_then(|value| value.get("last_token_usage")) {
+        return Some((token_counts_from_value(last), model));
+    }
+
+    Some((token_counts_from_value(token_payload), model))
+}
+
+fn current_codex_token_payload(event: &serde_json::Value) -> Option<&serde_json::Value> {
+    let payload = event.get("payload")?;
+    (event.get("type").and_then(|value| value.as_str()) == Some("event_msg")
+        && payload.get("type").and_then(|value| value.as_str()) == Some("token_count"))
+    .then_some(payload)
+}
+
+fn legacy_codex_token_payload(event: &serde_json::Value) -> Option<&serde_json::Value> {
+    let event_msg = event.get("event_msg")?;
+    (event_msg.get("type").and_then(|value| value.as_str()) == Some("token_count"))
+        .then_some(event_msg)
+}
+
+fn token_counts_from_value(value: &serde_json::Value) -> TokenCounts {
+    TokenCounts {
+        input: token_u64(value, "input_tokens"),
+        cached: value
+            .get("cached_input_tokens")
+            .or_else(|| value.get("cache_read_input_tokens"))
+            .and_then(|value| value.as_u64())
+            .unwrap_or(0),
+        output: token_u64(value, "output_tokens"),
+    }
+}
+
+fn token_u64(value: &serde_json::Value, key: &str) -> u64 {
+    value.get(key).and_then(|value| value.as_u64()).unwrap_or(0)
+}
+
 /// Check if any cost usage sources are available
 #[allow(dead_code)]
 pub fn has_cost_usage_sources() -> bool {
@@ -510,6 +591,7 @@ fn scan_codex_file_cost(path: &PathBuf) -> f64 {
 
     let reader = BufReader::new(file);
     let mut current_model = String::from("gpt-4o");
+    let mut previous_totals: Option<TokenCounts> = None;
     let mut total_cost = 0.0;
 
     for line in reader.lines().map_while(Result::ok) {
@@ -517,24 +599,34 @@ fn scan_codex_file_cost(path: &PathBuf) -> f64 {
             if let Some(model) = event.get("model").and_then(|m| m.as_str()) {
                 current_model = model.to_string();
             }
-
-            if let Some(event_msg) = event.get("event_msg")
-                && event_msg.get("type").and_then(|t| t.as_str()) == Some("token_count")
+            if event.get("type").and_then(|t| t.as_str()) == Some("turn_context")
+                && let Some(model) = event
+                    .get("payload")
+                    .and_then(|payload| payload.get("model"))
+                    .or_else(|| {
+                        event
+                            .get("payload")
+                            .and_then(|payload| payload.get("info"))
+                            .and_then(|info| info.get("model"))
+                    })
+                    .and_then(|m| m.as_str())
             {
-                let input = event_msg
-                    .get("input_tokens")
-                    .and_then(|t| t.as_u64())
-                    .unwrap_or(0);
-                let cached = event_msg
-                    .get("cached_input_tokens")
-                    .and_then(|t| t.as_u64())
-                    .unwrap_or(0);
-                let output = event_msg
-                    .get("output_tokens")
-                    .and_then(|t| t.as_u64())
-                    .unwrap_or(0);
+                current_model = model.to_string();
+            }
 
-                total_cost += CodexPricing::cost_usd(&current_model, input, cached, output);
+            if let Some((tokens, model)) =
+                codex_token_counts_from_event(&event, &current_model, &mut previous_totals)
+            {
+                if tokens.total() == 0 {
+                    continue;
+                }
+
+                total_cost += CodexPricing::cost_usd(
+                    &model,
+                    tokens.input,
+                    tokens.cached.min(tokens.input),
+                    tokens.output,
+                );
             }
         }
     }
@@ -545,6 +637,7 @@ fn scan_codex_file_cost(path: &PathBuf) -> f64 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::io::Write;
 
     #[test]
     fn test_codex_pricing() {
@@ -565,5 +658,38 @@ mod tests {
         assert_eq!(codex_speed_bucket("gpt-5.5-fast"), "fast");
         assert_eq!(codex_speed_bucket("gpt-5.3-codex-spark"), "fast");
         assert_eq!(codex_speed_bucket("gpt-5-codex"), "standard");
+    }
+
+    #[test]
+    fn parses_current_codex_payload_token_count_events() {
+        let path = std::env::temp_dir().join(format!(
+            "codexbar-current-codex-token-count-{}.jsonl",
+            std::process::id()
+        ));
+        let mut file = File::create(&path).unwrap();
+        writeln!(
+            file,
+            r#"{{"timestamp":"2026-05-27T17:12:48.000Z","type":"event_msg","payload":{{"type":"token_count","info":{{"model":"gpt-5","total_token_usage":{{"input_tokens":125,"cached_input_tokens":30,"output_tokens":15}}}}}}}}"#
+        )
+        .unwrap();
+        drop(file);
+
+        let scanner = CostScanner::new(30);
+        let mut summary = CostSummary::default();
+        scanner.parse_codex_file(&path, &mut summary);
+
+        assert_eq!(summary.sessions_count, 1);
+        assert_eq!(summary.input_tokens, 125);
+        assert_eq!(summary.cached_tokens, 30);
+        assert_eq!(summary.output_tokens, 15);
+        assert_eq!(
+            summary
+                .by_model_tokens
+                .get("gpt-5")
+                .map(ModelTokenCounts::total),
+            Some(170)
+        );
+        assert!(scan_codex_file_cost(&path) > 0.0);
+        let _ = std::fs::remove_file(&path);
     }
 }

--- a/rust/src/cost_scanner.rs
+++ b/rust/src/cost_scanner.rs
@@ -9,6 +9,8 @@ use std::fs::{self, File};
 use std::io::{BufRead, BufReader};
 use std::path::PathBuf;
 
+use crate::core::CostUsagePricing;
+
 /// Cost summary from scanning local logs
 #[derive(Debug, Clone, Default)]
 pub struct CostSummary {
@@ -87,7 +89,10 @@ struct CodexPricing;
 
 impl CodexPricing {
     fn cost_usd(model: &str, input: u64, cached: u64, output: u64) -> f64 {
-        // Default to GPT-4o pricing
+        if let Some(cost) = CostUsagePricing::codex_cost_usd(model, input, cached, output) {
+            return cost;
+        }
+
         let (input_price, cached_price, output_price) = match model.to_lowercase().as_str() {
             m if m.contains("gpt-4o-mini") => (0.15, 0.075, 0.60),
             m if m.contains("gpt-4o") => (2.50, 1.25, 10.00),
@@ -98,7 +103,9 @@ impl CodexPricing {
             _ => (2.50, 1.25, 10.00), // Default to GPT-4o
         };
 
-        let input_cost = (input as f64 / 1_000_000.0) * input_price;
+        let cached = cached.min(input);
+        let non_cached = input.saturating_sub(cached);
+        let input_cost = (non_cached as f64 / 1_000_000.0) * input_price;
         let cached_cost = (cached as f64 / 1_000_000.0) * cached_price;
         let output_cost = (output as f64 / 1_000_000.0) * output_price;
 
@@ -644,6 +651,16 @@ mod tests {
         // Test GPT-4o pricing: $2.50/1M input, $10/1M output
         let cost = CodexPricing::cost_usd("gpt-4o", 1_000_000, 0, 1_000_000);
         assert!((cost - 12.50).abs() < 0.01);
+    }
+
+    #[test]
+    fn test_codex_pricing_uses_gpt55_standard_short_context_rates() {
+        let cost = CodexPricing::cost_usd("gpt-5.5", 1_000_000, 400_000, 1_000_000);
+
+        // GPT-5.5 standard short-context pricing:
+        // 600k non-cached input at $5/M, 400k cached input at $0.50/M,
+        // and 1M output at $30/M.
+        assert!((cost - 33.20).abs() < 0.01);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
Fixes local Codex token/cost scanning on Windows for current Codex CLI JSONL session logs.

Recent Codex CLI sessions write token-count records as top-level `event_msg` entries with a nested payload:
```markdown
```json
{
  "type": "event_msg",
  "payload": {
    "type": "token_count",
    "info": {
      "model": "gpt-5.5",
      "total_token_usage": {
        "input_tokens": 123,
        "cached_input_tokens": 45,
        "output_tokens": 6
      }
    }
  }
}
```

`Win-CodexBar` 0.29.2 was only looking for the older shape:

```json
{
  "event_msg": {
    "type": "token_count"
  }
}
```

Because of that, `codexbar cost -p codex` showed `No usage data found` even when `%USERPROFILE%\.codex\sessions` contained recent Codex JSONL logs.

## What Changed
- Added parsing support for current Codex CLI `payload.type = "token_count"` events.
- Handles cumulative `total_token_usage` by converting it into per-event deltas.
- Keeps compatibility with the older `event_msg.type = "token_count"` format.
- Reads model information from current `payload.info.model` / `payload.model` shapes.
- Applies the same parsing path to the daily Codex cost-history helper used by the desktop/Tauri UI.
- Adds regression coverage for the current Codex JSONL token-count format.

## Windows / App Context
This was reproduced on Windows with the Tauri Win-CodexBar app and local Codex CLI logs under:

```text
%USERPROFILE%\.codex\sessions
```

The tray app was able to show Codex quota usage from the API, but local token/cost scanning returned no token totals because the JSONL parser did not recognize the current Codex log format.

After this change, the local CLI cost scanner reports Codex input, cached, output, and total tokens again.

## Test Plan
- `cargo test --manifest-path rust\Cargo.toml`
- `cargo test --manifest-path apps\desktop-tauri\src-tauri\Cargo.toml`
- `cargo run -p codexbar -- cost -p codex`

## Notes
`cargo clippy --manifest-path rust\Cargo.toml --all-targets -- -D warnings` was also run, but it currently fails on an unrelated pre-existing Claude OAuth `collapsible_if` warning in:

```text
rust/src/providers/claude/oauth.rs:323
```