### PR TITLE
Expand Alibaba Coding Plan regional support

### DIFF
--- a/apps/desktop-tauri/src-tauri/src/commands/provider_settings.rs
+++ b/apps/desktop-tauri/src-tauri/src/commands/provider_settings.rs
@@ -464,16 +464,13 @@ pub fn cookie_source_options_for(provider_id: &str, lang: Language) -> Vec<Cooki
 /// Empty vec means the provider has no region picker.
 pub fn region_options_for(provider_id: &str) -> Vec<RegionOption> {
     match provider_id {
-        "alibaba" => vec![
-            RegionOption {
-                value: "intl".to_string(),
-                label: "International (Model Studio)".to_string(),
-            },
-            RegionOption {
-                value: "cn".to_string(),
-                label: "China Mainland (Bailian)".to_string(),
-            },
-        ],
+        "alibaba" => codexbar::providers::AlibabaRegion::ALL
+            .iter()
+            .map(|region| RegionOption {
+                value: region.settings_value().to_string(),
+                label: region.display_name().to_string(),
+            })
+            .collect(),
         "zai" => vec![
             RegionOption {
                 value: "global".to_string(),

--- a/apps/desktop-tauri/src-tauri/src/commands/providers.rs
+++ b/apps/desktop-tauri/src-tauri/src/commands/providers.rs
@@ -97,6 +97,13 @@ pub(crate) fn provider_cookie_domain(id: ProviderId, settings: &Settings) -> Opt
             )),
         );
     }
+    if id == ProviderId::Alibaba {
+        return Some(
+            codexbar::providers::AlibabaProvider::cookie_domain_for_region(Some(
+                settings.api_region(id),
+            )),
+        );
+    }
     id.cookie_domain()
 }
 

--- a/apps/desktop-tauri/src-tauri/src/commands/tests.rs
+++ b/apps/desktop-tauri/src-tauri/src/commands/tests.rs
@@ -920,7 +920,7 @@ fn cookie_options_empty_for_providers_without_picker() {
 fn region_options_for_regional_provider() {
     let opts = super::region_options_for("alibaba");
     let values: Vec<_> = opts.iter().map(|o| o.value.as_str()).collect();
-    assert_eq!(values, vec!["intl", "cn"]);
+    assert_eq!(values, vec!["singapore", "us", "germany", "hongkong", "cn"]);
 }
 
 #[test]

--- a/rust/src/core/provider.rs
+++ b/rust/src/core/provider.rs
@@ -246,7 +246,9 @@ impl ProviderId {
             ProviderId::Augment => Some("app.augmentcode.com"),
             ProviderId::Amp => Some("sourcegraph.com"),
             ProviderId::Antigravity => Some("antigravity.ai"),
-            ProviderId::Alibaba => Some("tongyi.aliyun.com"),
+            ProviderId::Alibaba => {
+                Some(crate::providers::AlibabaRegion::Singapore.primary_cookie_domain())
+            }
             ProviderId::AlibabaTokenPlan => Some("bailian.console.aliyun.com"),
             ProviderId::Ollama => Some("ollama.com"),
             ProviderId::T3Chat => Some("t3.chat"),
@@ -715,7 +717,7 @@ mod tests {
         assert_eq!(ProviderId::Alibaba.display_name(), "Alibaba");
         assert_eq!(
             ProviderId::Alibaba.cookie_domain(),
-            Some("tongyi.aliyun.com")
+            Some("modelstudio.console.alibabacloud.com")
         );
         assert_eq!(
             ProviderId::from_cli_name("alibaba"),

--- a/rust/src/providers/alibaba/mod.rs
+++ b/rust/src/providers/alibaba/mod.rs
@@ -1,8 +1,25 @@
-//! Alibaba (Tongyi Qianwen) provider implementation
+//! Alibaba Cloud Model Studio – Coding Plan provider
 //!
-//! Fetches usage data from Tongyi Qianwen using browser cookies
+//! Uses the same-origin console data gateway (e.g.
+//! `modelstudio.console.alibabacloud.com` for the international regions), which
+//! is not protected by Alibaba's ISG bot detection.
+//!
+//! Flow:
+//!   1. GET the dashboard page to extract SEC_TOKEN from the page HTML.
+//!   2. POST to `/data/api.json` with the full params JSON and sec_token.
+//!
+//! Auth: browser cookies from the region's console domain.
+//!
+//! All region-specific behaviour (gateway, region code, cookie domains,
+//! dashboard URL and gateway request constants) lives in [`AlibabaRegion`],
+//! the single source of truth — mirroring the `MiniMaxRegion` pattern.
 
 use async_trait::async_trait;
+use chrono::{DateTime, TimeZone, Utc};
+use sha2::{Digest, Sha256};
+use std::collections::HashMap;
+use std::sync::{OnceLock, RwLock};
+use std::time::{Duration, Instant};
 
 use crate::browser::cookies::get_cookie_header;
 use crate::core::{
@@ -10,11 +27,226 @@ use crate::core::{
     RateWindow, SourceMode, UsageSnapshot,
 };
 
-const ALIBABA_INTL_COOKIE_DOMAIN: &str = "modelstudio.console.alibabacloud.com";
-const ALIBABA_CN_COOKIE_DOMAIN: &str = "bailian.console.aliyun.com";
-const ALIBABA_INTL_GATEWAY: &str = "https://modelstudio.console.alibabacloud.com";
-const ALIBABA_CN_GATEWAY: &str = "https://bailian.console.aliyun.com";
-const ALIBABA_LEGACY_DOMAIN: &str = "tongyi.aliyun.com";
+const USER_AGENT: &str = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) \
+    AppleWebKit/537.36 (KHTML, like Gecko) Chrome/149.0.0.0 Safari/537.36";
+
+/// How long a scraped SEC_TOKEN stays valid in the in-memory cache.
+const SEC_TOKEN_TTL: Duration = Duration::from_secs(25 * 60);
+
+// ─── Canonical region model ──────────────────────────────────────────────
+
+/// Per-platform request constants for the console data gateway. These differ
+/// between the international Model Studio console and the China-mainland
+/// Bailian console.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct AlibabaRequestProfile {
+    /// Base origin of the console data gateway (no trailing slash).
+    pub gateway: &'static str,
+    /// `action` gateway parameter.
+    pub api_action: &'static str,
+    /// `product` gateway parameter.
+    pub api_product: &'static str,
+    /// Fully-qualified gateway API method name.
+    pub api_method: &'static str,
+    /// Coding Plan commodity code queried.
+    pub commodity_code: &'static str,
+    /// `switchAgent` cornerstone parameter (fixed per console).
+    pub switch_agent: u64,
+    /// `switchUserType` cornerstone parameter (fixed per console).
+    pub switch_user_type: u64,
+    /// `consoleSite` cornerstone parameter.
+    pub console_site: &'static str,
+    /// `domain` cornerstone parameter (the console host).
+    pub console_domain: &'static str,
+}
+
+/// Verified request profile for the international Model Studio console
+/// (Singapore / US / Germany / Hong Kong share this — only the region code
+/// in the referer/feURL differs).
+const INTL_PROFILE: AlibabaRequestProfile = AlibabaRequestProfile {
+    gateway: "https://modelstudio.console.alibabacloud.com",
+    api_action: "IntlBroadScopeAspnGateway",
+    api_product: "sfm_bailian",
+    api_method: "zeldaEasy.broadscope-bailian.codingPlan.queryCodingPlanInstanceInfoV2",
+    commodity_code: "sfm_codingplan_public_intl",
+    switch_agent: 313762,
+    switch_user_type: 3,
+    console_site: "MODELSTUDIO_ALBABACLOUD",
+    console_domain: "modelstudio.console.alibabacloud.com",
+};
+
+/// Alibaba Coding Plan region — single source of truth for everything that
+/// varies by region: settings value, UI label, gateway, API region code,
+/// cookie domains, dashboard URL and gateway request constants.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AlibabaRegion {
+    Singapore,
+    UsEast,
+    Germany,
+    HongKong,
+    ChinaMainland,
+}
+
+impl AlibabaRegion {
+    /// Regions exposed in the settings UI.
+    ///
+    /// China Mainland routes to its own console gateway
+    /// (`bailian.console.alibabacloud.com`) and CN cookie domains — it never
+    /// shares the international endpoint. Its gateway request constants
+    /// (commodity code / action) currently inherit the international values
+    /// pending a verified China-mainland capture; see [`Self::request_profile`].
+    pub const ALL: &'static [AlibabaRegion] = &[
+        Self::Singapore,
+        Self::UsEast,
+        Self::Germany,
+        Self::HongKong,
+        Self::ChinaMainland,
+    ];
+
+    /// Parse the persisted `api_region` settings value (tolerant of aliases).
+    pub fn from_settings_value(value: Option<&str>) -> Self {
+        match value.unwrap_or_default().trim().to_lowercase().as_str() {
+            "us" | "us-east-1" | "useast" | "us-west-1" => Self::UsEast,
+            "germany" | "eu" | "eu-central-1" | "frankfurt" => Self::Germany,
+            "hongkong" | "hong-kong" | "hk" | "cn-hongkong" | "ap-east-1" => Self::HongKong,
+            "cn" | "china" | "china-mainland" | "china_mainland" | "mainland" => {
+                Self::ChinaMainland
+            }
+            // singapore / intl / ap-southeast-1 / unrecognised → Singapore
+            _ => Self::Singapore,
+        }
+    }
+
+    /// Canonical persisted settings value.
+    pub fn settings_value(self) -> &'static str {
+        match self {
+            Self::Singapore => "singapore",
+            Self::UsEast => "us",
+            Self::Germany => "germany",
+            Self::HongKong => "hongkong",
+            Self::ChinaMainland => "cn",
+        }
+    }
+
+    /// Human-readable label for the settings region picker.
+    pub fn display_name(self) -> &'static str {
+        match self {
+            Self::Singapore => "International – Singapore (ap-southeast-1)",
+            Self::UsEast => "International – US (us-east-1)",
+            Self::Germany => "International – Germany (eu-central-1)",
+            Self::HongKong => "International – Hong Kong (cn-hongkong)",
+            Self::ChinaMainland => "China Mainland (Bailian)",
+        }
+    }
+
+    /// Alibaba Cloud region code used in the dashboard path and referer.
+    pub fn region_code(self) -> &'static str {
+        match self {
+            Self::Singapore => "ap-southeast-1",
+            Self::UsEast => "us-east-1",
+            Self::Germany => "eu-central-1",
+            Self::HongKong => "cn-hongkong",
+            Self::ChinaMainland => "cn-hangzhou",
+        }
+    }
+
+    pub fn is_china(self) -> bool {
+        matches!(self, Self::ChinaMainland)
+    }
+
+    /// Browser cookie domains to try (in priority order) for auto-import.
+    pub fn cookie_domains(self) -> &'static [&'static str] {
+        match self {
+            Self::ChinaMainland => &["bailian.console.alibabacloud.com", "alibabacloud.com"],
+            _ => &["modelstudio.console.alibabacloud.com", "alibabacloud.com"],
+        }
+    }
+
+    /// Primary cookie domain shown in the browser-import hint.
+    pub fn primary_cookie_domain(self) -> &'static str {
+        self.cookie_domains()[0]
+    }
+
+    /// Per-platform gateway request constants.
+    pub fn request_profile(self) -> AlibabaRequestProfile {
+        match self {
+            Self::ChinaMainland => AlibabaRequestProfile {
+                gateway: "https://bailian.console.alibabacloud.com",
+                console_domain: "bailian.console.alibabacloud.com",
+                // The China-mainland console uses a different commodity code /
+                // action than the international plan; these inherit the intl
+                // values until a real CN request is captured. The gateway and
+                // cookie domains above are CN-correct, so CN cookies are never
+                // sent to the international endpoint.
+                ..INTL_PROFILE
+            },
+            _ => INTL_PROFILE,
+        }
+    }
+
+    /// Console data-gateway origin.
+    pub fn gateway(self) -> &'static str {
+        self.request_profile().gateway
+    }
+
+    /// Dashboard URL for the browser-import hint and the "open dashboard" link.
+    pub fn dashboard_url(self) -> String {
+        match self {
+            Self::ChinaMainland => self.gateway().to_string(),
+            _ => format!("{}/{}", self.gateway(), self.region_code()),
+        }
+    }
+}
+
+// ─── SEC_TOKEN cache (keyed by region + cookie identity) ─────────────────
+
+#[derive(Clone)]
+struct CachedSecToken {
+    token: String,
+    fetched_at: Instant,
+}
+
+fn token_cache() -> &'static RwLock<HashMap<String, CachedSecToken>> {
+    static CACHE: OnceLock<RwLock<HashMap<String, CachedSecToken>>> = OnceLock::new();
+    CACHE.get_or_init(|| RwLock::new(HashMap::new()))
+}
+
+/// Cache key bound to the real auth boundary: the region code plus a hash of
+/// the cookie header (account / cookie identity). Changing region, account,
+/// or cookies yields a different key, so a stale token is never reused.
+fn sec_token_cache_key(region_code: &str, cookies: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(cookies.as_bytes());
+    let digest = hasher.finalize();
+    let hex: String = digest.iter().take(8).map(|b| format!("{b:02x}")).collect();
+    format!("{region_code}:{hex}")
+}
+
+fn cached_sec_token(key: &str) -> Option<String> {
+    let cache = token_cache().read().ok()?;
+    let entry = cache.get(key)?;
+    (entry.fetched_at.elapsed() < SEC_TOKEN_TTL).then(|| entry.token.clone())
+}
+
+fn store_sec_token(key: &str, token: &str) {
+    if let Ok(mut cache) = token_cache().write() {
+        cache.insert(
+            key.to_string(),
+            CachedSecToken {
+                token: token.to_string(),
+                fetched_at: Instant::now(),
+            },
+        );
+    }
+}
+
+fn invalidate_sec_token(key: &str) {
+    if let Ok(mut cache) = token_cache().write() {
+        cache.remove(key);
+    }
+}
+
+// ─── Provider ────────────────────────────────────────────────────────────
 
 pub struct AlibabaProvider {
     metadata: ProviderMetadata,
@@ -26,148 +258,362 @@ impl AlibabaProvider {
             metadata: ProviderMetadata {
                 id: ProviderId::Alibaba,
                 display_name: "Alibaba",
-                session_label: "Daily",
-                weekly_label: "Monthly",
+                session_label: "5-Hour",
+                weekly_label: "Weekly",
                 supports_opus: false,
                 supports_credits: false,
                 default_enabled: false,
                 is_primary: false,
-                dashboard_url: Some("https://bailian.console.aliyun.com"),
+                dashboard_url: Some("https://modelstudio.console.alibabacloud.com"),
                 status_page_url: None,
             },
         }
     }
 
