### PR TITLE
Fix tray panel dismissal

### DIFF
--- a/apps/desktop-tauri/src-tauri/src/commands/bridge.rs
+++ b/apps/desktop-tauri/src-tauri/src/commands/bridge.rs
@@ -587,6 +587,10 @@ pub(crate) fn bridge_commands() -> Vec<BridgeCommandDescriptor> {
             description: "Switch the shell to a visible surface using a required typed target.",
         },
         BridgeCommandDescriptor {
+            id: "dismiss_tray_panel",
+            description: "Hide the tray panel without affecting other visible surfaces.",
+        },
+        BridgeCommandDescriptor {
             id: "close_settings_window",
             description: "Dismiss Settings without exiting the tray application.",
         },

--- a/apps/desktop-tauri/src-tauri/src/commands/surface.rs
+++ b/apps/desktop-tauri/src-tauri/src/commands/surface.rs
@@ -15,6 +15,11 @@ pub fn set_surface_mode(
         .map(|mode| mode.as_str().to_string())
 }
 
+#[tauri::command]
+pub fn dismiss_tray_panel(app: tauri::AppHandle) -> Result<(), String> {
+    crate::shell::hide_to_tray_if_current(&app, |mode| mode == SurfaceMode::TrayPanel).map(|_| ())
+}
+
 /// Open (or focus) a detached Settings/About window.
 ///
 /// Unlike `set_surface_mode`, this spawns a *separate* window so the tray

--- a/apps/desktop-tauri/src-tauri/src/commands/tests.rs
+++ b/apps/desktop-tauri/src-tauri/src/commands/tests.rs
@@ -60,6 +60,7 @@ fn bootstrap_contract_lists_current_surface_commands() {
         .collect::<Vec<_>>();
 
     assert!(ids.contains(&"set_surface_mode"));
+    assert!(ids.contains(&"dismiss_tray_panel"));
     assert!(ids.contains(&"get_current_surface_mode"));
     assert!(ids.contains(&"get_current_surface_state"));
     assert!(ids.contains(&"get_app_info"));

--- a/apps/desktop-tauri/src-tauri/src/main.rs
+++ b/apps/desktop-tauri/src-tauri/src/main.rs
@@ -27,6 +27,12 @@ use tauri::Manager;
 const PROOF_ACTIVATION_DELAY: Duration = Duration::from_millis(0);
 const VISIBLE_START_ACTIVATION_DELAY: Duration = Duration::from_millis(0);
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct LaunchBehavior {
+    open_tray_panel_at_start: bool,
+    suppress_blur_dismiss: bool,
+}
+
 fn should_hide_close_request(mode: SurfaceMode) -> bool {
     matches!(
         mode,
@@ -50,13 +56,28 @@ where
     })
 }
 
+fn launch_behavior<I, S>(force_visible: bool, args: I) -> LaunchBehavior
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<str>,
+{
+    LaunchBehavior {
+        open_tray_panel_at_start: force_visible || should_open_tray_panel_from_args(args),
+        suppress_blur_dismiss: force_visible,
+    }
+}
+
+fn should_suppress_blur_dismiss(launch: LaunchBehavior, proof_mode: bool) -> bool {
+    launch.suppress_blur_dismiss || proof_mode
+}
+
 fn main() {
     codexbar::logging::init(false, false).expect("failed to initialize logging");
 
     let proof_config = proof_harness::ProofConfig::from_env();
     let is_proof_mode = proof_config.is_some();
-    let force_start_visible = std::env::var_os("CODEXBAR_START_VISIBLE").is_some()
-        || should_open_tray_panel_from_args(std::env::args().skip(1));
+    let force_start_visible = std::env::var_os("CODEXBAR_START_VISIBLE").is_some();
+    let launch = launch_behavior(force_start_visible, std::env::args().skip(1));
 
     let mut initial_state = AppState::new();
     initial_state.proof_config = proof_config;
@@ -169,7 +190,7 @@ fn main() {
                     tokio::time::sleep(PROOF_ACTIVATION_DELAY).await;
                     proof_harness::activate(&app_handle);
                 });
