### PR TITLE
fix(antigravity): discover language-server API port on Windows

### DIFF
--- a/rust/src/providers/antigravity/mod.rs
+++ b/rust/src/providers/antigravity/mod.rs
@@ -49,7 +49,7 @@ impl AntigravityProvider {
         cmd.args([
                 "-ExecutionPolicy", "Bypass",
                 "-Command",
-                "Get-CimInstance Win32_Process | Where-Object { $_.Name -like '*language_server_windows*' } | Select-Object -ExpandProperty CommandLine"
+                "Get-CimInstance Win32_Process | Where-Object { $_.Name -like '*language_server_windows*' } | ForEach-Object { \"$($_.ProcessId)`t$($_.CommandLine)\" }"
             ]);
         #[cfg(windows)]
         cmd.creation_flags(CREATE_NO_WINDOW);
@@ -80,6 +80,13 @@ impl AntigravityProvider {
 
         for line in stdout.lines() {
             if line.contains("language_server_windows") && line.contains("--csrf_token") {
+                // Line is "<pid>\t<command line>"; split off the PID prefix we added so the
+                // PID can be used to enumerate the process's real listening ports below.
+                let (pid, line) = match line.split_once('\t') {
+                    Some((p, rest)) => (p.trim().parse::<u32>().ok(), rest),
+                    None => (None, line),
+                };
+
                 let csrf_token = csrf_regex
                     .captures(line)
                     .and_then(|c| c.get(1))
@@ -100,6 +107,7 @@ impl AntigravityProvider {
                         csrf_token: token,
                         extension_server_csrf_token: ext_csrf_token,
                         extension_port: p,
+                        pid,
                     });
                 }
             }
@@ -111,9 +119,13 @@ impl AntigravityProvider {
     }
 
     /// Find the actual API port by checking listening ports
-    async fn find_api_port(extension_port: u16) -> Result<u16, ProviderError> {
-        // The language server listens on multiple ports near the extension port
-        // Try ports in range extension_port to extension_port + 20
+    async fn find_api_port(extension_port: u16, pid: Option<u32>) -> Result<u16, ProviderError> {
+        // The language server binds a RANDOM localhost port at startup; --extension_server_port
+        // is only a reference point (and belongs to a separate HTTP extension server), so the
+        // real gRPC/Connect API port is not guaranteed to be within a small window above it.
+        // Mirror the macOS/Linux probe (which uses `lsof`) by enumerating the language-server
+        // process's own listening ports first, then fall back to the heuristic window and a
+        // few known ports.
         // SECURITY: TLS verification is disabled because the local language server uses
         // self-signed certificates. This is scoped to 127.0.0.1 only and the port range
         // is limited. We verify the server responds with the expected gRPC endpoint.
@@ -124,8 +136,30 @@ impl AntigravityProvider {
             .build()
             .map_err(|e| ProviderError::Other(e.to_string()))?;
 
-        for offset in 0..20 {
-            let port = extension_port + offset;
+        // 1) Probe the process's ACTUAL listening ports (Windows equivalent of `lsof`).
+        if let Some(pid) = pid {
+            for port in Self::listening_ports_for_pid(pid) {
+                let url = format!(
+                    "https://127.0.0.1:{}/exa.language_server_pb.LanguageServerService/GetUnleashData",
+                    port
+                );
+                if let Ok(resp) = client
+                    .post(&url)
+                    .header("Content-Type", "application/json")
+                    .header("Connect-Protocol-Version", "1")
+                    .body("{}")
+                    .send()
+                    .await
+                    && (resp.status().as_u16() == 200 || resp.status().as_u16() == 401)
+                {
+                    return Ok(port);
+                }
+            }
+        }
+
+        // 2) Heuristic window above the extension port (kept as a fallback).
+        for offset in 0..20u16 {
+            let port = extension_port.saturating_add(offset);
             let url = format!(
                 "https://127.0.0.1:{}/exa.language_server_pb.LanguageServerService/GetUnleashData",
                 port
@@ -147,7 +181,7 @@ impl AntigravityProvider {
             }
         }
 
-        // Fallback: try common ports
+        // 3) Fallback: try common ports
         for port in [53835, 53836, 53837, 53838, 53845, 53849] {
             let url = format!(
                 "https://127.0.0.1:{}/exa.language_server_pb.LanguageServerService/GetUnleashData",
@@ -171,10 +205,47 @@ impl AntigravityProvider {
         ))
     }
 
+    /// Enumerate the TCP ports a given PID is listening on (Windows `lsof` equivalent).
+    /// Uses Get-NetTCPConnection; returns an empty Vec on any failure so callers fall back
+    /// to the existing heuristics (no regression if the cmdlet is unavailable).
+    fn listening_ports_for_pid(pid: u32) -> Vec<u16> {
+        #[cfg(windows)]
+        const CREATE_NO_WINDOW: u32 = 0x08000000;
+
+        let mut cmd = Command::new("powershell.exe");
+        cmd.args([
+            "-ExecutionPolicy",
+            "Bypass",
+            "-Command",
+            &format!(
+                "Get-NetTCPConnection -OwningProcess {pid} -State Listen \
+                 -ErrorAction SilentlyContinue | Select-Object -ExpandProperty LocalPort"
+            ),
+        ]);
+        #[cfg(windows)]
+        cmd.creation_flags(CREATE_NO_WINDOW);
+
+        let Ok(output) = cmd.output() else {
+            return Vec::new();
+        };
+        if !output.status.success() {
+            return Vec::new();
+        }
+
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let mut ports: Vec<u16> = stdout
+            .lines()
+            .filter_map(|l| l.trim().parse::<u16>().ok())
+            .collect();
+        ports.sort_unstable();
+        ports.dedup();
+        ports
+    }
+
     /// Fetch user status from Antigravity API
     async fn fetch_user_status(&self) -> Result<UsageSnapshot, ProviderError> {
         let process_info = Self::detect_process_info()?;
-        let api_port = Self::find_api_port(process_info.extension_port).await?;
+        let api_port = Self::find_api_port(process_info.extension_port, process_info.pid).await?;
 
         // SECURITY: TLS verification disabled for local language server (see find_api_port)
         let client = reqwest::Client::builder()
@@ -309,6 +380,21 @@ impl AntigravityProvider {
             snapshot = snapshot.with_model_specific(ter);
         }
 
+        for (idx, config) in model_configs.iter().enumerate() {
+            let Some(quota) = &config.quota_info else {
+                continue;
+            };
+            let title = clean_model_label(&config.label);
+            if title.is_empty() {
+                continue;
+            }
+            snapshot = snapshot.with_extra_rate_window(
+                format!("model-{idx}"),
+                title,
+                rate_window_from_quota(quota),
+            );
+        }
+
         // Add plan info
         let plan_name = user_status
             .plan_status
@@ -364,6 +450,7 @@ struct ProcessInfo {
     csrf_token: String,
     extension_server_csrf_token: Option<String>,
     extension_port: u16,
+    pid: Option<u32>,
 }
 
 // API Response types
@@ -454,6 +541,14 @@ fn rate_window_from_quota(quota: &QuotaInfo) -> RateWindow {
     RateWindow::with_details(used_percent, None, None, quota.reset_time.clone())
 }
 
+fn clean_model_label(label: &str) -> String {
+    let mut out = label.trim().replace('_', " ");
+    while out.contains("  ") {
+        out = out.replace("  ", " ");
+    }
+    out
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -516,6 +611,12 @@ mod tests {
         assert!((sec.used_percent - 50.0).abs() < 0.1);
         let ter = snap.model_specific.unwrap();
         assert!((ter.used_percent - 10.0).abs() < 0.1);
+        assert_eq!(snap.extra_rate_windows.len(), 3);
+        assert!(
+            snap.extra_rate_windows
+                .iter()
+                .any(|window| window.title == "Gemini 2.5 Flash")
+        );
     }
 
     #[test]

--- a/rust/src/providers/antigravity/mod.rs
+++ b/rust/src/providers/antigravity/mod.rs
@@ -118,17 +118,18 @@ impl AntigravityProvider {
         ))
     }
 
-    /// Find the actual API port by checking listening ports
+    /// Find the actual API port by probing the language server's candidate ports.
     async fn find_api_port(extension_port: u16, pid: Option<u32>) -> Result<u16, ProviderError> {
         // The language server binds a RANDOM localhost port at startup; --extension_server_port
         // is only a reference point (and belongs to a separate HTTP extension server), so the
         // real gRPC/Connect API port is not guaranteed to be within a small window above it.
         // Mirror the macOS/Linux probe (which uses `lsof`) by enumerating the language-server
-        // process's own listening ports first, then fall back to the heuristic window and a
-        // few known ports.
-        // SECURITY: TLS verification is disabled because the local language server uses
-        // self-signed certificates. This is scoped to 127.0.0.1 only and the port range
-        // is limited. We verify the server responds with the expected gRPC endpoint.
+        // process's own listening ports first, then fall back to a heuristic window above the
+        // extension port and a few historically-seen ports.
+        //
+        // SECURITY: TLS verification is disabled because the local language server uses a
+        // self-signed certificate. This is scoped to 127.0.0.1 only; we confirm a port by
+        // checking that it answers the expected gRPC endpoint.
         let client = reqwest::Client::builder()
             .timeout(std::time::Duration::from_secs(2))
             .danger_accept_invalid_certs(true)
@@ -136,66 +137,23 @@ impl AntigravityProvider {
             .build()
             .map_err(|e| ProviderError::Other(e.to_string()))?;
 
-        // 1) Probe the process's ACTUAL listening ports (Windows equivalent of `lsof`).
+        // Ordered candidate ports: the process's real listening ports first (Windows
+        // equivalent of `lsof`), then the heuristic window above the extension port, then a
+        // few known ports as a last resort.
+        let mut candidates: Vec<u16> = Vec::new();
         if let Some(pid) = pid {
-            for port in Self::listening_ports_for_pid(pid) {
-                let url = format!(
-                    "https://127.0.0.1:{}/exa.language_server_pb.LanguageServerService/GetUnleashData",
-                    port
-                );
-                if let Ok(resp) = client
-                    .post(&url)
-                    .header("Content-Type", "application/json")
-                    .header("Connect-Protocol-Version", "1")
-                    .body("{}")
-                    .send()
-                    .await
-                    && (resp.status().as_u16() == 200 || resp.status().as_u16() == 401)
-                {
-                    return Ok(port);
-                }
-            }
+            candidates.extend(Self::listening_ports_for_pid(pid));
         }
+        candidates.extend((0..20u16).map(|offset| extension_port.saturating_add(offset)));
+        candidates.extend([53835, 53836, 53837, 53838, 53845, 53849]);
 
-        // 2) Heuristic window above the extension port (kept as a fallback).
-        for offset in 0..20u16 {
-            let port = extension_port.saturating_add(offset);
-            let url = format!(
-                "https://127.0.0.1:{}/exa.language_server_pb.LanguageServerService/GetUnleashData",
-                port
-            );
-
-            // Just check if the port responds (even with error)
-            if let Ok(resp) = client
-                .post(&url)
-                .header("Content-Type", "application/json")
-                .header("Connect-Protocol-Version", "1")
-                .body("{}")
-                .send()
-                .await
-            {
-                // If we get any response (even error), this is the API port
-                if resp.status().as_u16() == 200 || resp.status().as_u16() == 401 {
-                    return Ok(port);
-                }
+        let mut probed: Vec<u16> = Vec::new();
+        for port in candidates {
+            if probed.contains(&port) {
+                continue; // probe each port at most once
             }
-        }
-
-        // 3) Fallback: try common ports
-        for port in [53835, 53836, 53837, 53838, 53845, 53849] {
-            let url = format!(
-                "https://127.0.0.1:{}/exa.language_server_pb.LanguageServerService/GetUnleashData",
-                port
-            );
-            if let Ok(resp) = client
-                .post(&url)
-                .header("Content-Type", "application/json")
-                .header("Connect-Protocol-Version", "1")
-                .body("{}")
-                .send()
-                .await
-                && (resp.status().as_u16() == 200 || resp.status().as_u16() == 401)
-            {
+            probed.push(port);
+            if Self::probe_api_port(&client, port).await {
                 return Ok(port);
             }
         }
@@ -205,11 +163,34 @@ impl AntigravityProvider {
         ))
     }
 
+    /// Probe a single candidate port. Returns true if it answers the language server's
+    /// gRPC endpoint (HTTP 200 or 401).
+    async fn probe_api_port(client: &reqwest::Client, port: u16) -> bool {
+        let url = format!(
+            "https://127.0.0.1:{}/exa.language_server_pb.LanguageServerService/GetUnleashData",
+            port
+        );
+        match client
+            .post(&url)
+            .header("Content-Type", "application/json")
+            .header("Connect-Protocol-Version", "1")
+            .body("{}")
+            .send()
+            .await
+        {
+            Ok(resp) => {
+                let code = resp.status().as_u16();
+                code == 200 || code == 401
+            }
+            Err(_) => false,
+        }
+    }
+
     /// Enumerate the TCP ports a given PID is listening on (Windows `lsof` equivalent).
-    /// Uses Get-NetTCPConnection; returns an empty Vec on any failure so callers fall back
-    /// to the existing heuristics (no regression if the cmdlet is unavailable).
+    /// On Windows this uses `Get-NetTCPConnection`; it returns an empty list on any failure
+    /// so the caller deterministically falls back to the heuristic candidate ports.
+    #[cfg(windows)]
     fn listening_ports_for_pid(pid: u32) -> Vec<u16> {
-        #[cfg(windows)]
         const CREATE_NO_WINDOW: u32 = 0x08000000;
 
         let mut cmd = Command::new("powershell.exe");
@@ -222,7 +203,6 @@ impl AntigravityProvider {
                  -ErrorAction SilentlyContinue | Select-Object -ExpandProperty LocalPort"
             ),
         ]);
-        #[cfg(windows)]
         cmd.creation_flags(CREATE_NO_WINDOW);
 
         let Ok(output) = cmd.output() else {
@@ -240,6 +220,13 @@ impl AntigravityProvider {
         ports.sort_unstable();
         ports.dedup();
         ports
+    }
+
+    /// Non-Windows platforms have no `Get-NetTCPConnection`; return an empty list by design so
+    /// the caller falls back to the heuristic candidate ports.
+    #[cfg(not(windows))]
+    fn listening_ports_for_pid(_pid: u32) -> Vec<u16> {
+        Vec::new()
     }
 
     /// Fetch user status from Antigravity API
@@ -378,21 +365,6 @@ impl AntigravityProvider {
         }
         if let Some(ter) = tertiary {
             snapshot = snapshot.with_model_specific(ter);
-        }
-
-        for (idx, config) in model_configs.iter().enumerate() {
-            let Some(quota) = &config.quota_info else {
-                continue;
-            };
-            let title = clean_model_label(&config.label);
-            if title.is_empty() {
-                continue;
-            }
-            snapshot = snapshot.with_extra_rate_window(
-                format!("model-{idx}"),
-                title,
-                rate_window_from_quota(quota),
-            );
         }
 
         // Add plan info
@@ -541,14 +513,6 @@ fn rate_window_from_quota(quota: &QuotaInfo) -> RateWindow {
     RateWindow::with_details(used_percent, None, None, quota.reset_time.clone())
 }
 
-fn clean_model_label(label: &str) -> String {
-    let mut out = label.trim().replace('_', " ");
-    while out.contains("  ") {
-        out = out.replace("  ", " ");
-    }
-    out
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -611,12 +575,6 @@ mod tests {
         assert!((sec.used_percent - 50.0).abs() < 0.1);
         let ter = snap.model_specific.unwrap();
         assert!((ter.used_percent - 10.0).abs() < 0.1);
-        assert_eq!(snap.extra_rate_windows.len(), 3);
-        assert!(
-            snap.extra_rate_windows
-                .iter()
-                .any(|window| window.title == "Gemini 2.5 Flash")
-        );
     }
 
     #[test]


### PR DESCRIPTION
## Problem
On Windows the Antigravity provider fails with **"Could not find Antigravity API port"** and cannot show usage. `detect_process_info` correctly finds the `language_server_windows` process and its `--csrf_token` / `--extension_server_port`, but `find_api_port` only probes `extension_port + 0..20` plus a short hardcoded list. Antigravity (a Windsurf/Codeium fork) binds a **random** localhost port for its gRPC/Connect API, and `--extension_server_port` is only a reference point, so the real port is frequently outside that window. The macOS/Linux path already enumerates the process's listening ports via `lsof`; the Windows port was missing that step.

## Fix
- Capture the language-server PID in `detect_process_info`.
- - In `find_api_port`, enumerate the PID's real listening ports via `Get-NetTCPConnection -OwningProcess <pid> -State Listen` (the Windows `lsof` equivalent) and probe those first.
- - Keep the existing +20 window and hardcoded list as fallbacks; make the port math overflow-safe (`saturating_add`). If the cmdlet is unavailable the helper returns empty and behavior is unchanged (no regression).
Scope: 1 file (`rust/src/providers/antigravity/mod.rs`), no new dependencies, macOS/Linux behavior untouched.

## Testing
Verified on Windows:
- `cargo build` and `cargo test` pass.
- - With Antigravity running, `codexbar usage -p antigravity` now returns usage (Plan: Pro; Claude / Gemini Pro / Opus shown) instead of failing with "Could not find Antigravity API port".
---
## 問題
在 Windows 上 Antigravity 一直顯示「Could not find Antigravity API port」、無法顯示用量。`find_api_port` 只在 `extension_port + 0..20` 與一個寫死清單裡探測，但 Antigravity（Windsurf/Codeium 分支）的 gRPC API 會隨機綁定本機埠，真實埠常落在該範圍外。macOS/Linux 版本本來就用 `lsof` 列舉監聽埠，Windows 版漏了這步。

## 修法
擷取語言伺服器 PID，用 `Get-NetTCPConnection -OwningProcess <pid> -State Listen`（Windows 上等同 `lsof`）先列舉並探測真實監聽埠；保留原範圍與清單作為後援；埠運算改 `saturating_add`。若無此 cmdlet 則回退原行為。僅改 1 個檔案，不影響 macOS/Linux。

## 測試
已在 Windows 驗證：`cargo build`、`cargo test` 通過；Antigravity 開啟時 `codexbar usage -p antigravity` 能正常顯示用量（方案 Pro，Claude／Gemini Pro／Opus）。