-    fn get_auth_cookies(
-        &self,
-        ctx: &FetchContext,
-    ) -> Result<(String, &'static str), ProviderError> {
-        if let Some(ref cookie_header) = ctx.manual_cookie_header
-            && !cookie_header.trim().is_empty()
-        {
-            // Guess region from cookie contents
-            let gateway = if cookie_header.contains("alibabacloud") {
-                ALIBABA_INTL_GATEWAY
-            } else {
-                ALIBABA_CN_GATEWAY
-            };
-            return Ok((cookie_header.clone(), gateway));
-        }
+    /// Resolve the [`AlibabaRegion`] from a settings value.
+    pub fn region_from_settings(value: Option<&str>) -> AlibabaRegion {
+        AlibabaRegion::from_settings_value(value)
+    }
 
-        // Try international domain first, then China mainland, then legacy
-        for (domain, gateway) in [
-            (ALIBABA_INTL_COOKIE_DOMAIN, ALIBABA_INTL_GATEWAY),
-            (ALIBABA_CN_COOKIE_DOMAIN, ALIBABA_CN_GATEWAY),
-            (ALIBABA_LEGACY_DOMAIN, ALIBABA_CN_GATEWAY),
-        ] {
-            if let Ok(cookies) = get_cookie_header(domain)
-                && !cookies.is_empty()
-            {
-                return Ok((cookies, gateway));
+    /// Cookie domain for the browser import UI, driven by the selected region.
+    pub fn cookie_domain_for_region(value: Option<&str>) -> &'static str {
+        Self::region_from_settings(value).primary_cookie_domain()
+    }
+
+    /// Dashboard URL for the selected region.
+    pub fn dashboard_url_for_region(value: Option<&str>) -> String {
+        Self::region_from_settings(value).dashboard_url()
+    }
+
+    fn resolve_cookies(&self, ctx: &FetchContext) -> Result<String, ProviderError> {
+        if let Some(ref manual) = ctx.manual_cookie_header {
+            let trimmed = manual.trim();
+            if !trimmed.is_empty() {
+                return Ok(trimmed.to_string());
             }
         }
-
+        let region = AlibabaRegion::from_settings_value(ctx.api_region.as_deref());
+        for domain in region.cookie_domains() {
+            match get_cookie_header(domain) {
+                Ok(cookies) if !cookies.is_empty() => return Ok(cookies),
+                _ => {}
+            }
+        }
         Err(ProviderError::AuthRequired)
     }
 
+    /// Return the SEC_TOKEN, using a region+account-keyed cache to avoid
+    /// fetching the dashboard page on every provider refresh. `force_fresh`
+    /// bypasses the cache (used when retrying after an auth failure).
+    async fn resolve_sec_token(
+        &self,
+        client: &reqwest::Client,
+        cookies: &str,
+        region: AlibabaRegion,
+        cache_key: &str,
+        force_fresh: bool,
+    ) -> Option<String> {
+        let cached = if force_fresh {
+            None
+        } else {
+            cached_sec_token(cache_key)
+        };
+        if let Some(token) = cached {
+            return Some(token);
+        }
+        let token = self.fetch_sec_token(client, cookies, region).await?;
+        store_sec_token(cache_key, &token);
+        Some(token)
+    }
+
+    async fn fetch_sec_token(
+        &self,
+        client: &reqwest::Client,
+        cookies: &str,
+        region: AlibabaRegion,
+    ) -> Option<String> {
+        let dashboard_url = format!("{}/{}?tab=plan", region.gateway(), region.region_code());
+        let resp = client
+            .get(&dashboard_url)
+            .header("Cookie", cookies)
+            .header("User-Agent", USER_AGENT)
+            .header(
+                "Accept",
+                "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+            )
+            .send()
+            .await
+            .ok()?;
+        if !resp.status().is_success() {
+            return extract_cookie_value("sec_token", cookies);
+        }
+        let html = resp.text().await.ok()?;
+        extract_sec_token(&html).or_else(|| extract_cookie_value("sec_token", cookies))
+    }
+
     async fn fetch_via_web(&self, ctx: &FetchContext) -> Result<UsageSnapshot, ProviderError> {
-        let (cookies, gateway) = self.get_auth_cookies(ctx)?;
+        let cookies = self.resolve_cookies(ctx)?;
+        let region = AlibabaRegion::from_settings_value(ctx.api_region.as_deref());
+        let cache_key = sec_token_cache_key(region.region_code(), &cookies);
 
         let client = reqwest::Client::builder()
-            .timeout(std::time::Duration::from_secs(30))
+            .timeout(std::time::Duration::from_secs(ctx.web_timeout.max(15)))
             .build()
             .map_err(|e| ProviderError::Other(e.to_string()))?;
 
+        // Try with a cached token first; on an auth failure the token may be
+        // stale or rotated, so invalidate it and retry once with a fresh one.
+        let mut force_fresh = false;
+        let mut last_err = ProviderError::AuthRequired;
+        for _attempt in 0..2 {
+            let sec_token = self
+                .resolve_sec_token(&client, &cookies, region, &cache_key, force_fresh)
+                .await;
+            match self
+                .request_quota(&client, &cookies, region, sec_token)
+                .await
+            {
+                Ok(usage) => return Ok(usage),
+                Err(ProviderError::AuthRequired) => {
+                    invalidate_sec_token(&cache_key);
+                    force_fresh = true;
+                    last_err = ProviderError::AuthRequired;
+                    continue;
+                }
+                Err(e) => return Err(e),
+            }
+        }
+        Err(last_err)
+    }
+
+    async fn request_quota(
+        &self,
+        client: &reqwest::Client,
+        cookies: &str,
+        region: AlibabaRegion,
+        sec_token: Option<String>,
+    ) -> Result<UsageSnapshot, ProviderError> {
+        let profile = region.request_profile();
+        let cna = extract_cookie_value("cna", cookies).unwrap_or_default();
+        let referer = format!("{}/{}?tab=plan", profile.gateway, region.region_code());
+        let fe_url = format!("{referer}#/efm/subscription/coding-plan");
+
+        let params = serde_json::json!({
+            "Api": profile.api_method,
+            "V": "1.0",
+            "Data": {
+                "queryCodingPlanInstanceInfoRequest": {
+                    "commodityCode": profile.commodity_code,
+                    "onlyLatestOne": true
+                },
+                "cornerstoneParam": {
+                    "feTraceId": uuid::Uuid::new_v4().to_string(),
+                    "feURL": fe_url,
+                    "protocol": "V2",
+                    "console": "ONE_CONSOLE",
+                    "productCode": "p_efm",
+                    "switchAgent": profile.switch_agent,
+                    "switchUserType": profile.switch_user_type,
+                    "domain": profile.console_domain,
+                    "consoleSite": profile.console_site,
+                    "userNickName": "",
+                    "userPrincipalName": "",
+                    "xsp_lang": "en-US",
+                    "X-Anonymous-Id": cna
+                }
+            }
+        });
+
+        let url = format!(
+            "{}/data/api.json?action={}&product={}",
+            profile.gateway, profile.api_action, profile.api_product
+        );
+
+        let mut form = vec![
+            ("action", profile.api_action.to_string()),
+            ("product", profile.api_product.to_string()),
+            ("api", profile.api_method.to_string()),
+            ("_v", "undefined".to_string()),
+            ("params", params.to_string()),
+        ];
+        if let Some(token) = sec_token.filter(|t| !t.is_empty()) {
+            form.push(("sec_token", token));
+        }
+
         let resp = client
-            .get(format!("{}/api/user/info", gateway))
-            .header("Cookie", &cookies)
-            .header("Accept", "application/json")
-            .header(
-                "User-Agent",
-                "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36",
-            )
+            .post(&url)
+            .header("Cookie", cookies)
+            .header("Content-Type", "application/x-www-form-urlencoded")
+            .header("Accept", "*/*")
+            .header("Origin", profile.gateway)
+            .header("Referer", &referer)
+            .header("User-Agent", USER_AGENT)
+            .header("sec-fetch-site", "same-origin")
+            .header("sec-fetch-mode", "cors")
+            .header("sec-fetch-dest", "empty")
+            .form(&form)
             .send()
             .await?;
 
-        if !resp.status().is_success() {
-            let status = resp.status();
-            if status.as_u16() == 401 || status.as_u16() == 403 {
+        let status = resp.status();
+        if status.as_u16() == 401 || status.as_u16() == 403 {
+            return Err(ProviderError::AuthRequired);
+        }
+        if !status.is_success() {
+            return Err(ProviderError::Other(format!("HTTP {status}")));
+        }
+
+        let body = resp.bytes().await?;
+
+        // Detect HTML login-redirect pages (may have leading whitespace before '<').
+        let first_nonws = body.iter().find(|&&b| !b.is_ascii_whitespace()).copied();
+        if first_nonws == Some(b'<') {
+            return Err(ProviderError::AuthRequired);
+        }
+
+        let json: serde_json::Value =
+            serde_json::from_slice(&body).map_err(|e| ProviderError::Parse(e.to_string()))?;
+
+        self.parse_response(&json)
+    }
+
+    fn parse_response(&self, json: &serde_json::Value) -> Result<UsageSnapshot, ProviderError> {
+        let top_code = json.get("code").and_then(|v| v.as_str()).unwrap_or("");
+        if !top_code.is_empty() && top_code != "200" {
+            if top_code == "401" || top_code == "403" {
                 return Err(ProviderError::AuthRequired);
             }
-            return Err(ProviderError::Other(format!("API error: {}", status)));
+            let msg = json
+                .get("message")
+                .and_then(|v| v.as_str())
+                .unwrap_or(top_code);
+            return Err(ProviderError::Other(format!("API error: {msg}")));
         }
 
-        let json: serde_json::Value = resp
-            .json()
-            .await
-            .map_err(|e| ProviderError::Parse(e.to_string()))?;
+        // Authorization failures arrive as a 200 with an error ret/code.
+        if let Some(ret) = json.pointer("/data/DataV2/ret").and_then(|v| v.as_array()) {
+            let joined: String = ret
+                .iter()
+                .filter_map(|v| v.as_str())
+                .collect::<Vec<_>>()
+                .join(";");
+            if joined.contains("No Authority")
+                || joined.contains("10032390")
+                || joined.contains("NeedLogin")
+            {
+                return Err(ProviderError::AuthRequired);
+            }
+        }
 
-        self.parse_usage_response(&json)
-    }
+        let instances = json
+            .pointer("/data/DataV2/data/data/codingPlanInstanceInfos")
+            .and_then(|v| v.as_array())
+            .ok_or_else(|| {
+                ProviderError::Parse("codingPlanInstanceInfos not found in response".into())
+            })?;
 
-    fn parse_usage_response(
-        &self,
-        json: &serde_json::Value,
-    ) -> Result<UsageSnapshot, ProviderError> {
-        let data = json.get("data").unwrap_or(json);
+        let instance = instances
+            .iter()
+            .find(|i| i.get("status").and_then(|s| s.as_str()) == Some("VALID"))
+            .or_else(|| instances.first())
+            .ok_or_else(|| ProviderError::Parse("no Coding Plan instance in response".into()))?;
 
-        let daily_used = data
-            .get("dailyUsed")
-            .or_else(|| data.get("daily_used"))
-            .and_then(|v| v.as_f64())
-            .unwrap_or(0.0);
-        let daily_limit = data
-            .get("dailyLimit")
-            .or_else(|| data.get("daily_limit"))
-            .and_then(|v| v.as_f64())
-            .unwrap_or(500.0);
-        let daily_percent = if daily_limit > 0.0 {
-            (daily_used / daily_limit) * 100.0
-        } else {
-            0.0
-        };
+        let quota = instance
+            .get("codingPlanQuotaInfo")
+            .ok_or_else(|| ProviderError::Parse("codingPlanQuotaInfo missing".into()))?;
 
-        let monthly_used = data
-            .get("monthlyUsed")
-            .or_else(|| data.get("monthly_used"))
-            .and_then(|v| v.as_f64())
-            .unwrap_or(0.0);
-        let monthly_limit = data
-            .get("monthlyLimit")
-            .or_else(|| data.get("monthly_limit"))
-            .and_then(|v| v.as_f64())
-            .unwrap_or(10000.0);
-        let monthly_percent = if monthly_limit > 0.0 {
-            (monthly_used / monthly_limit) * 100.0
-        } else {
-            0.0
-        };
-
-        let primary = RateWindow::new(daily_percent);
-        let secondary = RateWindow::new(monthly_percent);
-
-        let plan = data
-            .get("planName")
-            .or_else(|| data.get("plan_name"))
-            .or_else(|| data.get("vipType"))
+        let plan_name = instance
+            .get("instanceName")
             .and_then(|v| v.as_str())
-            .unwrap_or("Free");
+            .unwrap_or("Coding Plan");
 
-        let nickname = data
-            .get("nickname")
-            .or_else(|| data.get("userName"))
-            .and_then(|v| v.as_str());
+        let ms_to_dt = |key: &str| -> Option<DateTime<Utc>> {
+            quota
+                .get(key)
+                .and_then(|v| v.as_i64())
+                .and_then(|ms| Utc.timestamp_opt(ms / 1000, 0).single())
+        };
 
-        let mut usage = UsageSnapshot::new(primary)
-            .with_secondary(secondary)
-            .with_login_method(plan);
+        let pct = |used_key: &str, total_key: &str| -> f64 {
+            let used = quota.get(used_key).and_then(|v| v.as_f64()).unwrap_or(0.0);
+            let total = quota.get(total_key).and_then(|v| v.as_f64()).unwrap_or(1.0);
+            if total > 0.0 {
+                (used / total * 100.0).clamp(0.0, 100.0)
+            } else {
+                0.0
+            }
+        };
 
-        if let Some(name) = nickname {
-            usage = usage.with_email(name.to_string());
-        }
+        let detail = |used_key: &str, total_key: &str| -> Option<String> {
+            let used = quota.get(used_key).and_then(|v| v.as_f64())?;
+            let total = quota.get(total_key).and_then(|v| v.as_f64())?;
+            Some(format!(
+                "{} / {} tokens",
+                fmt_tokens(used as i64),
+                fmt_tokens(total as i64)
+            ))
+        };
 
-        Ok(usage)
+        let five_hour = RateWindow::with_details(
+            pct("per5HourUsedQuota", "per5HourTotalQuota"),
+            Some(300),
+            ms_to_dt("per5HourQuotaNextRefreshTime"),
+            detail("per5HourUsedQuota", "per5HourTotalQuota"),
+        );
+        let weekly = RateWindow::with_details(
+            pct("perWeekUsedQuota", "perWeekTotalQuota"),
+            Some(7 * 24 * 60),
+            ms_to_dt("perWeekQuotaNextRefreshTime"),
+            detail("perWeekUsedQuota", "perWeekTotalQuota"),
+        );
+        let monthly = RateWindow::with_details(
+            pct("perBillMonthUsedQuota", "perBillMonthTotalQuota"),
+            Some(30 * 24 * 60),
+            ms_to_dt("perBillMonthQuotaNextRefreshTime"),
+            detail("perBillMonthUsedQuota", "perBillMonthTotalQuota"),
+        );
+
+        Ok(UsageSnapshot::new(five_hour)
+            .with_secondary(weekly)
+            .with_tertiary(monthly)
+            .with_login_method(plan_name))
     }
+}
+
+fn extract_sec_token(html: &str) -> Option<String> {
+    let pos = html.find("SEC_TOKEN")?;
+    let rest = &html[pos + "SEC_TOKEN".len()..];
+    let start = rest.find('"')? + 1;
+    let rest = &rest[start..];
+    let end = rest.find('"')?;
+    let token = rest[..end].trim();
+    if token.is_empty() {
+        None
+    } else {
+        Some(token.to_string())
+    }
+}
+
+fn extract_cookie_value(name: &str, cookie_header: &str) -> Option<String> {
+    cookie_header.split(';').find_map(|part| {
+        let (key, value) = part.trim().split_once('=')?;
+        key.trim()
+            .eq_ignore_ascii_case(name)
+            .then(|| value.trim().to_string())
+            .filter(|v| !v.is_empty())
+    })
+}
+
+fn fmt_tokens(n: i64) -> String {
+    let s = n.to_string();
+    let mut out = String::with_capacity(s.len() + s.len() / 3);
+    for (i, ch) in s.chars().rev().enumerate() {
+        if i > 0 && i % 3 == 0 {
+            out.push(',');
+        }
+        out.push(ch);
+    }
+    out.chars().rev().collect()
 }
 
 impl Default for AlibabaProvider {
@@ -187,8 +633,7 @@ impl Provider for AlibabaProvider {
     }
 
     async fn fetch_usage(&self, ctx: &FetchContext) -> Result<ProviderFetchResult, ProviderError> {
-        tracing::debug!("Fetching Alibaba usage");
-
+        tracing::debug!(region = ?ctx.api_region, "Fetching Alibaba Coding Plan usage");
         match ctx.source_mode {
             SourceMode::Auto | SourceMode::Web => {
                 let usage = self.fetch_via_web(ctx).await?;
@@ -216,50 +661,203 @@ impl Provider for AlibabaProvider {
 mod tests {
     use super::*;
 
-    #[test]
-    fn test_parse_usage_response_standard() {
-        let provider = AlibabaProvider::new();
-        let json = serde_json::json!({
+    fn sample_response() -> serde_json::Value {
+        serde_json::json!({
+            "code": "200",
             "data": {
-                "dailyUsed": 50.0,
-                "dailyLimit": 500.0,
-                "monthlyUsed": 2000.0,
-                "monthlyLimit": 10000.0,
-                "planName": "Pro",
-                "nickname": "test_user"
+                "DataV2": {
+                    "data": {
+                        "data": {
+                            "codingPlanInstanceInfos": [{
+                                "instanceName": "Coding Plan Pro",
+                                "status": "VALID",
+                                "codingPlanQuotaInfo": {
+                                    "per5HourUsedQuota": 0,
+                                    "per5HourTotalQuota": 6000,
+                                    "per5HourQuotaNextRefreshTime": 1780731422000_i64,
+                                    "perWeekUsedQuota": 2019,
+                                    "perWeekTotalQuota": 45000,
+                                    "perWeekQuotaNextRefreshTime": 1780848000000_i64,
+                                    "perBillMonthUsedQuota": 25,
+                                    "perBillMonthTotalQuota": 90000,
+                                    "perBillMonthQuotaNextRefreshTime": 1783267200000_i64
+                                }
+                            }]
+                        }
+                    }
+                }
             }
-        });
-        let usage = provider.parse_usage_response(&json).unwrap();
-        assert!((usage.primary.used_percent - 10.0).abs() < 0.01);
-        assert!(usage.secondary.is_some());
-        let sec = usage.secondary.unwrap();
-        assert!((sec.used_percent - 20.0).abs() < 0.01);
-        assert_eq!(usage.login_method.as_deref(), Some("Pro"));
-        assert_eq!(usage.account_email.as_deref(), Some("test_user"));
+        })
     }
 
     #[test]
-    fn test_parse_usage_response_empty() {
+    fn parses_real_response_shape() {
         let provider = AlibabaProvider::new();
-        let json = serde_json::json!({});
-        let usage = provider.parse_usage_response(&json).unwrap();
-        assert!((usage.primary.used_percent - 0.0).abs() < 0.01);
+        let usage = provider.parse_response(&sample_response()).unwrap();
+
+        assert!((usage.primary.used_percent - 0.0).abs() < 0.01); // 5h: 0/6000
+        assert_eq!(usage.primary.window_minutes, Some(300));
+        assert!(usage.primary.resets_at.is_some());
+
+        let weekly = usage.secondary.unwrap();
+        assert!((weekly.used_percent - 4.487).abs() < 0.01); // 2019/45000
+
+        let monthly = usage.tertiary.unwrap();
+        assert!((monthly.used_percent - 0.028).abs() < 0.01); // 25/90000
+
+        assert_eq!(usage.login_method.as_deref(), Some("Coding Plan Pro"));
     }
 
     #[test]
-    fn test_parse_usage_response_snake_case() {
+    fn picks_valid_instance_over_first() {
         let provider = AlibabaProvider::new();
         let json = serde_json::json!({
-            "data": {
-                "daily_used": 100.0,
-                "daily_limit": 200.0,
-                "monthly_used": 5000.0,
-                "monthly_limit": 10000.0,
-                "plan_name": "Enterprise"
-            }
+            "code": "200",
+            "data": { "DataV2": { "data": { "data": {
+                "codingPlanInstanceInfos": [
+                    {
+                        "instanceName": "Expired",
+                        "status": "EXPIRED",
+                        "codingPlanQuotaInfo": {
+                            "per5HourUsedQuota": 100, "per5HourTotalQuota": 100,
+                            "perWeekUsedQuota": 100, "perWeekTotalQuota": 100,
+                            "perBillMonthUsedQuota": 100, "perBillMonthTotalQuota": 100
+                        }
+                    },
+                    {
+                        "instanceName": "Coding Plan Pro",
+                        "status": "VALID",
+                        "codingPlanQuotaInfo": {
+                            "per5HourUsedQuota": 0, "per5HourTotalQuota": 6000,
+                            "perWeekUsedQuota": 10, "perWeekTotalQuota": 45000,
+                            "perBillMonthUsedQuota": 25, "perBillMonthTotalQuota": 90000
+                        }
+                    }
+                ]
+            }}}}
         });
-        let usage = provider.parse_usage_response(&json).unwrap();
-        assert!((usage.primary.used_percent - 50.0).abs() < 0.01);
-        assert_eq!(usage.login_method.as_deref(), Some("Enterprise"));
+        let usage = provider.parse_response(&json).unwrap();
+        assert_eq!(usage.login_method.as_deref(), Some("Coding Plan Pro"));
+        assert!(usage.primary.used_percent < 1.0);
+    }
+
+    #[test]
+    fn no_authority_response_maps_to_auth_required() {
+        let provider = AlibabaProvider::new();
+        let json = serde_json::json!({
+            "code": "200",
+            "data": { "DataV2": { "ret": ["10032390::No Authority"], "data": {} } }
+        });
+        assert!(matches!(
+            provider.parse_response(&json),
+            Err(ProviderError::AuthRequired)
+        ));
+    }
+
+    #[test]
+    fn region_from_settings_value_round_trips() {
+        for region in AlibabaRegion::ALL {
+            assert_eq!(
+                AlibabaRegion::from_settings_value(Some(region.settings_value())),
+                *region
+            );
+        }
+        // Defaults and aliases.
+        assert_eq!(
+            AlibabaRegion::from_settings_value(None),
+            AlibabaRegion::Singapore
+        );
+        assert_eq!(
+            AlibabaRegion::from_settings_value(Some("intl")),
+            AlibabaRegion::Singapore
+        );
+        assert_eq!(
+            AlibabaRegion::from_settings_value(Some("cn")),
+            AlibabaRegion::ChinaMainland
+        );
+    }
+
+    #[test]
+    fn region_codes_are_correct() {
+        assert_eq!(AlibabaRegion::Singapore.region_code(), "ap-southeast-1");
+        assert_eq!(AlibabaRegion::UsEast.region_code(), "us-east-1");
+        assert_eq!(AlibabaRegion::Germany.region_code(), "eu-central-1");
+        assert_eq!(AlibabaRegion::HongKong.region_code(), "cn-hongkong");
+    }
+
+    #[test]
+    fn china_routes_to_its_own_gateway_and_cookies() {
+        // Regression for the review: CN must not ride the international gateway.
+        let cn = AlibabaRegion::ChinaMainland;
+        assert!(cn.is_china());
+        assert_eq!(cn.gateway(), "https://bailian.console.alibabacloud.com");
+        assert_ne!(cn.gateway(), AlibabaRegion::Singapore.gateway());
+        assert_eq!(
+            cn.primary_cookie_domain(),
+            "bailian.console.alibabacloud.com"
+        );
+        assert_ne!(
+            cn.primary_cookie_domain(),
+            AlibabaRegion::Singapore.primary_cookie_domain()
+        );
+    }
+
+    #[test]
+    fn international_regions_share_one_gateway() {
+        let intl = "https://modelstudio.console.alibabacloud.com";
+        for region in [
+            AlibabaRegion::Singapore,
+            AlibabaRegion::UsEast,
+            AlibabaRegion::Germany,
+            AlibabaRegion::HongKong,
+        ] {
+            assert_eq!(region.gateway(), intl);
+            assert!(!region.is_china());
+        }
+    }
+
+    #[test]
+    fn exposed_regions_include_china() {
+        assert!(AlibabaRegion::ALL.contains(&AlibabaRegion::ChinaMainland));
+        assert_eq!(AlibabaRegion::ALL.len(), 5);
+    }
+
+    #[test]
+    fn cookie_domain_for_region_mapping() {
+        assert_eq!(
+            AlibabaProvider::cookie_domain_for_region(None),
+            "modelstudio.console.alibabacloud.com"
+        );
+        assert_eq!(
+            AlibabaProvider::cookie_domain_for_region(Some("cn")),
+            "bailian.console.alibabacloud.com"
+        );
+    }
+
+    #[test]
+    fn sec_token_cache_key_distinguishes_region_and_cookies() {
+        let a = sec_token_cache_key("ap-southeast-1", "cookie=one");
+        let b = sec_token_cache_key("us-east-1", "cookie=one");
+        let c = sec_token_cache_key("ap-southeast-1", "cookie=two");
+        assert_ne!(a, b); // region changes the key
+        assert_ne!(a, c); // cookies change the key
+        assert_eq!(a, sec_token_cache_key("ap-southeast-1", "cookie=one")); // stable
+    }
+
+    #[test]
+    fn extract_sec_token_from_html() {
+        let html = r#"var config = { SEC_TOKEN: "AvLZTKds7DW5utd3p5xm48", OTHER: "x" };"#;
+        assert_eq!(
+            extract_sec_token(html).as_deref(),
+            Some("AvLZTKds7DW5utd3p5xm48")
+        );
+    }
+
+    #[test]
+    fn fmt_tokens_formats_correctly() {
+        assert_eq!(fmt_tokens(6000), "6,000");
+        assert_eq!(fmt_tokens(90000), "90,000");
+        assert_eq!(fmt_tokens(25), "25");
+        assert_eq!(fmt_tokens(1000000), "1,000,000");
     }
 }

--- a/rust/src/providers/alibaba/mod.rs
+++ b/rust/src/providers/alibaba/mod.rs
@@ -71,6 +71,9 @@ const INTL_PROFILE: AlibabaRequestProfile = AlibabaRequestProfile {
     commodity_code: "sfm_codingplan_public_intl",
     switch_agent: 313762,
     switch_user_type: 3,
+    // NOTE: this is Alibaba's own (misspelled) token — "ALBABACLOUD", not
+    // "ALIBABACLOUD". It is copied verbatim from a verified working capture;
+    // the gateway rejects the correctly-spelled value. Do NOT "fix" it.
     console_site: "MODELSTUDIO_ALBABACLOUD",
     console_domain: "modelstudio.console.alibabacloud.com",
 };
@@ -108,12 +111,23 @@ impl AlibabaRegion {
         match value.unwrap_or_default().trim().to_lowercase().as_str() {
             "us" | "us-east-1" | "useast" | "us-west-1" => Self::UsEast,
             "germany" | "eu" | "eu-central-1" | "frankfurt" => Self::Germany,
-            "hongkong" | "hong-kong" | "hk" | "cn-hongkong" | "ap-east-1" => Self::HongKong,
+            "hongkong" | "hong-kong" | "hk" | "cn-hongkong" => Self::HongKong,
             "cn" | "china" | "china-mainland" | "china_mainland" | "mainland" => {
                 Self::ChinaMainland
             }
-            // singapore / intl / ap-southeast-1 / unrecognised → Singapore
-            _ => Self::Singapore,
+            // Known aliases that explicitly map to Singapore.
+            "" | "singapore" | "intl" | "ap-southeast-1" | "international" => Self::Singapore,
+            // Unrecognised → Singapore (safe default) but log a warning so the
+            // fall-through isn't completely silent. A corrupted/typoed
+            // settings value should be visible in logs rather than silently
+            // changing the selected endpoint and cookie-domain hint.
+            other => {
+                tracing::warn!(
+                    value = other,
+                    "Unknown Alibaba api_region value; falling back to Singapore",
+                );
+                Self::Singapore
+            }
         }
     }
 
@@ -155,9 +169,19 @@ impl AlibabaRegion {
     }
 
     /// Browser cookie domains to try (in priority order) for auto-import.
+    ///
+    /// For China Mainland we try both `alibabacloud.com` and the legacy
+    /// `aliyun.com` Bailian hosts, because existing CN browser sessions may
+    /// have cookies scoped to either depending on which console URL the user
+    /// logged in through.
     pub fn cookie_domains(self) -> &'static [&'static str] {
         match self {
-            Self::ChinaMainland => &["bailian.console.alibabacloud.com", "alibabacloud.com"],
+            Self::ChinaMainland => &[
+                "bailian.console.alibabacloud.com",
+                "bailian.console.aliyun.com",
+                "alibabacloud.com",
+                "aliyun.com",
+            ],
             _ => &["modelstudio.console.alibabacloud.com", "alibabacloud.com"],
         }
     }
@@ -168,16 +192,17 @@ impl AlibabaRegion {
     }
 
     /// Per-platform gateway request constants.
+    ///
+    /// China Mainland routes to its own `bailian.console.alibabacloud.com`
+    /// gateway with CN cookie domains — never the international endpoint. Its
+    /// remaining request constants (commodity code / action / method) inherit
+    /// the international values; if the China-mainland console expects
+    /// different ones, replace them here once a real CN request is captured.
     pub fn request_profile(self) -> AlibabaRequestProfile {
         match self {
             Self::ChinaMainland => AlibabaRequestProfile {
                 gateway: "https://bailian.console.alibabacloud.com",
                 console_domain: "bailian.console.alibabacloud.com",
-                // The China-mainland console uses a different commodity code /
-                // action than the international plan; these inherit the intl
-                // values until a real CN request is captured. The gateway and
-                // cookie domains above are CN-correct, so CN cookies are never
-                // sent to the international endpoint.
                 ..INTL_PROFILE
             },
             _ => INTL_PROFILE,
@@ -211,14 +236,16 @@ fn token_cache() -> &'static RwLock<HashMap<String, CachedSecToken>> {
     CACHE.get_or_init(|| RwLock::new(HashMap::new()))
 }
 
-/// Cache key bound to the real auth boundary: the region code plus a hash of
-/// the cookie header (account / cookie identity). Changing region, account,
-/// or cookies yields a different key, so a stale token is never reused.
+/// Cache key bound to the real auth boundary: the region code plus a full
+/// SHA-256 hash of the cookie header (account / cookie identity). Changing
+/// region, account, or cookies yields a different key, so a stale token is
+/// never reused. The full digest is hex-encoded (no truncation) so the
+/// collision resistance the comment claims actually holds.
 fn sec_token_cache_key(region_code: &str, cookies: &str) -> String {
     let mut hasher = Sha256::new();
     hasher.update(cookies.as_bytes());
     let digest = hasher.finalize();
-    let hex: String = digest.iter().take(8).map(|b| format!("{b:02x}")).collect();
+    let hex: String = digest.iter().map(|b| format!("{b:02x}")).collect();
     format!("{region_code}:{hex}")
 }
 
@@ -230,6 +257,7 @@ fn cached_sec_token(key: &str) -> Option<String> {
 
 fn store_sec_token(key: &str, token: &str) {
     if let Ok(mut cache) = token_cache().write() {
+        cache.retain(|_, v| v.fetched_at.elapsed() < SEC_TOKEN_TTL);
         cache.insert(
             key.to_string(),
             CachedSecToken {
@@ -332,7 +360,7 @@ impl AlibabaProvider {
         cookies: &str,
         region: AlibabaRegion,
     ) -> Option<String> {
-        let dashboard_url = format!("{}/{}?tab=plan", region.gateway(), region.region_code());
+        let dashboard_url = format!("{}?tab=plan", region.dashboard_url());
         let resp = client
             .get(&dashboard_url)
             .header("Cookie", cookies)
@@ -345,15 +373,20 @@ impl AlibabaProvider {
             .await
             .ok()?;
         if !resp.status().is_success() {
-            return extract_cookie_value("sec_token", cookies);
+            tracing::debug!(
+                status = %resp.status(),
+                region = ?region,
+                "Alibaba dashboard fetch returned non-success; not falling back to cookie sec_token",
+            );
+            return None;
         }
         let html = resp.text().await.ok()?;
         extract_sec_token(&html).or_else(|| extract_cookie_value("sec_token", cookies))
     }
 
     async fn fetch_via_web(&self, ctx: &FetchContext) -> Result<UsageSnapshot, ProviderError> {
-        let cookies = self.resolve_cookies(ctx)?;
         let region = AlibabaRegion::from_settings_value(ctx.api_region.as_deref());
+        let cookies = self.resolve_cookies(ctx)?;
         let cache_key = sec_token_cache_key(region.region_code(), &cookies);
 
         let client = reqwest::Client::builder()
@@ -395,7 +428,7 @@ impl AlibabaProvider {
     ) -> Result<UsageSnapshot, ProviderError> {
         let profile = region.request_profile();
         let cna = extract_cookie_value("cna", cookies).unwrap_or_default();
-        let referer = format!("{}/{}?tab=plan", profile.gateway, region.region_code());
+        let referer = format!("{}?tab=plan", region.dashboard_url());
         let fe_url = format!("{referer}#/efm/subscription/coding-plan");
 
         let params = serde_json::json!({
@@ -425,16 +458,20 @@ impl AlibabaProvider {
         });
 
         let url = format!(
-            "{}/data/api.json?action={}&product={}",
+            "{}/data/api.json?action={}&product={}&_tag=",
             profile.gateway, profile.api_action, profile.api_product
         );
 
+        // Field order and the `region` field match a verified working capture.
+        // The Intl gateway uses `region` to resolve the `api` method against the
+        // correct regional registry — dropping it yields `ApiEndpointNotExist`.
         let mut form = vec![
             ("action", profile.api_action.to_string()),
             ("product", profile.api_product.to_string()),
             ("api", profile.api_method.to_string()),
             ("_v", "undefined".to_string()),
             ("params", params.to_string()),
+            ("region", region.region_code().to_string()),
         ];
         if let Some(token) = sec_token.filter(|t| !t.is_empty()) {
             form.push(("sec_token", token));
@@ -580,40 +617,101 @@ impl AlibabaProvider {
     }
 }
 
+/// Scan the dashboard HTML for a `SEC_TOKEN` assignment. Tries every
+/// occurrence of the `SEC_TOKEN` substring (so a leading mention in a
+/// comment, error string, or user-controllable nickname cannot poison the
+/// extraction), and accepts only a value that follows an `=` or `:`
+/// assignment with either single or double quoting and a sane charset.
 fn extract_sec_token(html: &str) -> Option<String> {
-    let pos = html.find("SEC_TOKEN")?;
-    let rest = &html[pos + "SEC_TOKEN".len()..];
-    let start = rest.find('"')? + 1;
-    let rest = &rest[start..];
-    let end = rest.find('"')?;
-    let token = rest[..end].trim();
-    if token.is_empty() {
-        None
-    } else {
-        Some(token.to_string())
+    const NEEDLE: &str = "SEC_TOKEN";
+    let mut search_from = 0;
+    while let Some(rel) = html[search_from..].find(NEEDLE) {
+        let pos = search_from + rel;
+        let after = &html[pos + NEEDLE.len()..];
+        if let Some(token) = parse_sec_token_value(after) {
+            return Some(token);
+        }
+        search_from = pos + NEEDLE.len();
     }
+    None
 }
 
+fn parse_sec_token_value(after_key: &str) -> Option<String> {
+    let mut chars = after_key.char_indices().peekable();
+    // Optional closing quote when the key itself was quoted (e.g. "SEC_TOKEN").
+    if matches!(chars.peek(), Some(&(_, '"' | '\''))) {
+        chars.next();
+    }
+    while let Some(&(_, c)) = chars.peek() {
+        if c.is_whitespace() {
+            chars.next();
+        } else {
+            break;
+        }
+    }
+    let assign = chars.next()?;
+    if assign.1 != ':' && assign.1 != '=' {
+        return None;
+    }
+    while let Some(&(_, c)) = chars.peek() {
+        if c.is_whitespace() {
+            chars.next();
+        } else {
+            break;
+        }
+    }
+    let (open_idx, open_quote) = chars.next()?;
+    if open_quote != '"' && open_quote != '\'' {
+        return None;
+    }
+    let value_start = open_idx + open_quote.len_utf8();
+    let value = &after_key[value_start..];
+    let end = value.find(open_quote)?;
+    let token = &value[..end];
+    if token.is_empty() || !is_valid_sec_token(token) {
+        return None;
+    }
+    Some(token.to_string())
+}
+
+fn is_valid_sec_token(token: &str) -> bool {
+    token.len() >= 8
+        && token.len() <= 256
+        && token
+            .bytes()
+            .all(|b| b.is_ascii_alphanumeric() || matches!(b, b'_' | b'-' | b'+' | b'/' | b'='))
+}
+
+/// Look up a cookie value by name from a `Cookie:` header.
+///
+/// Cookie names are case-sensitive per RFC 6265 §4.1.1, so this comparison
+/// is case-sensitive too. Trims surrounding whitespace from name/value but
+/// preserves case.
 fn extract_cookie_value(name: &str, cookie_header: &str) -> Option<String> {
     cookie_header.split(';').find_map(|part| {
         let (key, value) = part.trim().split_once('=')?;
-        key.trim()
-            .eq_ignore_ascii_case(name)
+        (key.trim() == name)
             .then(|| value.trim().to_string())
             .filter(|v| !v.is_empty())
     })
 }
 
 fn fmt_tokens(n: i64) -> String {
-    let s = n.to_string();
-    let mut out = String::with_capacity(s.len() + s.len() / 3);
-    for (i, ch) in s.chars().rev().enumerate() {
+    let negative = n < 0;
+    let magnitude = (n as i128).unsigned_abs();
+    let digits = magnitude.to_string();
+    let mut out = String::with_capacity(digits.len() + digits.len() / 3 + 1);
+    for (i, ch) in digits.chars().rev().enumerate() {
         if i > 0 && i % 3 == 0 {
             out.push(',');
         }
         out.push(ch);
     }
-    out.chars().rev().collect()
+    let mut result: String = out.chars().rev().collect();
+    if negative {
+        result.insert(0, '-');
+    }
+    result
 }
 
 impl Default for AlibabaProvider {
@@ -859,5 +957,117 @@ mod tests {
         assert_eq!(fmt_tokens(90000), "90,000");
         assert_eq!(fmt_tokens(25), "25");
         assert_eq!(fmt_tokens(1000000), "1,000,000");
+    }
+
+    #[test]
+    fn fmt_tokens_handles_negative_values() {
+        assert_eq!(fmt_tokens(-100), "-100");
+        assert_eq!(fmt_tokens(-1000), "-1,000");
+        assert_eq!(fmt_tokens(-1000000), "-1,000,000");
+        assert_eq!(fmt_tokens(-1), "-1");
+        assert_eq!(fmt_tokens(0), "0");
+        assert_eq!(fmt_tokens(i64::MIN), "-9,223,372,036,854,775,808");
+    }
+
+    #[test]
+    fn extract_cookie_value_is_case_sensitive() {
+        assert_eq!(
+            extract_cookie_value("sec_token", "sec_token=lower").as_deref(),
+            Some("lower"),
+        );
+        assert_eq!(extract_cookie_value("sec_token", "SEC_TOKEN=upper"), None);
+        assert_eq!(
+            extract_cookie_value("sec_token", "SEC_TOKEN=upper; sec_token=lower").as_deref(),
+            Some("lower"),
+            "case-sensitive: must match the exact lowercase cookie, not the uppercase one",
+        );
+    }
+
+    #[test]
+    fn extract_sec_token_handles_json_quoted_key() {
+        let html = r#"{"SEC_TOKEN":"AbcDefGhi123","other":1}"#;
+        assert_eq!(extract_sec_token(html).as_deref(), Some("AbcDefGhi123"));
+    }
+
+    #[test]
+    fn extract_sec_token_handles_single_quotes() {
+        let html = r#"window.SEC_TOKEN = 'AvLZTKds7DW5utd3p5xm48';"#;
+        assert_eq!(
+            extract_sec_token(html).as_deref(),
+            Some("AvLZTKds7DW5utd3p5xm48"),
+        );
+    }
+
+    #[test]
+    fn extract_sec_token_skips_decoy_occurrences() {
+        let html = r#"<!-- SEC_TOKEN missing on "deadbeef" -->
+            <script>var config = { SEC_TOKEN: "RealTokenValue1234" };</script>"#;
+        assert_eq!(
+            extract_sec_token(html).as_deref(),
+            Some("RealTokenValue1234"),
+            "must not return the decoy 'deadbeef' from the comment",
+        );
+    }
+
+    #[test]
+    fn extract_sec_token_rejects_invalid_charset() {
+        let html = r#"var x = { SEC_TOKEN: "bad token with spaces" };"#;
+        assert_eq!(extract_sec_token(html), None);
+    }
+
+    #[test]
+    fn extract_sec_token_rejects_too_short_value() {
+        let html = r#"var x = { SEC_TOKEN: "abc" };"#;
+        assert_eq!(extract_sec_token(html), None);
+    }
+
+    #[test]
+    fn china_cookie_domains_include_legacy_aliyun() {
+        let domains = AlibabaRegion::ChinaMainland.cookie_domains();
+        assert!(
+            domains.contains(&"bailian.console.aliyun.com"),
+            "legacy aliyun.com fallback must remain for upgrading users; got {domains:?}",
+        );
+        assert!(domains.contains(&"bailian.console.alibabacloud.com"));
+    }
+
+    #[test]
+    fn intl_console_site_matches_verified_capture() {
+        // Alibaba's gateway expects its own misspelled token ("ALBABACLOUD").
+        // This value is from a verified working request — a "spelling fix"
+        // here silently breaks the live quota call, which no unit test that
+        // avoids the network can catch. Pin it.
+        assert_eq!(INTL_PROFILE.console_site, "MODELSTUDIO_ALBABACLOUD");
+    }
+
+    #[test]
+    fn sec_token_cache_key_uses_full_sha256_hex() {
+        let key = sec_token_cache_key("ap-southeast-1", "cookie=value");
+        let (_region, hex) = key.split_once(':').expect("key must contain ':'");
+        assert_eq!(hex.len(), 64, "full SHA-256 hex is 64 characters");
+        assert!(hex.chars().all(|c| c.is_ascii_hexdigit()));
+    }
+
+    #[test]
+    fn ap_east_1_no_longer_aliases_to_hongkong() {
+        assert_eq!(
+            AlibabaRegion::from_settings_value(Some("ap-east-1")),
+            AlibabaRegion::Singapore,
+            "ap-east-1 is an AWS region code, not Alibaba's; removed as HK alias",
+        );
+    }
+
+    #[test]
+    fn dashboard_url_with_tab_is_consistent_across_regions() {
+        let intl_url = format!("{}?tab=plan", AlibabaRegion::Singapore.dashboard_url());
+        assert_eq!(
+            intl_url,
+            "https://modelstudio.console.alibabacloud.com/ap-southeast-1?tab=plan",
+        );
+        let cn_url = format!("{}?tab=plan", AlibabaRegion::ChinaMainland.dashboard_url());
+        assert_eq!(
+            cn_url, "https://bailian.console.alibabacloud.com?tab=plan",
+            "CN dashboard URL must NOT contain a region-code path segment",
+        );
     }
 }

--- a/rust/src/providers/alibaba/mod.rs
+++ b/rust/src/providers/alibaba/mod.rs
@@ -1,280 +1,31 @@
-//! Alibaba Cloud Model Studio – Coding Plan provider
-//!
-//! Uses the same-origin console data gateway (e.g.
-//! `modelstudio.console.alibabacloud.com` for the international regions), which
-//! is not protected by Alibaba's ISG bot detection.
+//! Alibaba Cloud Model Studio – Coding Plan provider.
 //!
 //! Flow:
-//!   1. GET the dashboard page to extract SEC_TOKEN from the page HTML.
-//!   2. POST to `/data/api.json` with the full params JSON and sec_token.
-//!
-//! Auth: browser cookies from the region's console domain.
-//!
-//! All region-specific behaviour (gateway, region code, cookie domains,
-//! dashboard URL and gateway request constants) lives in [`AlibabaRegion`],
-//! the single source of truth — mirroring the `MiniMaxRegion` pattern.
+//! 1. Resolve cookies for the selected Alibaba region.
+//! 2. Fetch a dashboard `SEC_TOKEN`, cached by region and cookie identity.
+//! 3. POST to the console data gateway and parse the Coding Plan quota payload.
+
+mod parser;
+mod region;
+mod sec_token;
 
 use async_trait::async_trait;
-use chrono::{DateTime, TimeZone, Utc};
-use sha2::{Digest, Sha256};
-use std::collections::HashMap;
-use std::sync::{OnceLock, RwLock};
-use std::time::{Duration, Instant};
 
 use crate::browser::cookies::get_cookie_header;
 use crate::core::{
     FetchContext, Provider, ProviderError, ProviderFetchResult, ProviderId, ProviderMetadata,
-    RateWindow, SourceMode, UsageSnapshot,
+    SourceMode, UsageSnapshot,
+};
+
+use self::parser::parse_response;
+pub use self::region::AlibabaRegion;
+use self::sec_token::{
+    cached_sec_token, extract_cookie_value, extract_sec_token, invalidate_sec_token,
+    sec_token_cache_key, store_sec_token,
 };
 
 const USER_AGENT: &str = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) \
     AppleWebKit/537.36 (KHTML, like Gecko) Chrome/149.0.0.0 Safari/537.36";
-
-/// How long a scraped SEC_TOKEN stays valid in the in-memory cache.
-const SEC_TOKEN_TTL: Duration = Duration::from_secs(25 * 60);
-
-// ─── Canonical region model ──────────────────────────────────────────────
-
-/// Per-platform request constants for the console data gateway. These differ
-/// between the international Model Studio console and the China-mainland
-/// Bailian console.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct AlibabaRequestProfile {
-    /// Base origin of the console data gateway (no trailing slash).
-    pub gateway: &'static str,
-    /// `action` gateway parameter.
-    pub api_action: &'static str,
-    /// `product` gateway parameter.
-    pub api_product: &'static str,
-    /// Fully-qualified gateway API method name.
-    pub api_method: &'static str,
-    /// Coding Plan commodity code queried.
-    pub commodity_code: &'static str,
-    /// `switchAgent` cornerstone parameter (fixed per console).
-    pub switch_agent: u64,
-    /// `switchUserType` cornerstone parameter (fixed per console).
-    pub switch_user_type: u64,
-    /// `consoleSite` cornerstone parameter.
-    pub console_site: &'static str,
-    /// `domain` cornerstone parameter (the console host).
-    pub console_domain: &'static str,
-}
-
-/// Verified request profile for the international Model Studio console
-/// (Singapore / US / Germany / Hong Kong share this — only the region code
-/// in the referer/feURL differs).
-const INTL_PROFILE: AlibabaRequestProfile = AlibabaRequestProfile {
-    gateway: "https://modelstudio.console.alibabacloud.com",
-    api_action: "IntlBroadScopeAspnGateway",
-    api_product: "sfm_bailian",
-    api_method: "zeldaEasy.broadscope-bailian.codingPlan.queryCodingPlanInstanceInfoV2",
-    commodity_code: "sfm_codingplan_public_intl",
-    switch_agent: 313762,
-    switch_user_type: 3,
-    // NOTE: this is Alibaba's own (misspelled) token — "ALBABACLOUD", not
-    // "ALIBABACLOUD". It is copied verbatim from a verified working capture;
-    // the gateway rejects the correctly-spelled value. Do NOT "fix" it.
-    console_site: "MODELSTUDIO_ALBABACLOUD",
-    console_domain: "modelstudio.console.alibabacloud.com",
-};
-
-/// Alibaba Coding Plan region — single source of truth for everything that
-/// varies by region: settings value, UI label, gateway, API region code,
-/// cookie domains, dashboard URL and gateway request constants.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum AlibabaRegion {
-    Singapore,
-    UsEast,
-    Germany,
-    HongKong,
-    ChinaMainland,
-}
-
-impl AlibabaRegion {
-    /// Regions exposed in the settings UI.
-    ///
-    /// China Mainland routes to its own console gateway
-    /// (`bailian.console.alibabacloud.com`) and CN cookie domains — it never
-    /// shares the international endpoint. Its gateway request constants
-    /// (commodity code / action) currently inherit the international values
-    /// pending a verified China-mainland capture; see [`Self::request_profile`].
-    pub const ALL: &'static [AlibabaRegion] = &[
-        Self::Singapore,
-        Self::UsEast,
-        Self::Germany,
-        Self::HongKong,
-        Self::ChinaMainland,
-    ];
-
-    /// Parse the persisted `api_region` settings value (tolerant of aliases).
-    pub fn from_settings_value(value: Option<&str>) -> Self {
-        match value.unwrap_or_default().trim().to_lowercase().as_str() {
-            "us" | "us-east-1" | "useast" | "us-west-1" => Self::UsEast,
-            "germany" | "eu" | "eu-central-1" | "frankfurt" => Self::Germany,
-            "hongkong" | "hong-kong" | "hk" | "cn-hongkong" => Self::HongKong,
-            "cn" | "china" | "china-mainland" | "china_mainland" | "mainland" => {
-                Self::ChinaMainland
-            }
-            // Known aliases that explicitly map to Singapore.
-            "" | "singapore" | "intl" | "ap-southeast-1" | "international" => Self::Singapore,
-            // Unrecognised → Singapore (safe default) but log a warning so the
-            // fall-through isn't completely silent. A corrupted/typoed
-            // settings value should be visible in logs rather than silently
-            // changing the selected endpoint and cookie-domain hint.
-            other => {
-                tracing::warn!(
-                    value = other,
-                    "Unknown Alibaba api_region value; falling back to Singapore",
-                );
-                Self::Singapore
-            }
-        }
-    }
-
-    /// Canonical persisted settings value.
-    pub fn settings_value(self) -> &'static str {
-        match self {
-            Self::Singapore => "singapore",
-            Self::UsEast => "us",
-            Self::Germany => "germany",
-            Self::HongKong => "hongkong",
-            Self::ChinaMainland => "cn",
-        }
-    }
-
-    /// Human-readable label for the settings region picker.
-    pub fn display_name(self) -> &'static str {
-        match self {
-            Self::Singapore => "International – Singapore (ap-southeast-1)",
-            Self::UsEast => "International – US (us-east-1)",
-            Self::Germany => "International – Germany (eu-central-1)",
-            Self::HongKong => "International – Hong Kong (cn-hongkong)",
-            Self::ChinaMainland => "China Mainland (Bailian)",
-        }
-    }
-
-    /// Alibaba Cloud region code used in the dashboard path and referer.
-    pub fn region_code(self) -> &'static str {
-        match self {
-            Self::Singapore => "ap-southeast-1",
-            Self::UsEast => "us-east-1",
-            Self::Germany => "eu-central-1",
-            Self::HongKong => "cn-hongkong",
-            Self::ChinaMainland => "cn-hangzhou",
-        }
-    }
-
-    pub fn is_china(self) -> bool {
-        matches!(self, Self::ChinaMainland)
-    }
-
-    /// Browser cookie domains to try (in priority order) for auto-import.
-    ///
-    /// For China Mainland we try both `alibabacloud.com` and the legacy
-    /// `aliyun.com` Bailian hosts, because existing CN browser sessions may
-    /// have cookies scoped to either depending on which console URL the user
-    /// logged in through.
-    pub fn cookie_domains(self) -> &'static [&'static str] {
-        match self {
-            Self::ChinaMainland => &[
-                "bailian.console.alibabacloud.com",
-                "bailian.console.aliyun.com",
-                "alibabacloud.com",
-                "aliyun.com",
-            ],
-            _ => &["modelstudio.console.alibabacloud.com", "alibabacloud.com"],
-        }
-    }
-
-    /// Primary cookie domain shown in the browser-import hint.
-    pub fn primary_cookie_domain(self) -> &'static str {
-        self.cookie_domains()[0]
-    }
-
-    /// Per-platform gateway request constants.
-    ///
-    /// China Mainland routes to its own `bailian.console.alibabacloud.com`
-    /// gateway with CN cookie domains — never the international endpoint. Its
-    /// remaining request constants (commodity code / action / method) inherit
-    /// the international values; if the China-mainland console expects
-    /// different ones, replace them here once a real CN request is captured.
-    pub fn request_profile(self) -> AlibabaRequestProfile {
-        match self {
-            Self::ChinaMainland => AlibabaRequestProfile {
-                gateway: "https://bailian.console.alibabacloud.com",
-                console_domain: "bailian.console.alibabacloud.com",
-                ..INTL_PROFILE
-            },
-            _ => INTL_PROFILE,
-        }
-    }
-
-    /// Console data-gateway origin.
-    pub fn gateway(self) -> &'static str {
-        self.request_profile().gateway
-    }
-
-    /// Dashboard URL for the browser-import hint and the "open dashboard" link.
-    pub fn dashboard_url(self) -> String {
-        match self {
-            Self::ChinaMainland => self.gateway().to_string(),
-            _ => format!("{}/{}", self.gateway(), self.region_code()),
-        }
-    }
-}
-
-// ─── SEC_TOKEN cache (keyed by region + cookie identity) ─────────────────
-
-#[derive(Clone)]
-struct CachedSecToken {
-    token: String,
-    fetched_at: Instant,
-}
-
-fn token_cache() -> &'static RwLock<HashMap<String, CachedSecToken>> {
-    static CACHE: OnceLock<RwLock<HashMap<String, CachedSecToken>>> = OnceLock::new();
-    CACHE.get_or_init(|| RwLock::new(HashMap::new()))
-}
-
-/// Cache key bound to the real auth boundary: the region code plus a full
-/// SHA-256 hash of the cookie header (account / cookie identity). Changing
-/// region, account, or cookies yields a different key, so a stale token is
-/// never reused. The full digest is hex-encoded (no truncation) so the
-/// collision resistance the comment claims actually holds.
-fn sec_token_cache_key(region_code: &str, cookies: &str) -> String {
-    let mut hasher = Sha256::new();
-    hasher.update(cookies.as_bytes());
-    let digest = hasher.finalize();
-    let hex: String = digest.iter().map(|b| format!("{b:02x}")).collect();
-    format!("{region_code}:{hex}")
-}
-
-fn cached_sec_token(key: &str) -> Option<String> {
-    let cache = token_cache().read().ok()?;
-    let entry = cache.get(key)?;
-    (entry.fetched_at.elapsed() < SEC_TOKEN_TTL).then(|| entry.token.clone())
-}
-
-fn store_sec_token(key: &str, token: &str) {
-    if let Ok(mut cache) = token_cache().write() {
-        cache.retain(|_, v| v.fetched_at.elapsed() < SEC_TOKEN_TTL);
-        cache.insert(
-            key.to_string(),
-            CachedSecToken {
-                token: token.to_string(),
-                fetched_at: Instant::now(),
-            },
-        );
-    }
-}
-
-fn invalidate_sec_token(key: &str) {
-    if let Ok(mut cache) = token_cache().write() {
-        cache.remove(key);
-    }
-}
-
-// ─── Provider ────────────────────────────────────────────────────────────
 
 pub struct AlibabaProvider {
     metadata: ProviderMetadata,
@@ -320,6 +71,7 @@ impl AlibabaProvider {
                 return Ok(trimmed.to_string());
             }
         }
+
         let region = AlibabaRegion::from_settings_value(ctx.api_region.as_deref());
         for domain in region.cookie_domains() {
             match get_cookie_header(domain) {
@@ -330,9 +82,6 @@ impl AlibabaProvider {
         Err(ProviderError::AuthRequired)
     }
 
-    /// Return the SEC_TOKEN, using a region+account-keyed cache to avoid
-    /// fetching the dashboard page on every provider refresh. `force_fresh`
-    /// bypasses the cache (used when retrying after an auth failure).
     async fn resolve_sec_token(
         &self,
         client: &reqwest::Client,
@@ -349,6 +98,7 @@ impl AlibabaProvider {
         if let Some(token) = cached {
             return Some(token);
         }
+
         let token = self.fetch_sec_token(client, cookies, region).await?;
         store_sec_token(cache_key, &token);
         Some(token)
@@ -380,6 +130,7 @@ impl AlibabaProvider {
             );
             return None;
         }
+
         let html = resp.text().await.ok()?;
         extract_sec_token(&html).or_else(|| extract_cookie_value("sec_token", cookies))
     }
@@ -394,8 +145,6 @@ impl AlibabaProvider {
             .build()
             .map_err(|e| ProviderError::Other(e.to_string()))?;
 
-        // Try with a cached token first; on an auth failure the token may be
-        // stale or rotated, so invalidate it and retry once with a fresh one.
         let mut force_fresh = false;
         let mut last_err = ProviderError::AuthRequired;
         for _attempt in 0..2 {
@@ -411,7 +160,6 @@ impl AlibabaProvider {
                     invalidate_sec_token(&cache_key);
                     force_fresh = true;
                     last_err = ProviderError::AuthRequired;
-                    continue;
                 }
                 Err(e) => return Err(e),
             }
@@ -462,9 +210,6 @@ impl AlibabaProvider {
             profile.gateway, profile.api_action, profile.api_product
         );
 
-        // Field order and the `region` field match a verified working capture.
-        // The Intl gateway uses `region` to resolve the `api` method against the
-        // correct regional registry — dropping it yields `ApiEndpointNotExist`.
         let mut form = vec![
             ("action", profile.api_action.to_string()),
             ("product", profile.api_product.to_string()),
@@ -501,8 +246,6 @@ impl AlibabaProvider {
         }
 
         let body = resp.bytes().await?;
-
-        // Detect HTML login-redirect pages (may have leading whitespace before '<').
         let first_nonws = body.iter().find(|&&b| !b.is_ascii_whitespace()).copied();
         if first_nonws == Some(b'<') {
             return Err(ProviderError::AuthRequired);
@@ -510,208 +253,8 @@ impl AlibabaProvider {
 
         let json: serde_json::Value =
             serde_json::from_slice(&body).map_err(|e| ProviderError::Parse(e.to_string()))?;
-
-        self.parse_response(&json)
+        parse_response(&json)
     }
-
-    fn parse_response(&self, json: &serde_json::Value) -> Result<UsageSnapshot, ProviderError> {
-        let top_code = json.get("code").and_then(|v| v.as_str()).unwrap_or("");
-        if !top_code.is_empty() && top_code != "200" {
-            if top_code == "401" || top_code == "403" {
-                return Err(ProviderError::AuthRequired);
-            }
-            let msg = json
-                .get("message")
-                .and_then(|v| v.as_str())
-                .unwrap_or(top_code);
-            return Err(ProviderError::Other(format!("API error: {msg}")));
-        }
-
-        // Authorization failures arrive as a 200 with an error ret/code.
-        if let Some(ret) = json.pointer("/data/DataV2/ret").and_then(|v| v.as_array()) {
-            let joined: String = ret
-                .iter()
-                .filter_map(|v| v.as_str())
-                .collect::<Vec<_>>()
-                .join(";");
-            if joined.contains("No Authority")
-                || joined.contains("10032390")
-                || joined.contains("NeedLogin")
-            {
-                return Err(ProviderError::AuthRequired);
-            }
-        }
-
-        let instances = json
-            .pointer("/data/DataV2/data/data/codingPlanInstanceInfos")
-            .and_then(|v| v.as_array())
-            .ok_or_else(|| {
-                ProviderError::Parse("codingPlanInstanceInfos not found in response".into())
-            })?;
-
-        let instance = instances
-            .iter()
-            .find(|i| i.get("status").and_then(|s| s.as_str()) == Some("VALID"))
-            .or_else(|| instances.first())
-            .ok_or_else(|| ProviderError::Parse("no Coding Plan instance in response".into()))?;
-
-        let quota = instance
-            .get("codingPlanQuotaInfo")
-            .ok_or_else(|| ProviderError::Parse("codingPlanQuotaInfo missing".into()))?;
-
-        let plan_name = instance
-            .get("instanceName")
-            .and_then(|v| v.as_str())
-            .unwrap_or("Coding Plan");
-
-        let ms_to_dt = |key: &str| -> Option<DateTime<Utc>> {
-            quota
-                .get(key)
-                .and_then(|v| v.as_i64())
-                .and_then(|ms| Utc.timestamp_opt(ms / 1000, 0).single())
-        };
-
-        let pct = |used_key: &str, total_key: &str| -> f64 {
-            let used = quota.get(used_key).and_then(|v| v.as_f64()).unwrap_or(0.0);
-            let total = quota.get(total_key).and_then(|v| v.as_f64()).unwrap_or(1.0);
-            if total > 0.0 {
-                (used / total * 100.0).clamp(0.0, 100.0)
-            } else {
-                0.0
-            }
-        };
-
-        let detail = |used_key: &str, total_key: &str| -> Option<String> {
-            let used = quota.get(used_key).and_then(|v| v.as_f64())?;
-            let total = quota.get(total_key).and_then(|v| v.as_f64())?;
-            Some(format!(
-                "{} / {} tokens",
-                fmt_tokens(used as i64),
-                fmt_tokens(total as i64)
-            ))
-        };
-
-        let five_hour = RateWindow::with_details(
-            pct("per5HourUsedQuota", "per5HourTotalQuota"),
-            Some(300),
-            ms_to_dt("per5HourQuotaNextRefreshTime"),
-            detail("per5HourUsedQuota", "per5HourTotalQuota"),
-        );
-        let weekly = RateWindow::with_details(
-            pct("perWeekUsedQuota", "perWeekTotalQuota"),
-            Some(7 * 24 * 60),
-            ms_to_dt("perWeekQuotaNextRefreshTime"),
-            detail("perWeekUsedQuota", "perWeekTotalQuota"),
-        );
-        let monthly = RateWindow::with_details(
-            pct("perBillMonthUsedQuota", "perBillMonthTotalQuota"),
-            Some(30 * 24 * 60),
-            ms_to_dt("perBillMonthQuotaNextRefreshTime"),
-            detail("perBillMonthUsedQuota", "perBillMonthTotalQuota"),
-        );
-
-        Ok(UsageSnapshot::new(five_hour)
-            .with_secondary(weekly)
-            .with_tertiary(monthly)
-            .with_login_method(plan_name))
-    }
-}
-
-/// Scan the dashboard HTML for a `SEC_TOKEN` assignment. Tries every
-/// occurrence of the `SEC_TOKEN` substring (so a leading mention in a
-/// comment, error string, or user-controllable nickname cannot poison the
-/// extraction), and accepts only a value that follows an `=` or `:`
-/// assignment with either single or double quoting and a sane charset.
-fn extract_sec_token(html: &str) -> Option<String> {
-    const NEEDLE: &str = "SEC_TOKEN";
-    let mut search_from = 0;
-    while let Some(rel) = html[search_from..].find(NEEDLE) {
-        let pos = search_from + rel;
-        let after = &html[pos + NEEDLE.len()..];
-        if let Some(token) = parse_sec_token_value(after) {
-            return Some(token);
-        }
-        search_from = pos + NEEDLE.len();
-    }
-    None
-}
-
-fn parse_sec_token_value(after_key: &str) -> Option<String> {
-    let mut chars = after_key.char_indices().peekable();
-    // Optional closing quote when the key itself was quoted (e.g. "SEC_TOKEN").
-    if matches!(chars.peek(), Some(&(_, '"' | '\''))) {
-        chars.next();
-    }
-    while let Some(&(_, c)) = chars.peek() {
-        if c.is_whitespace() {
-            chars.next();
-        } else {
-            break;
-        }
-    }
-    let assign = chars.next()?;
-    if assign.1 != ':' && assign.1 != '=' {
-        return None;
-    }
-    while let Some(&(_, c)) = chars.peek() {
-        if c.is_whitespace() {
-            chars.next();
-        } else {
-            break;
-        }
-    }
-    let (open_idx, open_quote) = chars.next()?;
-    if open_quote != '"' && open_quote != '\'' {
-        return None;
-    }
-    let value_start = open_idx + open_quote.len_utf8();
-    let value = &after_key[value_start..];
-    let end = value.find(open_quote)?;
-    let token = &value[..end];
-    if token.is_empty() || !is_valid_sec_token(token) {
-        return None;
-    }
-    Some(token.to_string())
-}
-
-fn is_valid_sec_token(token: &str) -> bool {
-    token.len() >= 8
-        && token.len() <= 256
-        && token
-            .bytes()
-            .all(|b| b.is_ascii_alphanumeric() || matches!(b, b'_' | b'-' | b'+' | b'/' | b'='))
-}
-
-/// Look up a cookie value by name from a `Cookie:` header.
-///
-/// Cookie names are case-sensitive per RFC 6265 §4.1.1, so this comparison
-/// is case-sensitive too. Trims surrounding whitespace from name/value but
-/// preserves case.
-fn extract_cookie_value(name: &str, cookie_header: &str) -> Option<String> {
-    cookie_header.split(';').find_map(|part| {
-        let (key, value) = part.trim().split_once('=')?;
-        (key.trim() == name)
-            .then(|| value.trim().to_string())
-            .filter(|v| !v.is_empty())
-    })
-}
-
-fn fmt_tokens(n: i64) -> String {
-    let negative = n < 0;
-    let magnitude = (n as i128).unsigned_abs();
-    let digits = magnitude.to_string();
-    let mut out = String::with_capacity(digits.len() + digits.len() / 3 + 1);
-    for (i, ch) in digits.chars().rev().enumerate() {
-        if i > 0 && i % 3 == 0 {
-            out.push(',');
-        }
-        out.push(ch);
-    }
-    let mut result: String = out.chars().rev().collect();
-    if negative {
-        result.insert(0, '-');
-    }
-    result
 }
 
 impl Default for AlibabaProvider {
@@ -759,167 +302,6 @@ impl Provider for AlibabaProvider {
 mod tests {
     use super::*;
 
-    fn sample_response() -> serde_json::Value {
-        serde_json::json!({
-            "code": "200",
-            "data": {
-                "DataV2": {
-                    "data": {
-                        "data": {
-                            "codingPlanInstanceInfos": [{
-                                "instanceName": "Coding Plan Pro",
-                                "status": "VALID",
-                                "codingPlanQuotaInfo": {
-                                    "per5HourUsedQuota": 0,
-                                    "per5HourTotalQuota": 6000,
-                                    "per5HourQuotaNextRefreshTime": 1780731422000_i64,
-                                    "perWeekUsedQuota": 2019,
-                                    "perWeekTotalQuota": 45000,
-                                    "perWeekQuotaNextRefreshTime": 1780848000000_i64,
-                                    "perBillMonthUsedQuota": 25,
-                                    "perBillMonthTotalQuota": 90000,
-                                    "perBillMonthQuotaNextRefreshTime": 1783267200000_i64
-                                }
-                            }]
-                        }
-                    }
-                }
-            }
-        })
-    }
-
-    #[test]
-    fn parses_real_response_shape() {
-        let provider = AlibabaProvider::new();
-        let usage = provider.parse_response(&sample_response()).unwrap();
-
-        assert!((usage.primary.used_percent - 0.0).abs() < 0.01); // 5h: 0/6000
-        assert_eq!(usage.primary.window_minutes, Some(300));
-        assert!(usage.primary.resets_at.is_some());
-
-        let weekly = usage.secondary.unwrap();
-        assert!((weekly.used_percent - 4.487).abs() < 0.01); // 2019/45000
-
-        let monthly = usage.tertiary.unwrap();
-        assert!((monthly.used_percent - 0.028).abs() < 0.01); // 25/90000
-
-        assert_eq!(usage.login_method.as_deref(), Some("Coding Plan Pro"));
-    }
-
-    #[test]
-    fn picks_valid_instance_over_first() {
-        let provider = AlibabaProvider::new();
-        let json = serde_json::json!({
-            "code": "200",
-            "data": { "DataV2": { "data": { "data": {
-                "codingPlanInstanceInfos": [
-                    {
-                        "instanceName": "Expired",
-                        "status": "EXPIRED",
-                        "codingPlanQuotaInfo": {
-                            "per5HourUsedQuota": 100, "per5HourTotalQuota": 100,
-                            "perWeekUsedQuota": 100, "perWeekTotalQuota": 100,
-                            "perBillMonthUsedQuota": 100, "perBillMonthTotalQuota": 100
-                        }
-                    },
-                    {
-                        "instanceName": "Coding Plan Pro",
-                        "status": "VALID",
-                        "codingPlanQuotaInfo": {
-                            "per5HourUsedQuota": 0, "per5HourTotalQuota": 6000,
-                            "perWeekUsedQuota": 10, "perWeekTotalQuota": 45000,
-                            "perBillMonthUsedQuota": 25, "perBillMonthTotalQuota": 90000
-                        }
-                    }
-                ]
-            }}}}
-        });
-        let usage = provider.parse_response(&json).unwrap();
-        assert_eq!(usage.login_method.as_deref(), Some("Coding Plan Pro"));
-        assert!(usage.primary.used_percent < 1.0);
-    }
-
-    #[test]
-    fn no_authority_response_maps_to_auth_required() {
-        let provider = AlibabaProvider::new();
-        let json = serde_json::json!({
-            "code": "200",
-            "data": { "DataV2": { "ret": ["10032390::No Authority"], "data": {} } }
-        });
-        assert!(matches!(
-            provider.parse_response(&json),
-            Err(ProviderError::AuthRequired)
-        ));
-    }
-
-    #[test]
-    fn region_from_settings_value_round_trips() {
-        for region in AlibabaRegion::ALL {
-            assert_eq!(
-                AlibabaRegion::from_settings_value(Some(region.settings_value())),
-                *region
-            );
-        }
-        // Defaults and aliases.
-        assert_eq!(
-            AlibabaRegion::from_settings_value(None),
-            AlibabaRegion::Singapore
-        );
-        assert_eq!(
-            AlibabaRegion::from_settings_value(Some("intl")),
-            AlibabaRegion::Singapore
-        );
-        assert_eq!(
-            AlibabaRegion::from_settings_value(Some("cn")),
-            AlibabaRegion::ChinaMainland
-        );
-    }
-
-    #[test]
-    fn region_codes_are_correct() {
-        assert_eq!(AlibabaRegion::Singapore.region_code(), "ap-southeast-1");
-        assert_eq!(AlibabaRegion::UsEast.region_code(), "us-east-1");
-        assert_eq!(AlibabaRegion::Germany.region_code(), "eu-central-1");
-        assert_eq!(AlibabaRegion::HongKong.region_code(), "cn-hongkong");
-    }
-
-    #[test]
-    fn china_routes_to_its_own_gateway_and_cookies() {
-        // Regression for the review: CN must not ride the international gateway.
-        let cn = AlibabaRegion::ChinaMainland;
-        assert!(cn.is_china());
-        assert_eq!(cn.gateway(), "https://bailian.console.alibabacloud.com");
-        assert_ne!(cn.gateway(), AlibabaRegion::Singapore.gateway());
-        assert_eq!(
-            cn.primary_cookie_domain(),
-            "bailian.console.alibabacloud.com"
-        );
-        assert_ne!(
-            cn.primary_cookie_domain(),
-            AlibabaRegion::Singapore.primary_cookie_domain()
-        );
-    }
-
-    #[test]
-    fn international_regions_share_one_gateway() {
-        let intl = "https://modelstudio.console.alibabacloud.com";
-        for region in [
-            AlibabaRegion::Singapore,
-            AlibabaRegion::UsEast,
-            AlibabaRegion::Germany,
-            AlibabaRegion::HongKong,
-        ] {
-            assert_eq!(region.gateway(), intl);
-            assert!(!region.is_china());
-        }
-    }
-
-    #[test]
-    fn exposed_regions_include_china() {
-        assert!(AlibabaRegion::ALL.contains(&AlibabaRegion::ChinaMainland));
-        assert_eq!(AlibabaRegion::ALL.len(), 5);
-    }
-
     #[test]
     fn cookie_domain_for_region_mapping() {
         assert_eq!(
@@ -929,145 +311,6 @@ mod tests {
         assert_eq!(
             AlibabaProvider::cookie_domain_for_region(Some("cn")),
             "bailian.console.alibabacloud.com"
-        );
-    }
-
-    #[test]
-    fn sec_token_cache_key_distinguishes_region_and_cookies() {
-        let a = sec_token_cache_key("ap-southeast-1", "cookie=one");
-        let b = sec_token_cache_key("us-east-1", "cookie=one");
-        let c = sec_token_cache_key("ap-southeast-1", "cookie=two");
-        assert_ne!(a, b); // region changes the key
-        assert_ne!(a, c); // cookies change the key
-        assert_eq!(a, sec_token_cache_key("ap-southeast-1", "cookie=one")); // stable
-    }
-
-    #[test]
-    fn extract_sec_token_from_html() {
-        let html = r#"var config = { SEC_TOKEN: "AvLZTKds7DW5utd3p5xm48", OTHER: "x" };"#;
-        assert_eq!(
-            extract_sec_token(html).as_deref(),
-            Some("AvLZTKds7DW5utd3p5xm48")
-        );
-    }
-
-    #[test]
-    fn fmt_tokens_formats_correctly() {
-        assert_eq!(fmt_tokens(6000), "6,000");
-        assert_eq!(fmt_tokens(90000), "90,000");
-        assert_eq!(fmt_tokens(25), "25");
-        assert_eq!(fmt_tokens(1000000), "1,000,000");
-    }
-
-    #[test]
-    fn fmt_tokens_handles_negative_values() {
-        assert_eq!(fmt_tokens(-100), "-100");
-        assert_eq!(fmt_tokens(-1000), "-1,000");
-        assert_eq!(fmt_tokens(-1000000), "-1,000,000");
-        assert_eq!(fmt_tokens(-1), "-1");
-        assert_eq!(fmt_tokens(0), "0");
-        assert_eq!(fmt_tokens(i64::MIN), "-9,223,372,036,854,775,808");
-    }
-
-    #[test]
-    fn extract_cookie_value_is_case_sensitive() {
-        assert_eq!(
-            extract_cookie_value("sec_token", "sec_token=lower").as_deref(),
-            Some("lower"),
-        );
-        assert_eq!(extract_cookie_value("sec_token", "SEC_TOKEN=upper"), None);
-        assert_eq!(
-            extract_cookie_value("sec_token", "SEC_TOKEN=upper; sec_token=lower").as_deref(),
-            Some("lower"),
-            "case-sensitive: must match the exact lowercase cookie, not the uppercase one",
-        );
-    }
-
-    #[test]
-    fn extract_sec_token_handles_json_quoted_key() {
-        let html = r#"{"SEC_TOKEN":"AbcDefGhi123","other":1}"#;
-        assert_eq!(extract_sec_token(html).as_deref(), Some("AbcDefGhi123"));
-    }
-
-    #[test]
-    fn extract_sec_token_handles_single_quotes() {
-        let html = r#"window.SEC_TOKEN = 'AvLZTKds7DW5utd3p5xm48';"#;
-        assert_eq!(
-            extract_sec_token(html).as_deref(),
-            Some("AvLZTKds7DW5utd3p5xm48"),
-        );
-    }
-
-    #[test]
-    fn extract_sec_token_skips_decoy_occurrences() {
-        let html = r#"<!-- SEC_TOKEN missing on "deadbeef" -->
-            <script>var config = { SEC_TOKEN: "RealTokenValue1234" };</script>"#;
-        assert_eq!(
-            extract_sec_token(html).as_deref(),
-            Some("RealTokenValue1234"),
-            "must not return the decoy 'deadbeef' from the comment",
-        );
-    }
-
-    #[test]
-    fn extract_sec_token_rejects_invalid_charset() {
-        let html = r#"var x = { SEC_TOKEN: "bad token with spaces" };"#;
-        assert_eq!(extract_sec_token(html), None);
-    }
-
-    #[test]
-    fn extract_sec_token_rejects_too_short_value() {
-        let html = r#"var x = { SEC_TOKEN: "abc" };"#;
-        assert_eq!(extract_sec_token(html), None);
-    }
-
-    #[test]
-    fn china_cookie_domains_include_legacy_aliyun() {
-        let domains = AlibabaRegion::ChinaMainland.cookie_domains();
-        assert!(
-            domains.contains(&"bailian.console.aliyun.com"),
-            "legacy aliyun.com fallback must remain for upgrading users; got {domains:?}",
-        );
-        assert!(domains.contains(&"bailian.console.alibabacloud.com"));
-    }
-
-    #[test]
-    fn intl_console_site_matches_verified_capture() {
-        // Alibaba's gateway expects its own misspelled token ("ALBABACLOUD").
-        // This value is from a verified working request — a "spelling fix"
-        // here silently breaks the live quota call, which no unit test that
-        // avoids the network can catch. Pin it.
-        assert_eq!(INTL_PROFILE.console_site, "MODELSTUDIO_ALBABACLOUD");
-    }
-
-    #[test]
-    fn sec_token_cache_key_uses_full_sha256_hex() {
-        let key = sec_token_cache_key("ap-southeast-1", "cookie=value");
-        let (_region, hex) = key.split_once(':').expect("key must contain ':'");
-        assert_eq!(hex.len(), 64, "full SHA-256 hex is 64 characters");
-        assert!(hex.chars().all(|c| c.is_ascii_hexdigit()));
-    }
-
-    #[test]
-    fn ap_east_1_no_longer_aliases_to_hongkong() {
-        assert_eq!(
-            AlibabaRegion::from_settings_value(Some("ap-east-1")),
-            AlibabaRegion::Singapore,
-            "ap-east-1 is an AWS region code, not Alibaba's; removed as HK alias",
-        );
-    }
-
-    #[test]
-    fn dashboard_url_with_tab_is_consistent_across_regions() {
-        let intl_url = format!("{}?tab=plan", AlibabaRegion::Singapore.dashboard_url());
-        assert_eq!(
-            intl_url,
-            "https://modelstudio.console.alibabacloud.com/ap-southeast-1?tab=plan",
-        );
-        let cn_url = format!("{}?tab=plan", AlibabaRegion::ChinaMainland.dashboard_url());
-        assert_eq!(
-            cn_url, "https://bailian.console.alibabacloud.com?tab=plan",
-            "CN dashboard URL must NOT contain a region-code path segment",
         );
     }
 }

--- a/rust/src/providers/alibaba/parser.rs
+++ b/rust/src/providers/alibaba/parser.rs
@@ -1,0 +1,235 @@
+use chrono::{DateTime, TimeZone, Utc};
+
+use crate::core::{ProviderError, RateWindow, UsageSnapshot};
+
+pub(crate) fn parse_response(json: &serde_json::Value) -> Result<UsageSnapshot, ProviderError> {
+    let top_code = json.get("code").and_then(|v| v.as_str()).unwrap_or("");
+    if !top_code.is_empty() && top_code != "200" {
+        if top_code == "401" || top_code == "403" {
+            return Err(ProviderError::AuthRequired);
+        }
+        let msg = json
+            .get("message")
+            .and_then(|v| v.as_str())
+            .unwrap_or(top_code);
+        return Err(ProviderError::Other(format!("API error: {msg}")));
+    }
+
+    if let Some(ret) = json.pointer("/data/DataV2/ret").and_then(|v| v.as_array()) {
+        let joined: String = ret
+            .iter()
+            .filter_map(|v| v.as_str())
+            .collect::<Vec<_>>()
+            .join(";");
+        if joined.contains("No Authority")
+            || joined.contains("10032390")
+            || joined.contains("NeedLogin")
+        {
+            return Err(ProviderError::AuthRequired);
+        }
+    }
+
+    let instances = json
+        .pointer("/data/DataV2/data/data/codingPlanInstanceInfos")
+        .and_then(|v| v.as_array())
+        .ok_or_else(|| {
+            ProviderError::Parse("codingPlanInstanceInfos not found in response".into())
+        })?;
+
+    let instance = instances
+        .iter()
+        .find(|i| i.get("status").and_then(|s| s.as_str()) == Some("VALID"))
+        .or_else(|| instances.first())
+        .ok_or_else(|| ProviderError::Parse("no Coding Plan instance in response".into()))?;
+
+    let quota = instance
+        .get("codingPlanQuotaInfo")
+        .ok_or_else(|| ProviderError::Parse("codingPlanQuotaInfo missing".into()))?;
+
+    let plan_name = instance
+        .get("instanceName")
+        .and_then(|v| v.as_str())
+        .unwrap_or("Coding Plan");
+
+    let ms_to_dt = |key: &str| -> Option<DateTime<Utc>> {
+        quota
+            .get(key)
+            .and_then(|v| v.as_i64())
+            .and_then(|ms| Utc.timestamp_opt(ms / 1000, 0).single())
+    };
+
+    let pct = |used_key: &str, total_key: &str| -> f64 {
+        let used = quota.get(used_key).and_then(|v| v.as_f64()).unwrap_or(0.0);
+        let total = quota.get(total_key).and_then(|v| v.as_f64()).unwrap_or(1.0);
+        if total > 0.0 {
+            (used / total * 100.0).clamp(0.0, 100.0)
+        } else {
+            0.0
+        }
+    };
+
+    let detail = |used_key: &str, total_key: &str| -> Option<String> {
+        let used = quota.get(used_key).and_then(|v| v.as_f64())?;
+        let total = quota.get(total_key).and_then(|v| v.as_f64())?;
+        Some(format!(
+            "{} / {} tokens",
+            fmt_tokens(used as i64),
+            fmt_tokens(total as i64)
+        ))
+    };
+
+    let five_hour = RateWindow::with_details(
+        pct("per5HourUsedQuota", "per5HourTotalQuota"),
+        Some(300),
+        ms_to_dt("per5HourQuotaNextRefreshTime"),
+        detail("per5HourUsedQuota", "per5HourTotalQuota"),
+    );
+    let weekly = RateWindow::with_details(
+        pct("perWeekUsedQuota", "perWeekTotalQuota"),
+        Some(7 * 24 * 60),
+        ms_to_dt("perWeekQuotaNextRefreshTime"),
+        detail("perWeekUsedQuota", "perWeekTotalQuota"),
+    );
+    let monthly = RateWindow::with_details(
+        pct("perBillMonthUsedQuota", "perBillMonthTotalQuota"),
+        Some(30 * 24 * 60),
+        ms_to_dt("perBillMonthQuotaNextRefreshTime"),
+        detail("perBillMonthUsedQuota", "perBillMonthTotalQuota"),
+    );
+
+    Ok(UsageSnapshot::new(five_hour)
+        .with_secondary(weekly)
+        .with_tertiary(monthly)
+        .with_login_method(plan_name))
+}
+
+fn fmt_tokens(n: i64) -> String {
+    let negative = n < 0;
+    let magnitude = (n as i128).unsigned_abs();
+    let digits = magnitude.to_string();
+    let mut out = String::with_capacity(digits.len() + digits.len() / 3 + 1);
+    for (i, ch) in digits.chars().rev().enumerate() {
+        if i > 0 && i % 3 == 0 {
+            out.push(',');
+        }
+        out.push(ch);
+    }
+    let mut result: String = out.chars().rev().collect();
+    if negative {
+        result.insert(0, '-');
+    }
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_response() -> serde_json::Value {
+        serde_json::json!({
+            "code": "200",
+            "data": {
+                "DataV2": {
+                    "data": {
+                        "data": {
+                            "codingPlanInstanceInfos": [{
+                                "instanceName": "Coding Plan Pro",
+                                "status": "VALID",
+                                "codingPlanQuotaInfo": {
+                                    "per5HourUsedQuota": 0,
+                                    "per5HourTotalQuota": 6000,
+                                    "per5HourQuotaNextRefreshTime": 1780731422000_i64,
+                                    "perWeekUsedQuota": 2019,
+                                    "perWeekTotalQuota": 45000,
+                                    "perWeekQuotaNextRefreshTime": 1780848000000_i64,
+                                    "perBillMonthUsedQuota": 25,
+                                    "perBillMonthTotalQuota": 90000,
+                                    "perBillMonthQuotaNextRefreshTime": 1783267200000_i64
+                                }
+                            }]
+                        }
+                    }
+                }
+            }
+        })
+    }
+
+    #[test]
+    fn parses_real_response_shape() {
+        let usage = parse_response(&sample_response()).unwrap();
+
+        assert!((usage.primary.used_percent - 0.0).abs() < 0.01);
+        assert_eq!(usage.primary.window_minutes, Some(300));
+        assert!(usage.primary.resets_at.is_some());
+
+        let weekly = usage.secondary.unwrap();
+        assert!((weekly.used_percent - 4.487).abs() < 0.01);
+
+        let monthly = usage.tertiary.unwrap();
+        assert!((monthly.used_percent - 0.028).abs() < 0.01);
+
+        assert_eq!(usage.login_method.as_deref(), Some("Coding Plan Pro"));
+    }
+
+    #[test]
+    fn picks_valid_instance_over_first() {
+        let json = serde_json::json!({
+            "code": "200",
+            "data": { "DataV2": { "data": { "data": {
+                "codingPlanInstanceInfos": [
+                    {
+                        "instanceName": "Expired",
+                        "status": "EXPIRED",
+                        "codingPlanQuotaInfo": {
+                            "per5HourUsedQuota": 100, "per5HourTotalQuota": 100,
+                            "perWeekUsedQuota": 100, "perWeekTotalQuota": 100,
+                            "perBillMonthUsedQuota": 100, "perBillMonthTotalQuota": 100
+                        }
+                    },
+                    {
+                        "instanceName": "Coding Plan Pro",
+                        "status": "VALID",
+                        "codingPlanQuotaInfo": {
+                            "per5HourUsedQuota": 0, "per5HourTotalQuota": 6000,
+                            "perWeekUsedQuota": 10, "perWeekTotalQuota": 45000,
+                            "perBillMonthUsedQuota": 25, "perBillMonthTotalQuota": 90000
+                        }
+                    }
+                ]
+            }}}}
+        });
+        let usage = parse_response(&json).unwrap();
+        assert_eq!(usage.login_method.as_deref(), Some("Coding Plan Pro"));
+        assert!(usage.primary.used_percent < 1.0);
+    }
+
+    #[test]
+    fn no_authority_response_maps_to_auth_required() {
+        let json = serde_json::json!({
+            "code": "200",
+            "data": { "DataV2": { "ret": ["10032390::No Authority"], "data": {} } }
+        });
+        assert!(matches!(
+            parse_response(&json),
+            Err(ProviderError::AuthRequired)
+        ));
+    }
+
+    #[test]
+    fn fmt_tokens_formats_correctly() {
+        assert_eq!(fmt_tokens(6000), "6,000");
+        assert_eq!(fmt_tokens(90000), "90,000");
+        assert_eq!(fmt_tokens(25), "25");
+        assert_eq!(fmt_tokens(1000000), "1,000,000");
+    }
+
+    #[test]
+    fn fmt_tokens_handles_negative_values() {
+        assert_eq!(fmt_tokens(-100), "-100");
+        assert_eq!(fmt_tokens(-1000), "-1,000");
+        assert_eq!(fmt_tokens(-1000000), "-1,000,000");
+        assert_eq!(fmt_tokens(-1), "-1");
+        assert_eq!(fmt_tokens(0), "0");
+        assert_eq!(fmt_tokens(i64::MIN), "-9,223,372,036,854,775,808");
+    }
+}

--- a/rust/src/providers/alibaba/region.rs
+++ b/rust/src/providers/alibaba/region.rs
@@ -1,0 +1,274 @@
+/// Per-platform request constants for the console data gateway. These differ
+/// between the international Model Studio console and the China-mainland
+/// Bailian console.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct AlibabaRequestProfile {
+    /// Base origin of the console data gateway (no trailing slash).
+    pub gateway: &'static str,
+    /// `action` gateway parameter.
+    pub api_action: &'static str,
+    /// `product` gateway parameter.
+    pub api_product: &'static str,
+    /// Fully-qualified gateway API method name.
+    pub api_method: &'static str,
+    /// Coding Plan commodity code queried.
+    pub commodity_code: &'static str,
+    /// `switchAgent` cornerstone parameter (fixed per console).
+    pub switch_agent: u64,
+    /// `switchUserType` cornerstone parameter (fixed per console).
+    pub switch_user_type: u64,
+    /// `consoleSite` cornerstone parameter.
+    pub console_site: &'static str,
+    /// `domain` cornerstone parameter (the console host).
+    pub console_domain: &'static str,
+}
+
+/// Verified request profile for the international Model Studio console
+/// (Singapore / US / Germany / Hong Kong share this; only the region code
+/// in the referer/feURL differs).
+pub(crate) const INTL_PROFILE: AlibabaRequestProfile = AlibabaRequestProfile {
+    gateway: "https://modelstudio.console.alibabacloud.com",
+    api_action: "IntlBroadScopeAspnGateway",
+    api_product: "sfm_bailian",
+    api_method: "zeldaEasy.broadscope-bailian.codingPlan.queryCodingPlanInstanceInfoV2",
+    commodity_code: "sfm_codingplan_public_intl",
+    switch_agent: 313762,
+    switch_user_type: 3,
+    // NOTE: this is Alibaba's own (misspelled) token, "ALBABACLOUD", not
+    // "ALIBABACLOUD". It is copied verbatim from a verified working capture;
+    // the gateway rejects the correctly-spelled value. Do not "fix" it.
+    console_site: "MODELSTUDIO_ALBABACLOUD",
+    console_domain: "modelstudio.console.alibabacloud.com",
+};
+
+/// Alibaba Coding Plan region: the single source of truth for settings value,
+/// UI label, gateway, API region code, cookie domains, dashboard URL and gateway
+/// request constants.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AlibabaRegion {
+    Singapore,
+    UsEast,
+    Germany,
+    HongKong,
+    ChinaMainland,
+}
+
+impl AlibabaRegion {
+    /// Regions exposed in the settings UI.
+    pub const ALL: &'static [AlibabaRegion] = &[
+        Self::Singapore,
+        Self::UsEast,
+        Self::Germany,
+        Self::HongKong,
+        Self::ChinaMainland,
+    ];
+
+    /// Parse the persisted `api_region` settings value.
+    pub fn from_settings_value(value: Option<&str>) -> Self {
+        match value.unwrap_or_default().trim().to_lowercase().as_str() {
+            "us" | "us-east-1" | "useast" | "us-west-1" => Self::UsEast,
+            "germany" | "eu" | "eu-central-1" | "frankfurt" => Self::Germany,
+            "hongkong" | "hong-kong" | "hk" | "cn-hongkong" => Self::HongKong,
+            "cn" | "china" | "china-mainland" | "china_mainland" | "mainland" => {
+                Self::ChinaMainland
+            }
+            "" | "singapore" | "intl" | "ap-southeast-1" | "international" => Self::Singapore,
+            other => {
+                tracing::warn!(
+                    value = other,
+                    "Unknown Alibaba api_region value; falling back to Singapore",
+                );
+                Self::Singapore
+            }
+        }
+    }
+
+    /// Canonical persisted settings value.
+    pub fn settings_value(self) -> &'static str {
+        match self {
+            Self::Singapore => "singapore",
+            Self::UsEast => "us",
+            Self::Germany => "germany",
+            Self::HongKong => "hongkong",
+            Self::ChinaMainland => "cn",
+        }
+    }
+
+    /// Human-readable label for the settings region picker.
+    pub fn display_name(self) -> &'static str {
+        match self {
+            Self::Singapore => "International – Singapore (ap-southeast-1)",
+            Self::UsEast => "International – US (us-east-1)",
+            Self::Germany => "International – Germany (eu-central-1)",
+            Self::HongKong => "International – Hong Kong (cn-hongkong)",
+            Self::ChinaMainland => "China Mainland (Bailian)",
+        }
+    }
+
+    /// Alibaba Cloud region code used in the dashboard path and referer.
+    pub fn region_code(self) -> &'static str {
+        match self {
+            Self::Singapore => "ap-southeast-1",
+            Self::UsEast => "us-east-1",
+            Self::Germany => "eu-central-1",
+            Self::HongKong => "cn-hongkong",
+            Self::ChinaMainland => "cn-hangzhou",
+        }
+    }
+
+    pub fn is_china(self) -> bool {
+        matches!(self, Self::ChinaMainland)
+    }
+
+    /// Browser cookie domains to try, in priority order, for auto-import.
+    pub fn cookie_domains(self) -> &'static [&'static str] {
+        match self {
+            Self::ChinaMainland => &[
+                "bailian.console.alibabacloud.com",
+                "bailian.console.aliyun.com",
+                "alibabacloud.com",
+                "aliyun.com",
+            ],
+            _ => &["modelstudio.console.alibabacloud.com", "alibabacloud.com"],
+        }
+    }
+
+    /// Primary cookie domain shown in the browser-import hint.
+    pub fn primary_cookie_domain(self) -> &'static str {
+        self.cookie_domains()[0]
+    }
+
+    /// Per-platform gateway request constants.
+    pub fn request_profile(self) -> AlibabaRequestProfile {
+        match self {
+            Self::ChinaMainland => AlibabaRequestProfile {
+                gateway: "https://bailian.console.alibabacloud.com",
+                console_domain: "bailian.console.alibabacloud.com",
+                ..INTL_PROFILE
+            },
+            _ => INTL_PROFILE,
+        }
+    }
+
+    /// Console data-gateway origin.
+    pub fn gateway(self) -> &'static str {
+        self.request_profile().gateway
+    }
+
+    /// Dashboard URL for the browser-import hint and the "open dashboard" link.
+    pub fn dashboard_url(self) -> String {
+        match self {
+            Self::ChinaMainland => self.gateway().to_string(),
+            _ => format!("{}/{}", self.gateway(), self.region_code()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn region_from_settings_value_round_trips() {
+        for region in AlibabaRegion::ALL {
+            assert_eq!(
+                AlibabaRegion::from_settings_value(Some(region.settings_value())),
+                *region
+            );
+        }
+        assert_eq!(
+            AlibabaRegion::from_settings_value(None),
+            AlibabaRegion::Singapore
+        );
+        assert_eq!(
+            AlibabaRegion::from_settings_value(Some("intl")),
+            AlibabaRegion::Singapore
+        );
+        assert_eq!(
+            AlibabaRegion::from_settings_value(Some("cn")),
+            AlibabaRegion::ChinaMainland
+        );
+    }
+
+    #[test]
+    fn region_codes_are_correct() {
+        assert_eq!(AlibabaRegion::Singapore.region_code(), "ap-southeast-1");
+        assert_eq!(AlibabaRegion::UsEast.region_code(), "us-east-1");
+        assert_eq!(AlibabaRegion::Germany.region_code(), "eu-central-1");
+        assert_eq!(AlibabaRegion::HongKong.region_code(), "cn-hongkong");
+    }
+
+    #[test]
+    fn china_routes_to_its_own_gateway_and_cookies() {
+        let cn = AlibabaRegion::ChinaMainland;
+        assert!(cn.is_china());
+        assert_eq!(cn.gateway(), "https://bailian.console.alibabacloud.com");
+        assert_ne!(cn.gateway(), AlibabaRegion::Singapore.gateway());
+        assert_eq!(
+            cn.primary_cookie_domain(),
+            "bailian.console.alibabacloud.com"
+        );
+        assert_ne!(
+            cn.primary_cookie_domain(),
+            AlibabaRegion::Singapore.primary_cookie_domain()
+        );
+    }
+
+    #[test]
+    fn international_regions_share_one_gateway() {
+        let intl = "https://modelstudio.console.alibabacloud.com";
+        for region in [
+            AlibabaRegion::Singapore,
+            AlibabaRegion::UsEast,
+            AlibabaRegion::Germany,
+            AlibabaRegion::HongKong,
+        ] {
+            assert_eq!(region.gateway(), intl);
+            assert!(!region.is_china());
+        }
+    }
+
+    #[test]
+    fn exposed_regions_include_china() {
+        assert!(AlibabaRegion::ALL.contains(&AlibabaRegion::ChinaMainland));
+        assert_eq!(AlibabaRegion::ALL.len(), 5);
+    }
+
+    #[test]
+    fn china_cookie_domains_include_legacy_aliyun() {
+        let domains = AlibabaRegion::ChinaMainland.cookie_domains();
+        assert!(
+            domains.contains(&"bailian.console.aliyun.com"),
+            "legacy aliyun.com fallback must remain for upgrading users; got {domains:?}",
+        );
+        assert!(domains.contains(&"bailian.console.alibabacloud.com"));
+    }
+
+    #[test]
+    fn intl_console_site_matches_verified_capture() {
+        assert_eq!(INTL_PROFILE.console_site, "MODELSTUDIO_ALBABACLOUD");
+    }
+
+    #[test]
+    fn ap_east_1_no_longer_aliases_to_hongkong() {
+        assert_eq!(
+            AlibabaRegion::from_settings_value(Some("ap-east-1")),
+            AlibabaRegion::Singapore,
+            "ap-east-1 is an AWS region code, not Alibaba's; removed as HK alias",
+        );
+    }
+
+    #[test]
+    fn dashboard_url_with_tab_is_consistent_across_regions() {
+        let intl_url = format!("{}?tab=plan", AlibabaRegion::Singapore.dashboard_url());
+        assert_eq!(
+            intl_url,
+            "https://modelstudio.console.alibabacloud.com/ap-southeast-1?tab=plan",
+        );
+        let cn_url = format!("{}?tab=plan", AlibabaRegion::ChinaMainland.dashboard_url());
+        assert_eq!(
+            cn_url, "https://bailian.console.alibabacloud.com?tab=plan",
+            "CN dashboard URL must NOT contain a region-code path segment",
+        );
+    }
+}

--- a/rust/src/providers/alibaba/sec_token.rs
+++ b/rust/src/providers/alibaba/sec_token.rs
@@ -1,0 +1,205 @@
+use sha2::{Digest, Sha256};
+use std::collections::HashMap;
+use std::sync::{OnceLock, RwLock};
+use std::time::{Duration, Instant};
+
+/// How long a scraped SEC_TOKEN stays valid in the in-memory cache.
+const SEC_TOKEN_TTL: Duration = Duration::from_secs(25 * 60);
+
+#[derive(Clone)]
+struct CachedSecToken {
+    token: String,
+    fetched_at: Instant,
+}
+
+fn token_cache() -> &'static RwLock<HashMap<String, CachedSecToken>> {
+    static CACHE: OnceLock<RwLock<HashMap<String, CachedSecToken>>> = OnceLock::new();
+    CACHE.get_or_init(|| RwLock::new(HashMap::new()))
+}
+
+/// Cache key bound to the real auth boundary: the region code plus a full
+/// SHA-256 hash of the cookie header.
+pub(crate) fn sec_token_cache_key(region_code: &str, cookies: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(cookies.as_bytes());
+    let digest = hasher.finalize();
+    let hex: String = digest.iter().map(|b| format!("{b:02x}")).collect();
+    format!("{region_code}:{hex}")
+}
+
+pub(crate) fn cached_sec_token(key: &str) -> Option<String> {
+    let cache = token_cache().read().ok()?;
+    let entry = cache.get(key)?;
+    (entry.fetched_at.elapsed() < SEC_TOKEN_TTL).then(|| entry.token.clone())
+}
+
+pub(crate) fn store_sec_token(key: &str, token: &str) {
+    if let Ok(mut cache) = token_cache().write() {
+        cache.retain(|_, v| v.fetched_at.elapsed() < SEC_TOKEN_TTL);
+        cache.insert(
+            key.to_string(),
+            CachedSecToken {
+                token: token.to_string(),
+                fetched_at: Instant::now(),
+            },
+        );
+    }
+}
+
+pub(crate) fn invalidate_sec_token(key: &str) {
+    if let Ok(mut cache) = token_cache().write() {
+        cache.remove(key);
+    }
+}
+
+/// Scan the dashboard HTML for a `SEC_TOKEN` assignment.
+pub(crate) fn extract_sec_token(html: &str) -> Option<String> {
+    const NEEDLE: &str = "SEC_TOKEN";
+    let mut search_from = 0;
+    while let Some(rel) = html[search_from..].find(NEEDLE) {
+        let pos = search_from + rel;
+        let after = &html[pos + NEEDLE.len()..];
+        if let Some(token) = parse_sec_token_value(after) {
+            return Some(token);
+        }
+        search_from = pos + NEEDLE.len();
+    }
+    None
+}
+
+fn parse_sec_token_value(after_key: &str) -> Option<String> {
+    let mut chars = after_key.char_indices().peekable();
+    if matches!(chars.peek(), Some(&(_, '"' | '\''))) {
+        chars.next();
+    }
+    while let Some(&(_, c)) = chars.peek() {
+        if c.is_whitespace() {
+            chars.next();
+        } else {
+            break;
+        }
+    }
+    let assign = chars.next()?;
+    if assign.1 != ':' && assign.1 != '=' {
+        return None;
+    }
+    while let Some(&(_, c)) = chars.peek() {
+        if c.is_whitespace() {
+            chars.next();
+        } else {
+            break;
+        }
+    }
+    let (open_idx, open_quote) = chars.next()?;
+    if open_quote != '"' && open_quote != '\'' {
+        return None;
+    }
+    let value_start = open_idx + open_quote.len_utf8();
+    let value = &after_key[value_start..];
+    let end = value.find(open_quote)?;
+    let token = &value[..end];
+    if token.is_empty() || !is_valid_sec_token(token) {
+        return None;
+    }
+    Some(token.to_string())
+}
+
+fn is_valid_sec_token(token: &str) -> bool {
+    token.len() >= 8
+        && token.len() <= 256
+        && token
+            .bytes()
+            .all(|b| b.is_ascii_alphanumeric() || matches!(b, b'_' | b'-' | b'+' | b'/' | b'='))
+}
+
+/// Look up a cookie value by name from a `Cookie:` header.
+pub(crate) fn extract_cookie_value(name: &str, cookie_header: &str) -> Option<String> {
+    cookie_header.split(';').find_map(|part| {
+        let (key, value) = part.trim().split_once('=')?;
+        (key.trim() == name)
+            .then(|| value.trim().to_string())
+            .filter(|v| !v.is_empty())
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sec_token_cache_key_distinguishes_region_and_cookies() {
+        let a = sec_token_cache_key("ap-southeast-1", "cookie=one");
+        let b = sec_token_cache_key("us-east-1", "cookie=one");
+        let c = sec_token_cache_key("ap-southeast-1", "cookie=two");
+        assert_ne!(a, b);
+        assert_ne!(a, c);
+        assert_eq!(a, sec_token_cache_key("ap-southeast-1", "cookie=one"));
+    }
+
+    #[test]
+    fn sec_token_cache_key_uses_full_sha256_hex() {
+        let key = sec_token_cache_key("ap-southeast-1", "cookie=value");
+        let (_region, hex) = key.split_once(':').expect("key must contain ':'");
+        assert_eq!(hex.len(), 64, "full SHA-256 hex is 64 characters");
+        assert!(hex.chars().all(|c| c.is_ascii_hexdigit()));
+    }
+
+    #[test]
+    fn extract_cookie_value_is_case_sensitive() {
+        assert_eq!(
+            extract_cookie_value("sec_token", "sec_token=lower").as_deref(),
+            Some("lower"),
+        );
+        assert_eq!(extract_cookie_value("sec_token", "SEC_TOKEN=upper"), None);
+        assert_eq!(
+            extract_cookie_value("sec_token", "SEC_TOKEN=upper; sec_token=lower").as_deref(),
+            Some("lower"),
+        );
+    }
+
+    #[test]
+    fn extract_sec_token_from_html() {
+        let html = r#"var config = { SEC_TOKEN: "AvLZTKds7DW5utd3p5xm48", OTHER: "x" };"#;
+        assert_eq!(
+            extract_sec_token(html).as_deref(),
+            Some("AvLZTKds7DW5utd3p5xm48")
+        );
+    }
+
+    #[test]
+    fn extract_sec_token_handles_json_quoted_key() {
+        let html = r#"{"SEC_TOKEN":"AbcDefGhi123","other":1}"#;
+        assert_eq!(extract_sec_token(html).as_deref(), Some("AbcDefGhi123"));
+    }
+
+    #[test]
+    fn extract_sec_token_handles_single_quotes() {
+        let html = r#"window.SEC_TOKEN = 'AvLZTKds7DW5utd3p5xm48';"#;
+        assert_eq!(
+            extract_sec_token(html).as_deref(),
+            Some("AvLZTKds7DW5utd3p5xm48"),
+        );
+    }
+
+    #[test]
+    fn extract_sec_token_skips_decoy_occurrences() {
+        let html = r#"<!-- SEC_TOKEN missing on "deadbeef" -->
+            <script>var config = { SEC_TOKEN: "RealTokenValue1234" };</script>"#;
+        assert_eq!(
+            extract_sec_token(html).as_deref(),
+            Some("RealTokenValue1234"),
+        );
+    }
+
+    #[test]
+    fn extract_sec_token_rejects_invalid_charset() {
+        let html = r#"var x = { SEC_TOKEN: "bad token with spaces" };"#;
+        assert_eq!(extract_sec_token(html), None);
+    }
+
+    #[test]
+    fn extract_sec_token_rejects_too_short_value() {
+        let html = r#"var x = { SEC_TOKEN: "abc" };"#;
+        assert_eq!(extract_sec_token(html), None);
+    }
+}

--- a/rust/src/providers/mod.rs
+++ b/rust/src/providers/mod.rs
@@ -55,7 +55,7 @@ pub mod zai;
 
 // Re-export provider implementations
 pub use abacus::AbacusProvider;
-pub use alibaba::AlibabaProvider;
+pub use alibaba::{AlibabaProvider, AlibabaRegion};
 pub use alibabatokenplan::AlibabaTokenPlanProvider;
 pub use amp::AmpProvider;
 pub use antigravity::AntigravityProvider;

--- a/rust/src/settings.rs
+++ b/rust/src/settings.rs
@@ -228,7 +228,7 @@ const DEFAULT_PROVIDER_SOURCE: &str = "auto";
 /// Default API region for providers that expose one.
 fn default_api_region(id: ProviderId) -> &'static str {
     match id {
-        ProviderId::Alibaba => "intl",
+        ProviderId::Alibaba => crate::providers::AlibabaRegion::Singapore.settings_value(),
         ProviderId::Zai | ProviderId::MiniMax => "global",
         _ => "",
     }

--- a/rust/src/settings/tests.rs
+++ b/rust/src/settings/tests.rs
@@ -549,7 +549,7 @@ fn test_per_provider_defaults_applied() {
     let settings = Settings::default();
     assert_eq!(settings.cookie_source(ProviderId::Codex), "manual");
     assert_eq!(settings.usage_source(ProviderId::Codex), "auto");
-    assert_eq!(settings.api_region(ProviderId::Alibaba), "intl");
+    assert_eq!(settings.api_region(ProviderId::Alibaba), "singapore");
     assert_eq!(settings.api_region(ProviderId::Zai), "global");
     assert_eq!(settings.api_region(ProviderId::MiniMax), "global");
     assert!(settings.openai_web_extras(ProviderId::Codex));


### PR DESCRIPTION
## Summary

Reworks the **Alibaba Coding Plan** provider to support multiple international regions and resolve cookies per selected region, and includes a secondary fix for tray panel flicker.

### Alibaba Coding Plan (primary)
- Rewrite the provider to expose region-specific hosts and `cookie_domain_for_region`.
- Default region changed `intl` → `singapore`.
- `cookie_domain` for Alibaba → `modelstudio.console.alibabacloud.com`.
- Region options now offer **Singapore / US / Germany / Hong Kong / CN**.
- Cookie domain is resolved from the user's selected region.
- Unit tests updated to match the new defaults.

### Tray panel flicker (secondary)
- Adds an `isMeasuringRef` guard that breaks the `ResizeObserver` feedback loop triggered by the layout measurement pass.
- `isRefreshing` no longer forces a relayout on every refresh.

## Testing
- Frontend (vitest): 77/77 passing
- Rust `codexbar` lib: 382/382 passing
- Rust `desktop-tauri`: 225/225 passing