-            } else if force_start_visible {
+            } else if launch.open_tray_panel_at_start {
                 let app = app.handle().clone();
                 tauri::async_runtime::spawn(async move {
                     tokio::time::sleep(VISIBLE_START_ACTIVATION_DELAY).await;
@@ -197,7 +218,10 @@ fn main() {
                 tauri::WindowEvent::Focused(false) => {
                     // Suppress blur-dismiss in proof mode so the window stays
                     // visible for automated screenshot capture.
-                    if force_start_visible || proof_harness::is_proof_mode(window.app_handle()) {
+                    if should_suppress_blur_dismiss(
+                        launch,
+                        proof_harness::is_proof_mode(window.app_handle()),
+                    ) {
                         return;
                     }
                     // Grace period: ignore blur within 500ms of showing the panel.
@@ -209,10 +233,19 @@ fn main() {
                     {
                         return;
                     }
-                    // Blur in TrayPanel mode → auto-hide.
-                    let _ = shell::hide_to_tray_if_current(window.app_handle(), |mode| {
-                        mode == SurfaceMode::TrayPanel
-                    });
+                    // Blur in TrayPanel mode → auto-hide. Record successful
+                    // dismissals so the same tray click cannot reopen it.
+                    if matches!(
+                        shell::hide_to_tray_if_current(window.app_handle(), |mode| {
+                            mode == SurfaceMode::TrayPanel
+                        }),
+                        Ok(Some(_))
+                    ) && let Some(st) = window.app_handle().try_state::<Mutex<AppState>>()
+                    {
+                        st.lock()
+                            .unwrap()
+                            .mark_blur_dismissed(std::time::Instant::now());
+                    }
                 }
                 tauri::WindowEvent::Moved(_) | tauri::WindowEvent::Resized(_) => {
                     // Capture geometry for surfaces eligible for persistence
@@ -265,6 +298,36 @@ mod tests {
     #[test]
     fn unrelated_launch_args_do_not_open_tray_panel() {
         assert!(!should_open_tray_panel_from_args(["usage", "-p", "claude"]));
+    }
+
+    #[test]
+    fn menubar_launch_does_not_suppress_blur_dismiss() {
+        assert_eq!(
+            launch_behavior(false, ["menubar"]),
+            LaunchBehavior {
+                open_tray_panel_at_start: true,
+                suppress_blur_dismiss: false,
+            }
+        );
+    }
+
+    #[test]
+    fn automation_launch_opens_and_suppresses_blur_dismiss() {
+        let launch = launch_behavior(true, std::iter::empty::<&str>());
+        assert_eq!(
+            launch,
+            LaunchBehavior {
+                open_tray_panel_at_start: true,
+                suppress_blur_dismiss: true,
+            }
+        );
+        assert!(should_suppress_blur_dismiss(launch, false));
+    }
+
+    #[test]
+    fn proof_mode_suppresses_blur_dismiss() {
+        let launch = launch_behavior(false, std::iter::empty::<&str>());
+        assert!(should_suppress_blur_dismiss(launch, true));
     }
 
     #[test]

--- a/apps/desktop-tauri/src-tauri/src/main.rs
+++ b/apps/desktop-tauri/src-tauri/src/main.rs
@@ -101,6 +101,7 @@ fn main() {
             commands::get_settings_snapshot,
             commands::update_settings,
             commands::set_surface_mode,
+            commands::dismiss_tray_panel,
             commands::reveal_tray_panel_window,
             commands::open_settings_window,
             commands::close_settings_window,

--- a/apps/desktop-tauri/src-tauri/src/shell/mod.rs
+++ b/apps/desktop-tauri/src-tauri/src/shell/mod.rs
@@ -21,7 +21,9 @@ pub use position::{
     default_surface_position, inferred_tray_panel_position, remember_current_geometry_if_settings,
     shortcut_panel_position, tray_panel_position,
 };
-pub use transition::{reopen_to_target, toggle_tray_panel, transition_to_target};
+pub use transition::{
+    handle_tray_panel_click, reopen_to_target, toggle_tray_panel, transition_to_target,
+};
 #[allow(unused_imports)]
 pub use window::{
     apply_window_properties, hide_to_tray, hide_to_tray_if_current, hide_to_tray_state,

--- a/apps/desktop-tauri/src-tauri/src/shell/tests.rs
+++ b/apps/desktop-tauri/src-tauri/src/shell/tests.rs
@@ -71,6 +71,36 @@ fn tray_toggle_hides_only_when_panel_window_is_visible() {
 }
 
 #[test]
+fn immediate_tray_click_consumes_blur_dismissal() {
+    let mut state = AppState::new();
+    let dismissed_at = std::time::Instant::now();
+
+    state.mark_blur_dismissed(dismissed_at);
+
+    assert!(state.take_recent_blur_dismissal(
+        dismissed_at + std::time::Duration::from_millis(20),
+        std::time::Duration::from_millis(250),
+    ));
+    assert!(!state.take_recent_blur_dismissal(
+        dismissed_at + std::time::Duration::from_millis(20),
+        std::time::Duration::from_millis(250),
+    ));
+}
+
+#[test]
+fn later_tray_click_does_not_consume_expired_blur_dismissal() {
+    let mut state = AppState::new();
+    let dismissed_at = std::time::Instant::now();
+
+    state.mark_blur_dismissed(dismissed_at);
+
+    assert!(!state.take_recent_blur_dismissal(
+        dismissed_at + std::time::Duration::from_millis(251),
+        std::time::Duration::from_millis(250),
+    ));
+}
+
+#[test]
 fn same_mode_about_request_resolves_as_retarget() {
     let mut state = AppState::new();
     state.transition_surface(

--- a/apps/desktop-tauri/src-tauri/src/shell/transition.rs
+++ b/apps/desktop-tauri/src-tauri/src/shell/transition.rs
@@ -527,6 +527,23 @@ pub(super) fn apply_transition(
     }
 }
 
+pub fn handle_tray_panel_click(app: &AppHandle, position: Option<(i32, i32)>) {
+    const BLUR_DISMISS_CLICK_WINDOW: std::time::Duration = std::time::Duration::from_millis(250);
+
+    let consumed_blur_dismissal = {
+        let st = app.state::<Mutex<AppState>>();
+        st.lock()
+            .unwrap()
+            .take_recent_blur_dismissal(std::time::Instant::now(), BLUR_DISMISS_CLICK_WINDOW)
+    };
+
+    if consumed_blur_dismissal {
+        return;
+    }
+
+    toggle_tray_panel(app, position);
+}
+
 /// Toggle the tray panel: hide if currently showing, show at `position` otherwise.
 pub fn toggle_tray_panel(app: &AppHandle, position: Option<(i32, i32)>) {
     let current = {

--- a/apps/desktop-tauri/src-tauri/src/state.rs
+++ b/apps/desktop-tauri/src-tauri/src/state.rs
@@ -143,6 +143,9 @@ pub struct AppState {
     /// Instant when the tray panel was last shown — used to suppress
     /// spurious blur-dismiss during the show animation on Windows.
     pub last_shown_at: Option<std::time::Instant>,
+    /// Instant when focus loss last dismissed the tray panel. The following
+    /// tray click consumes this marker instead of reopening the panel.
+    pub last_blur_dismissed_at: Option<std::time::Instant>,
 }
 
 impl Default for AppState {
@@ -182,7 +185,22 @@ impl AppState {
             proof_config: None,
             notification_manager: codexbar::notifications::NotificationManager::new(),
             last_shown_at: None,
+            last_blur_dismissed_at: None,
         }
+    }
+
+    pub fn mark_blur_dismissed(&mut self, dismissed_at: std::time::Instant) {
+        self.last_blur_dismissed_at = Some(dismissed_at);
+    }
+
+    pub fn take_recent_blur_dismissal(
+        &mut self,
+        now: std::time::Instant,
+        max_age: std::time::Duration,
+    ) -> bool {
+        self.last_blur_dismissed_at
+            .take()
+            .is_some_and(|dismissed_at| now.duration_since(dismissed_at) <= max_age)
     }
 
     pub fn transition_surface(

--- a/apps/desktop-tauri/src-tauri/src/tray_bridge.rs
+++ b/apps/desktop-tauri/src-tauri/src/tray_bridge.rs
@@ -255,17 +255,17 @@ pub fn setup(app: &mut tauri::App) -> Result<(), Box<dyn std::error::Error>> {
         .on_tray_icon_event(|tray, event| {
             if let TrayIconEvent::Click {
                 button,
-                button_state: MouseButtonState::Up,
+                button_state,
                 position,
                 rect,
                 ..
             } = event
             {
                 let app = tray.app_handle();
-                store_anchor(app, &rect, position);
-                if button == MouseButton::Left {
+                if button == MouseButton::Left && button_state == MouseButtonState::Up {
+                    store_anchor(app, &rect, position);
                     let position = shell::tray_panel_position(app);
-                    shell::toggle_tray_panel(app, position);
+                    shell::handle_tray_panel_click(app, position);
                 }
             }
         })

--- a/apps/desktop-tauri/src/lib/tauri.ts
+++ b/apps/desktop-tauri/src/lib/tauri.ts
@@ -60,6 +60,10 @@ export function setSurfaceMode<M extends VisibleSurfaceMode>(
   return invoke<SurfaceMode>("set_surface_mode", { mode, target });
 }
 
+export function dismissTrayPanel(): Promise<void> {
+  return invoke<void>("dismiss_tray_panel");
+}
+
 export function openSettingsWindow(tab: string): Promise<void> {
   return invoke<void>("open_settings_window", { tab });
 }

--- a/apps/desktop-tauri/src/surfaces/TrayPanel.test.tsx
+++ b/apps/desktop-tauri/src/surfaces/TrayPanel.test.tsx
@@ -14,6 +14,7 @@ const tauriMocks = vi.hoisted(() => ({
   dismissUpdate: vi.fn(),
   openReleasePage: vi.fn(),
   setSurfaceMode: vi.fn(),
+  dismissTrayPanel: vi.fn(),
   openSettingsWindow: vi.fn(),
   quitApp: vi.fn(),
   getWorkAreaRect: vi.fn(),
@@ -174,6 +175,7 @@ describe("TrayPanel provider grid", () => {
     eventMocks.listeners.clear();
     tauriMocks.refreshProviders.mockResolvedValue(undefined);
     tauriMocks.refreshProvidersIfStale.mockResolvedValue(undefined);
+    tauriMocks.dismissTrayPanel.mockResolvedValue(undefined);
     tauriMocks.reanchorTrayPanel.mockResolvedValue(undefined);
     tauriMocks.getWorkAreaRect.mockResolvedValue({
       x: 0,
@@ -212,6 +214,50 @@ describe("TrayPanel provider grid", () => {
         return Promise.resolve(() => {});
       },
     );
+  });
+
+  it("dismisses the tray panel on unmodified Escape", async () => {
+    const { container } = renderTrayPanel([provider("claude", "Claude", 35)]);
+
+    await waitFor(() => {
+      expect(container.querySelector(".tray-panel-reveal--ready")).not.toBeNull();
+    });
+
+    fireEvent.keyDown(window, { key: "Escape" });
+
+    await waitFor(() => {
+      expect(tauriMocks.dismissTrayPanel).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("does not dismiss the tray panel on modified Escape", async () => {
+    const { container } = renderTrayPanel([provider("claude", "Claude", 35)]);
+
+    await waitFor(() => {
+      expect(container.querySelector(".tray-panel-reveal--ready")).not.toBeNull();
+    });
+
+    fireEvent.keyDown(window, { key: "Escape", ctrlKey: true });
+    fireEvent.keyDown(window, { key: "Escape", shiftKey: true });
+    fireEvent.keyDown(window, { key: "Escape", altKey: true });
+    fireEvent.keyDown(window, { key: "Escape", metaKey: true });
+
+    expect(tauriMocks.dismissTrayPanel).not.toHaveBeenCalled();
+  });
+
+  it("keeps the existing Ctrl+R tray shortcut", async () => {
+    const { container } = renderTrayPanel([provider("claude", "Claude", 35)]);
+
+    await waitFor(() => {
+      expect(container.querySelector(".tray-panel-reveal--ready")).not.toBeNull();
+    });
+    tauriMocks.refreshProviders.mockClear();
+
+    fireEvent.keyDown(window, { key: "r", ctrlKey: true });
+
+    await waitFor(() => {
+      expect(tauriMocks.refreshProviders).toHaveBeenCalledTimes(1);
+    });
   });
 
   it.each([

--- a/apps/desktop-tauri/src/surfaces/TrayPanel.tsx
+++ b/apps/desktop-tauri/src/surfaces/TrayPanel.tsx
@@ -1,7 +1,12 @@
 import { Fragment, useCallback, useEffect, useMemo, useState } from "react";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import type { BootstrapState, ProviderUsageSnapshot } from "../types/bridge";
-import { setSurfaceMode, openSettingsWindow, quitApp as quitApplication } from "../lib/tauri";
+import {
+  dismissTrayPanel,
+  openSettingsWindow,
+  quitApp as quitApplication,
+  setSurfaceMode,
+} from "../lib/tauri";
 import { useProviders } from "../hooks/useProviders";
 import { useSettings } from "../hooks/useSettings";
 import { useUpdateState } from "../hooks/useUpdateState";
@@ -197,6 +202,17 @@ export default function TrayPanel({ state }: { state: BootstrapState }) {
   // Keyboard shortcuts
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
+      if (
+        e.key === "Escape" &&
+        !e.ctrlKey &&
+        !e.shiftKey &&
+        !e.altKey &&
+        !e.metaKey
+      ) {
+        e.preventDefault();
+        void dismissTrayPanel().catch(() => {});
+        return;
+      }
       if (!e.ctrlKey || e.shiftKey || e.altKey || e.metaKey) return;
       switch (e.key.toLowerCase()) {
         case "r":


### PR DESCRIPTION
## Summary

- close the tray panel when it loses focus
- close it when pressing Escape
- prevent tray-icon clicks from closing and immediately reopening the panel

Closes #84

## Testing

- 82 frontend tests passed
- 244 Tauri Rust tests passed
- frontend production build passed
- Rust formatting and clippy passed
- manually verified on Windows 11 25H2