### PR TITLE
fix: sync tray settings updates across surfaces

### DIFF
--- a/apps/desktop-tauri/src-tauri/src/commands/bridge.rs
+++ b/apps/desktop-tauri/src-tauri/src/commands/bridge.rs
@@ -855,6 +855,10 @@ pub(crate) fn bridge_events() -> Vec<BridgeEventDescriptor> {
             id: "locale-changed",
             description: "Emitted when the persisted UI language changes. Payload: serialized language label.",
         },
+        BridgeEventDescriptor {
+            id: "settings-updated",
+            description: "Emitted after settings are persisted. Payload: the full settings snapshot.",
+        },
     ]
 }
 

--- a/apps/desktop-tauri/src-tauri/src/commands/settings.rs
+++ b/apps/desktop-tauri/src-tauri/src/commands/settings.rs
@@ -61,9 +61,11 @@ impl SettingsUpdate {
 
     fn refreshes_tray_presentation(&self) -> bool {
         self.tray_icon_mode.is_some()
+            || self.switcher_shows_icons.is_some()
             || self.menu_bar_shows_highest_usage.is_some()
             || self.menu_bar_shows_percent.is_some()
             || self.show_as_used.is_some()
+            || self.reset_time_relative.is_some()
             || self.menu_bar_display_mode.is_some()
             || self.provider_metrics.is_some()
             || self.enabled_providers.is_some()
@@ -295,5 +297,31 @@ pub async fn update_settings(
         crate::tray_bridge::refresh_tray_presentation(&app);
     }
 
-    Ok(SettingsSnapshot::from(settings))
+    let snapshot = SettingsSnapshot::from(settings);
+    events::emit_settings_updated(&app, &snapshot);
+
+    Ok(snapshot)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn display_settings_that_affect_tray_trigger_presentation_refresh() {
+        assert!(
+            SettingsUpdate {
+                switcher_shows_icons: Some(false),
+                ..Default::default()
+            }
+            .refreshes_tray_presentation()
+        );
+        assert!(
+            SettingsUpdate {
+                reset_time_relative: Some(false),
+                ..Default::default()
+            }
+            .refreshes_tray_presentation()
+        );
+    }
 }

--- a/apps/desktop-tauri/src-tauri/src/events.rs
+++ b/apps/desktop-tauri/src-tauri/src/events.rs
@@ -4,7 +4,7 @@
 use serde::Serialize;
 use tauri::{AppHandle, Emitter};
 
-use crate::commands::ProviderUsageSnapshot;
+use crate::commands::{ProviderUsageSnapshot, SettingsSnapshot};
 use crate::proof_harness::ProofStatePayload;
 use crate::state::UpdateStatePayload;
 use crate::surface::SurfaceMode;
@@ -20,6 +20,7 @@ pub const UPDATE_STATE_CHANGED: &str = "update-state-changed";
 pub const LOGIN_PHASE_CHANGED: &str = "login-phase-changed";
 pub const PROOF_STATE_CHANGED: &str = "proof-state-changed";
 pub const LOCALE_CHANGED: &str = "locale-changed";
+pub const SETTINGS_UPDATED: &str = "settings-updated";
 
 // ── Payloads ─────────────────────────────────────────────────────────
 
@@ -84,4 +85,8 @@ pub fn emit_login_phase_changed(app: &AppHandle) {
 
 pub fn emit_proof_state_changed(app: &AppHandle, payload: &ProofStatePayload) {
     let _ = app.emit(PROOF_STATE_CHANGED, payload);
+}
+
+pub fn emit_settings_updated(app: &AppHandle, snapshot: &SettingsSnapshot) {
+    let _ = app.emit(SETTINGS_UPDATED, snapshot);
 }

--- a/apps/desktop-tauri/src/hooks/useSettings.test.tsx
+++ b/apps/desktop-tauri/src/hooks/useSettings.test.tsx
@@ -1,0 +1,129 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const tauriMocks = vi.hoisted(() => ({
+  getSettingsSnapshot: vi.fn(),
+  updateSettings: vi.fn(),
+}));
+
+const eventMocks = vi.hoisted(() => ({
+  listen: vi.fn(),
+  listeners: new Map<string, Array<(event: { payload: unknown }) => void>>(),
+}));
+
+vi.mock("../lib/tauri", () => tauriMocks);
+
+vi.mock("@tauri-apps/api/event", () => eventMocks);
+
+import type { SettingsSnapshot } from "../types/bridge";
+import { useSettings } from "./useSettings";
+
+function settings(overrides: Partial<SettingsSnapshot> = {}): SettingsSnapshot {
+  return {
+    enabledProviders: ["codex"],
+    refreshIntervalSecs: 300,
+    startAtLogin: false,
+    startMinimized: true,
+    showNotifications: true,
+    soundEnabled: true,
+    soundVolume: 50,
+    highUsageThreshold: 80,
+    criticalUsageThreshold: 95,
+    trayIconMode: "single",
+    switcherShowsIcons: true,
+    menuBarShowsHighestUsage: true,
+    menuBarShowsPercent: false,
+    showAsUsed: true,
+    showCreditsExtraUsage: true,
+    showAllTokenAccountsInMenu: false,
+    surpriseAnimations: true,
+    enableAnimations: true,
+    resetTimeRelative: true,
+    menuBarDisplayMode: "compact",
+    hidePersonalInfo: false,
+    updateChannel: "stable",
+    autoDownloadUpdates: true,
+    installUpdatesOnQuit: true,
+    globalShortcut: "Ctrl+Shift+U",
+    uiLanguage: "english",
+    theme: "auto",
+    claudeAvoidKeychainPrompts: false,
+    disableKeychainAccess: false,
+    showDebugSettings: false,
+    providerMetrics: {},
+    floatBarEnabled: false,
+    floatBarOpacity: 100,
+    floatBarOrientation: "horizontal",
+    floatBarClickThrough: false,
+    floatBarProviderIds: [],
+    floatBarDarkText: false,
+    ...overrides,
+  };
+}
+
+function emitSettingsEvent(payload: SettingsSnapshot) {
+  for (const listener of eventMocks.listeners.get("settings-updated") ?? []) {
+    listener({ payload });
+  }
+}
+
+describe("useSettings", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    eventMocks.listeners.clear();
+    tauriMocks.getSettingsSnapshot.mockResolvedValue(settings());
+    tauriMocks.updateSettings.mockResolvedValue(settings());
+    eventMocks.listen.mockImplementation(
+      (event: string, handler: (event: { payload: unknown }) => void) => {
+        const listeners = eventMocks.listeners.get(event) ?? [];
+        listeners.push(handler);
+        eventMocks.listeners.set(event, listeners);
+        return Promise.resolve(() => {});
+      },
+    );
+  });
+
+  it("subscribes to saved settings from other surfaces", async () => {
+    const initial = settings({ switcherShowsIcons: true });
+    const next = settings({
+      switcherShowsIcons: false,
+      menuBarShowsPercent: true,
+      trayIconMode: "perProvider",
+    });
+
+    const { result } = renderHook(() => useSettings(initial));
+
+    await waitFor(() => {
+      expect(tauriMocks.getSettingsSnapshot).toHaveBeenCalledTimes(1);
+    });
+
+    act(() => {
+      emitSettingsEvent(next);
+    });
+
+    expect(result.current.settings.switcherShowsIcons).toBe(false);
+    expect(result.current.settings.menuBarShowsPercent).toBe(true);
+    expect(result.current.settings.trayIconMode).toBe("perProvider");
+  });
+
+  it("keeps same-window hooks synchronized through the local DOM event", async () => {
+    const initial = settings({ switcherShowsIcons: true });
+    const next = settings({ switcherShowsIcons: false });
+
+    const { result } = renderHook(() => useSettings(initial));
+
+    await waitFor(() => {
+      expect(tauriMocks.getSettingsSnapshot).toHaveBeenCalledTimes(1);
+    });
+
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent<SettingsSnapshot>("codexbar:settings-updated", {
+          detail: next,
+        }),
+      );
+    });
+
+    expect(result.current.settings.switcherShowsIcons).toBe(false);
+  });
+});

