### PR TITLE
feat: add weekly on-pace usage budgets

### DIFF
--- a/apps/desktop-tauri/src/components/MenuCard.test.tsx
+++ b/apps/desktop-tauri/src/components/MenuCard.test.tsx
@@ -214,8 +214,9 @@ describe("MenuCard", () => {
     expect(
       await screen.findByRole("button", { name: /On-pace budget/ }),
     ).toBeInTheDocument();
-    expect(screen.getByText("now 0%")).toBeInTheDocument();
-    expect(screen.queryByText(/in reserve/)).not.toBeInTheDocument();
+      expect(screen.getByText("now 0%")).toBeInTheDocument();
+      expect(screen.queryByText(/in reserve/)).not.toBeInTheDocument();
+      expect(screen.queryByText("Lasts until reset")).not.toBeInTheDocument();
   });
 
   it("does not show pace budgets for a five-hour session window", async () => {
@@ -238,10 +239,9 @@ describe("MenuCard", () => {
   it("keeps the reserve row when timing data is incomplete", async () => {
     const snapshot = provider(null, 20);
     snapshot.primary = rateWindow(20, {
-      reservePercent: 12,
-      reserveDescription: "Lasts until reset",
-      windowMinutes: 7 * 24 * 60,
-    });
+        reservePercent: 12,
+        reserveDescription: "Lasts until reset",
+      });
 
     renderCard(snapshot);
 

--- a/apps/desktop-tauri/src/components/MenuCard.test.tsx
+++ b/apps/desktop-tauri/src/components/MenuCard.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const tauriMocks = vi.hoisted(() => ({
@@ -24,17 +24,24 @@ import MenuCard from "./MenuCard";
 
 function rateWindow(
   usedPercent = 0,
-  opts: { exhausted?: boolean; resetDescription?: string | null } = {},
+  opts: {
+    exhausted?: boolean;
+    resetDescription?: string | null;
+    reservePercent?: number | null;
+    reserveDescription?: string | null;
+    windowMinutes?: number | null;
+    resetsAt?: string | null;
+  } = {},
 ) {
   return {
     usedPercent,
     remainingPercent: 100 - usedPercent,
-    windowMinutes: null,
-    resetsAt: null,
+    windowMinutes: opts.windowMinutes ?? null,
+    resetsAt: opts.resetsAt ?? null,
     resetDescription: opts.resetDescription ?? null,
     isExhausted: opts.exhausted ?? false,
-    reservePercent: null,
-    reserveDescription: null,
+    reservePercent: opts.reservePercent ?? null,
+    reserveDescription: opts.reserveDescription ?? null,
   };
 }
 
@@ -163,5 +170,82 @@ describe("MenuCard", () => {
     expect(screen.getByText("30d tokens")).toBeInTheDocument();
     expect(screen.getByText("584K")).toBeInTheDocument();
     expect(screen.getByText("Estimated from local logs")).toBeInTheDocument();
+  });
+
+  it("shows on-pace budgets and expands projection details", async () => {
+    const onLayoutChange = vi.fn();
+    const resetAt = new Date(
+      Date.now() + 0.6 * 7 * 24 * 60 * 60 * 1000,
+    );
+    const snapshot = provider(null, 20);
+    snapshot.primary = rateWindow(20, {
+      reservePercent: 20,
+      reserveDescription: "Lasts until reset",
+      windowMinutes: 7 * 24 * 60,
+      resetsAt: resetAt.toISOString(),
+    });
+
+    renderCard(snapshot, { onLayoutChange });
+
+    const toggle = await screen.findByRole("button", { name: /On-pace budget/ });
+    expect(screen.getByText("now 20%")).toBeInTheDocument();
+    expect(screen.getByText("1h 21%")).toBeInTheDocument();
+    expect(screen.queryByRole("img", { name: /usage pace/i })).not.toBeInTheDocument();
+
+    fireEvent.click(toggle);
+
+    expect(toggle).toHaveAttribute("aria-expanded", "true");
+    expect(screen.getByRole("img", { name: /usage pace/i })).toBeInTheDocument();
+    await waitFor(() => {
+      expect(onLayoutChange).toHaveBeenCalled();
+    });
+  });
+
+  it("shows on-pace budgets when timing exists without reserve metadata", async () => {
+    const resetAt = new Date(Date.now() + 6 * 24 * 60 * 60 * 1000);
+    const snapshot = provider(null, 31);
+    snapshot.primary = rateWindow(31, {
+      windowMinutes: 7 * 24 * 60,
+      resetsAt: resetAt.toISOString(),
+    });
+
+    renderCard(snapshot);
+
+    expect(
+      await screen.findByRole("button", { name: /On-pace budget/ }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("now 0%")).toBeInTheDocument();
+    expect(screen.queryByText(/in reserve/)).not.toBeInTheDocument();
+  });
+
+  it("does not show pace budgets for a five-hour session window", async () => {
+    const resetAt = new Date(Date.now() + 4 * 60 * 60 * 1000);
+    const snapshot = provider(null, 31);
+    snapshot.primary = rateWindow(31, {
+      windowMinutes: 5 * 60,
+      resetsAt: resetAt.toISOString(),
+    });
+
+    renderCard(snapshot);
+
+    expect(await screen.findByText("69% left")).toBeInTheDocument();
+    expect(screen.queryByText("On-pace budget")).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("img", { name: /usage pace/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("keeps the reserve row when timing data is incomplete", async () => {
+    const snapshot = provider(null, 20);
+    snapshot.primary = rateWindow(20, {
+      reservePercent: 12,
+      reserveDescription: "Lasts until reset",
+      windowMinutes: 7 * 24 * 60,
+    });
+
+    renderCard(snapshot);
+
+    expect(await screen.findByText("12% in reserve")).toBeInTheDocument();
+    expect(screen.queryByText("On-pace budget")).not.toBeInTheDocument();
   });
 });

--- a/apps/desktop-tauri/src/components/MenuCard.tsx
+++ b/apps/desktop-tauri/src/components/MenuCard.tsx
@@ -15,6 +15,8 @@ import { paceCategory } from "../surfaces/tray/paceCategory";
 import { SimpleBarChart, StackedBarChart } from "./MiniBarChart";
 import { DEMO_ENABLED } from "../lib/demoProviders";
 import { providerSupportsChartData } from "../lib/providerCharts";
+import { getPaceBudget } from "../lib/paceBudget";
+import PaceDetailsChart from "./PaceDetailsChart";
 
 /** Small copy-to-clipboard button matching macOS CopyIconButton (doc.on.doc → checkmark). */
 function CopyIconButton({ text }: { text: string }) {
@@ -227,6 +229,8 @@ function paceStageKey(stage: PaceSnapshot["stage"]): LocaleKey {
 }
 
 type UsageLevel = "normal" | "high" | "critical" | "exhausted";
+const WEEKLY_WINDOW_MINUTES = 7 * 24 * 60;
+
 function levelOf(remainPct: number, exhausted: boolean): UsageLevel {
   if (exhausted) return "exhausted";
   if (remainPct <= 5) return "critical";
@@ -235,6 +239,7 @@ function levelOf(remainPct: number, exhausted: boolean): UsageLevel {
 }
 
 interface MetricEntry {
+  id: string;
   label: string;
   snap: RateWindowSnapshot;
 }
@@ -251,12 +256,16 @@ function MetricRow({
   exhaustedLabel,
   resetTimeRelative,
   showAsUsed,
+  expanded,
+  onToggleExpanded,
 }: {
   title: string;
   snap: RateWindowSnapshot;
   exhaustedLabel: string;
   resetTimeRelative: boolean;
   showAsUsed: boolean;
+  expanded: boolean;
+  onToggleExpanded: () => void;
 }) {
   const usedPct = Number.isFinite(snap.usedPercent) ? Math.max(0, snap.usedPercent) : 0;
   const barPct = Math.min(100, usedPct);
@@ -270,6 +279,11 @@ function MetricRow({
     snap.resetDescription,
     resetTimeRelative,
   );
+  const isWeeklyWindow =
+    snap.windowMinutes != null && snap.windowMinutes >= WEEKLY_WINDOW_MINUTES;
+  const paceBudget = isWeeklyWindow ? getPaceBudget(snap) : null;
+  const formatBudget = (value: number) =>
+    value < 10 ? value.toFixed(1).replace(/\.0$/, "") : Math.round(value).toString();
   return (
     <div className="menu-metric">
       <span className="menu-metric__title">{title}</span>
@@ -285,14 +299,43 @@ function MetricRow({
       {snap.isExhausted && (
         <div className="menu-metric__exhausted">{exhaustedLabel}</div>
       )}
-      {snap.reservePercent != null && (
+      {paceBudget && !snap.isExhausted && (
+        <div className="menu-metric__budget">
+          <button
+            type="button"
+            className="menu-metric__budget-header"
+            onClick={onToggleExpanded}
+            aria-expanded={expanded}
+          >
+            <span>On-pace budget</span>
+            <span>{snap.reserveDescription ?? "Lasts until reset"}</span>
+          </button>
+          <div className="menu-metric__budget-pills">
+            {[
+              ["now", paceBudget.now],
+              ["1h", paceBudget.nextHour],
+              ["5h", paceBudget.nextFiveHours],
+              ["today", paceBudget.today],
+            ].map(([label, value]) => (
+              <span className="menu-metric__budget-pill" key={String(label)}>
+                {label} {formatBudget(Number(value))}%
+              </span>
+            ))}
+          </div>
+          {expanded && <PaceDetailsChart snap={snap} />}
+        </div>
+      )}
+      {isWeeklyWindow &&
+        snap.reservePercent != null &&
+        !paceBudget &&
+        !snap.isExhausted && (
         <div className="menu-metric__row menu-metric__reserve">
           <span className="menu-metric__pct">{Math.round(snap.reservePercent)}% in reserve</span>
           {snap.reserveDescription && (
             <span className="menu-metric__reset">{snap.reserveDescription}</span>
           )}
         </div>
-      )}
+        )}
     </div>
   );
 }
@@ -324,6 +367,7 @@ export default function MenuCard({
 }: MenuCardProps) {
   const { t } = useLocale();
   const [chartData, setChartData] = useState<ProviderChartData | null>(null);
+  const [expandedPaceWindow, setExpandedPaceWindow] = useState<string | null>(null);
   const formattedCostReset = useFormattedResetTime(
     provider.cost?.resetsAt ?? null,
     null,
@@ -363,19 +407,36 @@ export default function MenuCard({
   const planName = displayPlanName(provider.planName);
 
   const metrics: MetricEntry[] = [
-    { label: provider.primaryLabel ?? t("DetailWindowPrimary"), snap: provider.primary },
+    {
+      id: "primary",
+      label: provider.primaryLabel ?? t("DetailWindowPrimary"),
+      snap: provider.primary,
+    },
   ];
   if (provider.secondary)
-    metrics.push({ label: provider.secondaryLabel ?? t("DetailWindowSecondary"), snap: provider.secondary });
+    metrics.push({
+      id: "secondary",
+      label: provider.secondaryLabel ?? t("DetailWindowSecondary"),
+      snap: provider.secondary,
+    });
   if (provider.modelSpecific)
     metrics.push({
+      id: "model-specific",
       label: t("DetailWindowModelSpecific"),
       snap: provider.modelSpecific,
     });
   if (provider.tertiary)
-    metrics.push({ label: t("DetailWindowTertiary"), snap: provider.tertiary });
+    metrics.push({
+      id: "tertiary",
+      label: t("DetailWindowTertiary"),
+      snap: provider.tertiary,
+    });
   for (const extra of provider.extraRateWindows ?? []) {
-    metrics.push({ label: extra.title, snap: extra.window });
+    metrics.push({
+      id: `extra-${extra.id}`,
+      label: extra.title,
+      snap: extra.window,
+    });
   }
   const visibleMetrics = compactMetrics ? metrics.slice(0, 2) : metrics;
 
@@ -438,12 +499,19 @@ export default function MenuCard({
             <section className="menu-card__group menu-card__metrics">
               {visibleMetrics.map((m) => (
                 <MetricRow
-                  key={m.label}
+                  key={m.id}
                   title={m.label}
                   snap={m.snap}
                   exhaustedLabel={t("DetailWindowExhausted")}
                   resetTimeRelative={resetTimeRelative}
                   showAsUsed={showAsUsed}
+                  expanded={expandedPaceWindow === m.id}
+                  onToggleExpanded={() => {
+                    setExpandedPaceWindow((current) =>
+                      current === m.id ? null : m.id,
+                    );
+                    requestAnimationFrame(() => onLayoutChange?.());
+                  }}
                 />
               ))}
             </section>

--- a/apps/desktop-tauri/src/components/MenuCard.tsx
+++ b/apps/desktop-tauri/src/components/MenuCard.tsx
@@ -244,6 +244,30 @@ interface MetricEntry {
   snap: RateWindowSnapshot;
 }
 
+type MetricPaceView =
+  | { kind: "budget"; budget: NonNullable<ReturnType<typeof getPaceBudget>> }
+  | { kind: "reserve"; percent: number; description: string | null }
+  | { kind: "none" };
+
+function getMetricPaceView(snap: RateWindowSnapshot): MetricPaceView {
+  if (snap.isExhausted) return { kind: "none" };
+
+  const isWeeklyWindow =
+    snap.windowMinutes != null && snap.windowMinutes >= WEEKLY_WINDOW_MINUTES;
+  const budget = isWeeklyWindow ? getPaceBudget(snap) : null;
+  if (budget) return { kind: "budget", budget };
+
+  if (snap.reservePercent != null) {
+    return {
+      kind: "reserve",
+      percent: snap.reservePercent,
+      description: snap.reserveDescription,
+    };
+  }
+
+  return { kind: "none" };
+}
+
 /**
  * Single metric row inside the card — mirrors upstream `MetricRow`:
  *   • title (body / medium)
@@ -279,9 +303,7 @@ function MetricRow({
     snap.resetDescription,
     resetTimeRelative,
   );
-  const isWeeklyWindow =
-    snap.windowMinutes != null && snap.windowMinutes >= WEEKLY_WINDOW_MINUTES;
-  const paceBudget = isWeeklyWindow ? getPaceBudget(snap) : null;
+  const paceView = getMetricPaceView(snap);
   const formatBudget = (value: number) =>
     value < 10 ? value.toFixed(1).replace(/\.0$/, "") : Math.round(value).toString();
   return (
@@ -299,7 +321,7 @@ function MetricRow({
       {snap.isExhausted && (
         <div className="menu-metric__exhausted">{exhaustedLabel}</div>
       )}
-      {paceBudget && !snap.isExhausted && (
+      {paceView.kind === "budget" && (
         <div className="menu-metric__budget">
           <button
             type="button"
@@ -308,14 +330,14 @@ function MetricRow({
             aria-expanded={expanded}
           >
             <span>On-pace budget</span>
-            <span>{snap.reserveDescription ?? "Lasts until reset"}</span>
+            {snap.reserveDescription && <span>{snap.reserveDescription}</span>}
           </button>
           <div className="menu-metric__budget-pills">
             {[
-              ["now", paceBudget.now],
-              ["1h", paceBudget.nextHour],
-              ["5h", paceBudget.nextFiveHours],
-              ["today", paceBudget.today],
+              ["now", paceView.budget.now],
+              ["1h", paceView.budget.nextHour],
+              ["5h", paceView.budget.nextFiveHours],
+              ["today", paceView.budget.today],
             ].map(([label, value]) => (
               <span className="menu-metric__budget-pill" key={String(label)}>
                 {label} {formatBudget(Number(value))}%
@@ -325,17 +347,14 @@ function MetricRow({
           {expanded && <PaceDetailsChart snap={snap} />}
         </div>
       )}
-      {isWeeklyWindow &&
-        snap.reservePercent != null &&
-        !paceBudget &&
-        !snap.isExhausted && (
+      {paceView.kind === "reserve" && (
         <div className="menu-metric__row menu-metric__reserve">
-          <span className="menu-metric__pct">{Math.round(snap.reservePercent)}% in reserve</span>
-          {snap.reserveDescription && (
-            <span className="menu-metric__reset">{snap.reserveDescription}</span>
+          <span className="menu-metric__pct">{Math.round(paceView.percent)}% in reserve</span>
+          {paceView.description && (
+            <span className="menu-metric__reset">{paceView.description}</span>
           )}
         </div>
-        )}
+      )}
     </div>
   );
 }

--- a/apps/desktop-tauri/src/components/PaceDetailsChart.tsx
+++ b/apps/desktop-tauri/src/components/PaceDetailsChart.tsx
@@ -1,0 +1,79 @@
+import type { RateWindowSnapshot } from "../types/bridge";
+import { getPaceChartSnapshot } from "../lib/paceBudget";
+
+const CHART_WIDTH = 300;
+const CHART_HEIGHT = 76;
+const CHART_PADDING = 4;
+
+function chartX(percent: number): number {
+  return CHART_PADDING + (percent / 100) * (CHART_WIDTH - 2 * CHART_PADDING);
+}
+
+function chartY(percent: number): number {
+  return CHART_HEIGHT - CHART_PADDING
+    - (percent / 100) * (CHART_HEIGHT - 2 * CHART_PADDING);
+}
+
+export default function PaceDetailsChart({
+  snap,
+}: {
+  snap: RateWindowSnapshot;
+}) {
+  const chart = getPaceChartSnapshot(snap);
+  if (!chart) return null;
+
+  const startX = chartX(0);
+  const startY = chartY(0);
+  const nowX = chartX(chart.elapsedPercent);
+  const actualY = chartY(chart.usedPercent);
+  const resetX = chartX(100);
+  const idealResetY = chartY(100);
+  const projectionY = chartY(chart.projectedPercent);
+
+  return (
+    <div className="pace-details-chart">
+      <svg
+        viewBox={`0 0 ${CHART_WIDTH} ${CHART_HEIGHT}`}
+        role="img"
+        aria-label="Average usage pace and projection through the current rate window"
+      >
+        <line
+          className="pace-details-chart__grid"
+          x1={startX}
+          y1={startY}
+          x2={resetX}
+          y2={startY}
+        />
+        <line
+          className="pace-details-chart__ideal"
+          x1={startX}
+          y1={startY}
+          x2={resetX}
+          y2={idealResetY}
+        />
+        <polyline
+          className="pace-details-chart__actual"
+          points={`${startX},${startY} ${nowX},${actualY}`}
+        />
+        <line
+          className="pace-details-chart__projection"
+          x1={nowX}
+          y1={actualY}
+          x2={resetX}
+          y2={projectionY}
+        />
+        <circle
+          className="pace-details-chart__point"
+          cx={nowX}
+          cy={actualY}
+          r="3"
+        />
+      </svg>
+      <div className="pace-details-chart__legend">
+        <span data-series="actual">Average so far</span>
+        <span data-series="ideal">Ideal pace</span>
+        <span data-series="projection">Projection</span>
+      </div>
+    </div>
+  );
+}

--- a/apps/desktop-tauri/src/lib/paceBudget.test.ts
+++ b/apps/desktop-tauri/src/lib/paceBudget.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from "vitest";
+import type { RateWindowSnapshot } from "../types/bridge";
+import { getPaceBudget, getPaceChartSnapshot } from "./paceBudget";
+
+function snapshot(
+  overrides: Partial<RateWindowSnapshot> = {},
+): RateWindowSnapshot {
+  return {
+    usedPercent: 20,
+    remainingPercent: 80,
+    windowMinutes: 10 * 60,
+    resetsAt: "2026-06-12T10:00:00.000Z",
+    resetDescription: null,
+    isExhausted: false,
+    reservePercent: 20,
+    reserveDescription: "Lasts until reset",
+    ...overrides,
+  };
+}
+
+describe("getPaceBudget", () => {
+  it("returns additional usage allowed at each horizon", () => {
+    const budget = getPaceBudget(
+      snapshot(),
+      new Date("2026-06-12T04:00:00.000Z"),
+    );
+
+    expect(budget).toEqual({
+      now: 20,
+      nextHour: 30,
+      nextFiveHours: 70,
+      today: 80,
+    });
+  });
+
+  it("never recommends negative usage when actual usage is ahead of pace", () => {
+    const budget = getPaceBudget(
+      snapshot({ usedPercent: 65, remainingPercent: 35 }),
+      new Date("2026-06-12T04:00:00.000Z"),
+    );
+
+    expect(budget).toMatchObject({ now: 0, nextHour: 0 });
+  });
+
+  it("caps horizons at reset and budgets at remaining quota", () => {
+    const budget = getPaceBudget(
+      snapshot({
+        usedPercent: 10,
+        remainingPercent: 12,
+        resetsAt: "2026-06-12T05:00:00.000Z",
+      }),
+      new Date("2026-06-12T04:30:00.000Z"),
+    );
+
+    expect(budget).toEqual({
+      now: 12,
+      nextHour: 12,
+      nextFiveHours: 12,
+      today: 12,
+    });
+  });
+
+  it("returns no budget for incomplete, expired, or exhausted windows", () => {
+    const now = new Date("2026-06-12T04:00:00.000Z");
+
+    expect(getPaceBudget(snapshot({ resetsAt: null }), now)).toBeNull();
+    expect(getPaceBudget(snapshot({ windowMinutes: null }), now)).toBeNull();
+    expect(
+      getPaceBudget(snapshot({ resetsAt: "2026-06-12T03:00:00.000Z" }), now),
+    ).toBeNull();
+    expect(getPaceBudget(snapshot({ isExhausted: true }), now)).toBeNull();
+  });
+});
+
+describe("getPaceChartSnapshot", () => {
+  it("projects the current average burn rate to reset", () => {
+    const chart = getPaceChartSnapshot(
+      snapshot({ usedPercent: 30 }),
+      new Date("2026-06-12T04:00:00.000Z"),
+    );
+
+    expect(chart).toEqual({
+      elapsedPercent: 40,
+      usedPercent: 30,
+      projectedPercent: 75,
+    });
+  });
+
+  it("projects ahead-of-pace usage above the ideal reset endpoint", () => {
+    const chart = getPaceChartSnapshot(
+      snapshot({ usedPercent: 50 }),
+      new Date("2026-06-12T04:00:00.000Z"),
+    );
+
+    expect(chart).toEqual({
+      elapsedPercent: 40,
+      usedPercent: 50,
+      projectedPercent: 100,
+    });
+  });
+
+  it("clips over-quota usage to the visible chart bounds", () => {
+    const chart = getPaceChartSnapshot(
+      snapshot({ usedPercent: 115 }),
+      new Date("2026-06-12T04:00:00.000Z"),
+    );
+
+    expect(chart).toEqual({
+      elapsedPercent: 40,
+      usedPercent: 100,
+      projectedPercent: 100,
+    });
+  });
+
+  it("returns no chart without a current, valid rate window", () => {
+    const now = new Date("2026-06-12T04:00:00.000Z");
+
+    expect(getPaceChartSnapshot(snapshot({ resetsAt: null }), now)).toBeNull();
+    expect(getPaceChartSnapshot(snapshot({ windowMinutes: null }), now)).toBeNull();
+    expect(
+      getPaceChartSnapshot(
+        snapshot({ resetsAt: "2026-06-12T03:00:00.000Z" }),
+        now,
+      ),
+    ).toBeNull();
+  });
+});

--- a/apps/desktop-tauri/src/lib/paceBudget.ts
+++ b/apps/desktop-tauri/src/lib/paceBudget.ts
@@ -1,0 +1,117 @@
+import type { RateWindowSnapshot } from "../types/bridge";
+
+export interface PaceBudget {
+  now: number;
+  nextHour: number;
+  nextFiveHours: number;
+  today: number;
+}
+
+interface PaceWindow {
+  startMs: number;
+  resetMs: number;
+  durationMs: number;
+}
+
+const HOUR_MS = 60 * 60 * 1000;
+
+function paceWindow(
+  snap: RateWindowSnapshot,
+  nowMs: number,
+): PaceWindow | null {
+  if (
+    snap.windowMinutes == null ||
+    !Number.isFinite(snap.windowMinutes) ||
+    snap.windowMinutes <= 0 ||
+    !snap.resetsAt
+  ) {
+    return null;
+  }
+
+  const resetMs = Date.parse(snap.resetsAt);
+  const durationMs = snap.windowMinutes * 60 * 1000;
+  if (!Number.isFinite(resetMs) || resetMs <= nowMs || durationMs <= 0) {
+    return null;
+  }
+
+  return {
+    startMs: resetMs - durationMs,
+    resetMs,
+    durationMs,
+  };
+}
+
+function startOfTomorrow(now: Date): number {
+  const tomorrow = new Date(now);
+  tomorrow.setHours(24, 0, 0, 0);
+  return tomorrow.getTime();
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
+}
+
+export function getPaceBudget(
+  snap: RateWindowSnapshot,
+  now = new Date(),
+): PaceBudget | null {
+  const nowMs = now.getTime();
+  if (
+    !Number.isFinite(nowMs) ||
+    snap.isExhausted ||
+    !Number.isFinite(snap.usedPercent) ||
+    !Number.isFinite(snap.remainingPercent)
+  ) {
+    return null;
+  }
+
+  const window = paceWindow(snap, nowMs);
+  if (!window) return null;
+
+  const remaining = Math.max(0, snap.remainingPercent);
+  const budgetAt = (targetMs: number) => {
+    const cappedTarget = Math.min(targetMs, window.resetMs);
+    const elapsed = clamp(
+      cappedTarget - window.startMs,
+      0,
+      window.durationMs,
+    );
+    const expectedUsed = (elapsed / window.durationMs) * 100;
+    return clamp(expectedUsed - snap.usedPercent, 0, remaining);
+  };
+
+  return {
+    now: budgetAt(nowMs),
+    nextHour: budgetAt(nowMs + HOUR_MS),
+    nextFiveHours: budgetAt(nowMs + 5 * HOUR_MS),
+    today: budgetAt(startOfTomorrow(now)),
+  };
+}
+
+export interface PaceChartSnapshot {
+  elapsedPercent: number;
+  usedPercent: number;
+  projectedPercent: number;
+}
+
+export function getPaceChartSnapshot(
+  snap: RateWindowSnapshot,
+  now = new Date(),
+): PaceChartSnapshot | null {
+  const nowMs = now.getTime();
+  const window = paceWindow(snap, nowMs);
+  if (!window || !Number.isFinite(snap.usedPercent)) return null;
+
+  const elapsedPercent = clamp(
+    ((nowMs - window.startMs) / window.durationMs) * 100,
+    0,
+    100,
+  );
+  const usedPercent = clamp(snap.usedPercent, 0, 100);
+  const projectedPercent =
+    elapsedPercent > 0
+      ? clamp((usedPercent / elapsedPercent) * 100, 0, 100)
+      : usedPercent;
+
+  return { elapsedPercent, usedPercent, projectedPercent };
+}

--- a/apps/desktop-tauri/src/styles.css
+++ b/apps/desktop-tauri/src/styles.css
@@ -3775,6 +3775,116 @@ html:has(.menu-surface--tray) {
   font-size: 10px;
 }
 
+.menu-metric__budget {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.menu-metric__budget-header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 8px;
+  width: 100%;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: var(--text-primary);
+  font: inherit;
+  font-size: 10px;
+  cursor: pointer;
+}
+
+.menu-metric__budget-header span:last-child {
+  color: var(--text-secondary);
+}
+
+.menu-metric__budget-pills {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+}
+
+.menu-metric__budget-pill {
+  padding: 2px 6px;
+  border: 1px solid var(--usage-bar-track);
+  border-radius: 999px;
+  background: var(--surface-elevated);
+  color: var(--text-secondary);
+  font-size: 9px;
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+
+.pace-details-chart {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+  padding-top: 2px;
+}
+
+.pace-details-chart svg {
+  width: 100%;
+  height: 76px;
+  overflow: visible;
+}
+
+.pace-details-chart__grid {
+  stroke: var(--usage-bar-track);
+  stroke-width: 1;
+}
+
+.pace-details-chart__ideal {
+  stroke: var(--chart-credits-fg);
+  stroke-width: 1.5;
+  vector-effect: non-scaling-stroke;
+}
+
+.pace-details-chart__actual {
+  fill: none;
+  stroke: var(--accent);
+  stroke-width: 2;
+  vector-effect: non-scaling-stroke;
+}
+
+.pace-details-chart__projection {
+  stroke: var(--text-secondary);
+  stroke-width: 1.5;
+  stroke-dasharray: 4 3;
+  vector-effect: non-scaling-stroke;
+}
+
+.pace-details-chart__point {
+  fill: var(--accent);
+  vector-effect: non-scaling-stroke;
+}
+
+.pace-details-chart__legend {
+  display: flex;
+  gap: 10px;
+  color: var(--text-secondary);
+  font-size: 9px;
+}
+
+.pace-details-chart__legend span::before {
+  display: inline-block;
+  width: 8px;
+  height: 2px;
+  margin-right: 4px;
+  vertical-align: middle;
+  background: var(--text-secondary);
+  content: "";
+}
+
+.pace-details-chart__legend span[data-series="actual"]::before {
+  background: var(--accent);
+}
+
+.pace-details-chart__legend span[data-series="ideal"]::before {
+  background: var(--chart-credits-fg);
+}
+
 /* ── Cost section (upstream `tokenUsage` block) ─────────────────────── */
 
 .menu-card__cost-line {


### PR DESCRIPTION
## Summary
- Show weekly usage budgets for now, one hour, five hours, and today.
- Add an expandable weekly pace chart with ideal, average, and projected usage.
- Keep session windows unchanged.
- Preserve the reserve fallback when timing data is incomplete.

Closes #86 
## Testing
- Frontend tests passed: 89 tests.
- Production frontend build passed.
- Manually tested using the portable Windows executable.

## Preview

Default:
<img width="492" height="748" alt="image" src="https://github.com/user-attachments/assets/3d95f21f-6779-4386-a01e-2143710937dc" />

Expanded:
<img width="492" height="900" alt="image" src="https://github.com/user-attachments/assets/af7f501b-ea00-4e5e-9160-643b0db5f3e5" />