--- a/apps/desktop-tauri/src/hooks/useSettings.ts
+++ b/apps/desktop-tauri/src/hooks/useSettings.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useState } from "react";
+import { listen } from "@tauri-apps/api/event";
 import type { SettingsSnapshot, SettingsUpdate } from "../types/bridge";
 import { getSettingsSnapshot, updateSettings } from "../lib/tauri";
 
@@ -33,8 +34,29 @@ export function useSettings(initial: SettingsSnapshot): UseSettingsReturn {
         // Keep the bootstrap snapshot if the background sync fails.
       });
 
+    const onDomSettingsUpdated = (event: Event) => {
+      if (cancelled) return;
+      const next = (event as CustomEvent<SettingsSnapshot>).detail;
+      if (next) {
+        setSettings(next);
+      }
+    };
+
+    window.addEventListener("codexbar:settings-updated", onDomSettingsUpdated);
+
+    const unlistenSettingsUpdated = listen<SettingsSnapshot>(
+      "settings-updated",
+      (event) => {
+        if (!cancelled) {
+          setSettings(event.payload);
+        }
+      },
+    );
+
     return () => {
       cancelled = true;
+      window.removeEventListener("codexbar:settings-updated", onDomSettingsUpdated);
+      unlistenSettingsUpdated.then((fn) => fn());
     };
   }, [initial]);
 


### PR DESCRIPTION
﻿## Summary
- emit a `settings-updated` backend event after `update_settings` persists changes
- subscribe `useSettings` to the backend event and the existing local DOM event so tray/pop-out/settings surfaces share the latest settings snapshot
- include Display settings that affect tray presentation in the tray refresh trigger
- add hook coverage for cross-surface and same-window settings synchronization

Fixes #81.

## Testing
- `git diff --check`

Not run locally:
- `cargo fmt` / Rust tests: `cargo` and `rustc` are not available in this Windows environment
- `pnpm test`: Node/npm/pnpm are not available on PATH in this environment
