### PR TITLE
Allow provider reordering in tray panel

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,75 @@
+name: Bug report
+description: Report something broken in Win-CodexBar.
+title: "[Bug]: "
+labels: ["bug"]
+body:
+  - type: checkboxes
+    id: existing-issues
+    attributes:
+      label: Existing issues
+      description: Please search open and closed issues before filing a new one.
+      options:
+        - label: I searched existing issues and did not find a duplicate.
+          required: true
+
+  - type: textarea
+    id: summary
+    attributes:
+      label: What happened?
+      description: Describe the bug and the behavior you expected instead.
+      placeholder: The tray panel shows...
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: affected-area
+    attributes:
+      label: Affected area
+      description: Select every surface that seems relevant.
+      options:
+        - label: Tray panel
+        - label: Settings UI
+        - label: Config file / settings persistence
+        - label: CLI
+        - label: Provider-specific behavior
+        - label: Installer / release packaging
+        - label: Startup / background behavior
+        - label: Other
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: Provide the smallest reliable reproduction you know.
+      placeholder: |
+        1. Open...
+        2. Click...
+        3. See...
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs, screenshots, or recordings
+      description: Add logs, screenshots, CUA proof, or a short recording if relevant. Do not paste secrets, tokens, cookies, or API keys.
+      render: text
+
+  - type: input
+    id: version
+    attributes:
+      label: App version
+      description: Version, commit, or installer used.
+      placeholder: v0.33.3
+
+  - type: input
+    id: windows-version
+    attributes:
+      label: Windows version
+      placeholder: Windows 11 24H2
+
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional context
+      description: Anything else that would help debug the issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,65 @@
+name: Feature request
+description: Suggest an improvement for Win-CodexBar.
+title: "[Feature]: "
+labels: ["enhancement"]
+body:
+  - type: checkboxes
+    id: existing-issues
+    attributes:
+      label: Existing issues
+      description: Please search open and closed issues before filing a new one.
+      options:
+        - label: I searched existing issues and did not find a duplicate.
+          required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem or use case
+      description: What are you trying to do, and what is hard or impossible today?
+      placeholder: I want to...
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposed-solution
+    attributes:
+      label: Proposed solution
+      description: Describe the behavior or UX you would like.
+      placeholder: It would be helpful if...
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: affected-area
+    attributes:
+      label: Affected area
+      description: Select every surface that should change or needs consideration.
+      options:
+        - label: Tray panel
+        - label: Settings UI
+        - label: Config file / settings persistence
+        - label: CLI
+        - label: Provider-specific behavior
+        - label: Installer / release packaging
+        - label: Startup / background behavior
+        - label: Documentation
+        - label: Other
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Describe workarounds or other designs you considered.
+
+  - type: textarea
+    id: visual-details
+    attributes:
+      label: Visual details
+      description: Add mockups, screenshots, recordings, or examples if this affects UI/tray behavior.
+
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional context
+      description: Links, related tools, provider docs, or other background.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,46 @@
+## Summary
+
+Describe what changed and why.
+
+## Related issue
+
+Fixes #
+
+## Affected areas
+
+Check every area this PR changes or could affect:
+
+- [ ] Tray panel
+- [ ] Settings UI
+- [ ] Config file / settings persistence
+- [ ] CLI
+- [ ] Provider-specific behavior
+- [ ] Installer / release packaging
+- [ ] Startup / background behavior
+- [ ] Documentation
+- [ ] Other:
+
+## Validation
+
+List the exact commands you ran and their results. If a check is not relevant, say why.
+
+- [ ] `cargo test --manifest-path rust\Cargo.toml`
+- [ ] `cargo test --manifest-path apps\desktop-tauri\src-tauri\Cargo.toml`
+- [ ] `cargo fmt --all`
+- [ ] `cargo clippy --all-targets -- -D warnings`
+- [ ] `pnpm --dir apps\desktop-tauri test`
+- [ ] `pnpm --dir apps\desktop-tauri run build`
+- [ ] Thermo-nuclear code quality review completed before submitting: https://github.com/cursor/plugins/blob/main/cursor-team-kit/skills/thermo-nuclear-code-quality-review/SKILL.md
+- [ ] Other:
+
+## UI / tray proof
+
+For UI, tray, settings, or visual behavior changes, use CUA Driver for visual proof. If CUA Driver cannot be used, explain why and attach equivalent manual proof.
+
+- [ ] Not applicable
+- [ ] CUA Driver visual proof attached
+- [ ] CUA Driver could not be used; equivalent manual proof and explanation attached
+
+## Notes for reviewers
+
+Call out risky areas, follow-up work, or anything reviewers should focus on.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,65 @@
+# Contributing
+
+Thanks for helping improve Win-CodexBar. This repo is the Windows/Tauri port, so prefer the active Tauri and Rust codepaths over historical upstream macOS material.
+
+## Active project layout
+
+- `apps\desktop-tauri\` is the default desktop app.
+- `apps\desktop-tauri\src\` contains the React frontend.
+- `apps\desktop-tauri\src-tauri\src\` contains the Tauri shell, tray bridge, commands, and desktop integration.
+- `rust\src\` contains shared backend/domain logic and the standalone `codexbar` CLI.
+- `rust\src\providers\` contains provider-specific fetch, auth, and parsing logic.
+- `docs\` may include upstream or historical macOS notes. Do not treat those as authoritative for Windows/Tauri work unless the issue is explicitly about upstream parity.
+
+## Before filing an issue
+
+Search existing open and closed issues first. When filing a bug or feature request, use the GitHub issue template and include the affected surfaces, such as tray panel, Settings UI, config file, CLI, installer, or provider-specific behavior.
+
+Do not paste secrets, API keys, cookies, OAuth tokens, private account details, or raw credential files into issues.
+
+## Before opening a PR
+
+Keep PRs focused on one behavior change or fix. Link the issue when one exists, and explain what changed in user-facing terms.
+
+For UI, tray, Settings, or visual behavior changes, use CUA Driver for visual proof. If CUA Driver cannot be used, explain why in the PR and include equivalent manual proof. For provider/parser changes, include deterministic samples or tests where practical.
+
+Before submitting a PR, run a thermo-nuclear code quality review against the final diff and address any structural maintainability issues it finds: https://github.com/cursor/plugins/blob/main/cursor-team-kit/skills/thermo-nuclear-code-quality-review/SKILL.md
+
+## Build and test
+
+Run checks that match the code you changed and list the exact commands in the PR.
+
+Common commands from the repo root:
+
+```powershell
+cargo test --manifest-path rust\Cargo.toml
+cargo test --manifest-path apps\desktop-tauri\src-tauri\Cargo.toml
+cargo fmt --all
+cargo clippy --manifest-path rust\Cargo.toml --all-targets -- -D warnings
+cargo clippy --manifest-path apps\desktop-tauri\src-tauri\Cargo.toml --all-targets -- -D warnings
+pnpm --dir apps\desktop-tauri test
+pnpm --dir apps\desktop-tauri run build
+```
+
+Build the desktop shell through Tauri:
+
+```powershell
+pnpm --dir apps\desktop-tauri tauri:build
+```
+
+Raw `cargo build --release` for the Tauri crate is not the preferred desktop build because it can still point at the dev URL.
+
+## Coding expectations
+
+- Keep provider-specific logic inside the provider module when possible.
+- Route new provider construction through `codexbar::core::instantiate_provider`.
+- Keep settings and ordering behavior in shared Rust when it is cross-surface state.
+- Use existing helpers instead of adding near-duplicate logic.
+- Avoid logging or storing raw secrets.
+- Add focused tests near the changed code.
+- Keep UI behavior accessible; do not rely only on brittle drag/drop when a button or keyboard path is needed.
+- For UI/tray flows, use CUA Driver proof instead of eyeballing only, especially when interaction reliability matters.
+
+## Release and packaging changes
+
+Installer, Winget, and release workflow changes need extra care. Verify release URLs, installer hashes, and packaging behavior before opening a PR that changes release artifacts or manifests.

--- a/apps/desktop-tauri/src-tauri/src/commands/bridge.rs
+++ b/apps/desktop-tauri/src-tauri/src/commands/bridge.rs
@@ -397,6 +397,7 @@ pub struct ProviderCatalogEntry {
 #[serde(rename_all = "camelCase")]
 pub struct SettingsSnapshot {
     enabled_providers: Vec<String>,
+    provider_order: Vec<String>,
     refresh_interval_secs: u64,
     start_at_login: bool,
     start_minimized: bool,
@@ -440,19 +441,20 @@ pub struct SettingsSnapshot {
 
 #[tauri::command]
 pub fn get_bootstrap_state() -> BootstrapState {
+    let settings = Settings::load();
     BootstrapState {
         contract_version: "v1",
         surface_modes: surface_modes(),
         commands: bridge_commands(),
         events: bridge_events(),
-        providers: provider_catalog(),
-        settings: SettingsSnapshot::from(Settings::load()),
+        providers: provider_catalog_for(&settings),
+        settings: SettingsSnapshot::from(settings),
     }
 }
 
 #[tauri::command]
 pub fn get_provider_catalog() -> Vec<ProviderCatalogEntry> {
-    provider_catalog()
+    provider_catalog_for(&Settings::load())
 }
 
 #[tauri::command]
@@ -464,8 +466,12 @@ impl From<Settings> for SettingsSnapshot {
     fn from(settings: Settings) -> Self {
         let avoid_keychain_prompts = settings.claude_avoid_keychain_prompts();
 
-        let mut enabled_providers = settings.enabled_providers.into_iter().collect::<Vec<_>>();
-        enabled_providers.sort();
+        let provider_order = settings.provider_display_order_names();
+        let enabled_providers = provider_order
+            .iter()
+            .filter(|provider_id| settings.enabled_providers.contains(*provider_id))
+            .cloned()
+            .collect();
 
         let provider_metrics = settings
             .provider_metrics
@@ -475,6 +481,7 @@ impl From<Settings> for SettingsSnapshot {
 
         Self {
             enabled_providers,
+            provider_order,
             refresh_interval_secs: settings.refresh_interval_secs,
             start_at_login: settings.start_at_login,
             start_minimized: settings.start_minimized,
@@ -518,9 +525,10 @@ impl From<Settings> for SettingsSnapshot {
     }
 }
 
-fn provider_catalog() -> Vec<ProviderCatalogEntry> {
-    ProviderId::all()
-        .iter()
+pub(crate) fn provider_catalog_for(settings: &Settings) -> Vec<ProviderCatalogEntry> {
+    settings
+        .provider_display_order()
+        .into_iter()
         .map(|provider| ProviderCatalogEntry {
             id: provider.cli_name().to_string(),
             display_name: provider.display_name().to_string(),

--- a/apps/desktop-tauri/src-tauri/src/commands/provider_settings.rs
+++ b/apps/desktop-tauri/src-tauri/src/commands/provider_settings.rs
@@ -12,40 +12,9 @@ pub struct ProviderSummary {
     pub order: u32,
 }
 
-/// Canonicalise a requested provider order: keep requested ids that match a
-/// real `ProviderId`, drop duplicates, and append any canonical ids that were
-/// omitted (preserving their canonical order).
-pub(crate) fn apply_provider_order(requested: &[String]) -> Vec<String> {
-    let canonical: Vec<String> = ProviderId::all()
-        .iter()
-        .map(|p| p.cli_name().to_string())
-        .collect();
-    let valid: std::collections::HashSet<&str> = canonical.iter().map(|s| s.as_str()).collect();
-
-    let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
-    let mut out: Vec<String> = Vec::with_capacity(canonical.len());
-
-    for id in requested {
-        if valid.contains(id.as_str()) && seen.insert(id.clone()) {
-            out.push(id.clone());
-        }
-    }
-    for id in &canonical {
-        if seen.insert(id.clone()) {
-            out.push(id.clone());
-        }
-    }
-
-    out
-}
-
 /// Build `ProviderSummary` list honouring the persisted `provider_order`.
 pub(crate) fn build_provider_summaries(settings: &Settings) -> Vec<ProviderSummary> {
-    let order = if settings.provider_order.is_empty() {
-        apply_provider_order(&[])
-    } else {
-        apply_provider_order(&settings.provider_order)
-    };
+    let order = settings.provider_display_order_names();
 
     let by_id: std::collections::HashMap<String, &ProviderId> = ProviderId::all()
         .iter()
@@ -67,10 +36,14 @@ pub(crate) fn build_provider_summaries(settings: &Settings) -> Vec<ProviderSumma
 }
 
 #[tauri::command]
-pub fn reorder_providers(ids: Vec<String>) -> Result<Vec<ProviderSummary>, String> {
+pub fn reorder_providers(
+    app: tauri::AppHandle,
+    ids: Vec<String>,
+) -> Result<Vec<ProviderSummary>, String> {
     let mut settings = Settings::load();
-    settings.provider_order = apply_provider_order(&ids);
+    settings.provider_order = codexbar::settings::normalize_provider_order(&ids);
     settings.save().map_err(|e| e.to_string())?;
+    crate::tray_bridge::refresh_tray_presentation(&app);
     Ok(build_provider_summaries(&settings))
 }
 

--- a/apps/desktop-tauri/src-tauri/src/commands/tests.rs
+++ b/apps/desktop-tauri/src-tauri/src/commands/tests.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use super::{
-    ProviderSummary, ProviderUsageSnapshot, apply_provider_order, bridge_commands, bridge_events,
+    ProviderSummary, ProviderUsageSnapshot, bridge_commands, bridge_events,
     provider_cookie_source_lookup, provider_region_lookup, validate_external_url,
     validate_surface_target,
 };
@@ -193,7 +193,8 @@ fn bootstrap_contract_lists_global_shortcut_event() {
 fn apply_provider_order_dedupes_and_appends_unknown_canonical() {
     // Request only "codex" and "claude" — remaining canonical ids should
     // be appended after, preserving canonical order.
-    let order = apply_provider_order(&["codex".to_string(), "claude".to_string()]);
+    let order =
+        codexbar::settings::normalize_provider_order(&["codex".to_string(), "claude".to_string()]);
     assert_eq!(order[0], "codex");
     assert_eq!(order[1], "claude");
     // Every canonical id appears exactly once.
@@ -213,7 +214,10 @@ fn apply_provider_order_dedupes_and_appends_unknown_canonical() {
 
 #[test]
 fn apply_provider_order_ignores_unknown_ids() {
-    let order = apply_provider_order(&["not-a-provider".to_string(), "codex".to_string()]);
+    let order = codexbar::settings::normalize_provider_order(&[
+        "not-a-provider".to_string(),
+        "codex".to_string(),
+    ]);
     assert_eq!(order[0], "codex");
     assert!(!order.iter().any(|id| id == "not-a-provider"));
 }
@@ -228,6 +232,67 @@ fn provider_summaries_reflect_settings_order() {
     for (i, s) in summaries.iter().enumerate() {
         assert_eq!(s.order, i as u32);
     }
+}
+
+#[test]
+fn provider_catalog_preserves_partial_config_order() {
+    let settings = Settings {
+        provider_order: codexbar::settings::normalize_provider_order(&[
+            "gemini".to_string(),
+            "claude".to_string(),
+            "codex".to_string(),
+        ]),
+        ..Settings::default()
+    };
+
+    let catalog = super::provider_catalog_for(&settings);
+
+    assert_eq!(
+        catalog
+            .iter()
+            .take(3)
+            .map(|provider| provider.id.as_str())
+            .collect::<Vec<_>>(),
+        vec!["gemini", "claude", "codex"]
+    );
+}
+
+#[test]
+fn settings_snapshot_preserves_partial_config_order_for_enabled_providers() {
+    let settings = Settings {
+        enabled_providers: ["gemini", "claude", "codex"]
+            .into_iter()
+            .map(str::to_string)
+            .collect(),
+        provider_order: codexbar::settings::normalize_provider_order(&[
+            "gemini".to_string(),
+            "claude".to_string(),
+            "codex".to_string(),
+        ]),
+        ..Settings::default()
+    };
+
+    let snapshot = serde_json::to_value(super::SettingsSnapshot::from(settings)).unwrap();
+
+    assert_eq!(
+        snapshot["providerOrder"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .take(3)
+            .map(|value| value.as_str().unwrap())
+            .collect::<Vec<_>>(),
+        vec!["gemini", "claude", "codex"],
+    );
+    assert_eq!(
+        snapshot["enabledProviders"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|value| value.as_str().unwrap())
+            .collect::<Vec<_>>(),
+        vec!["gemini", "claude", "codex"],
+    );
 }
 
 #[test]

--- a/apps/desktop-tauri/src-tauri/src/tray_bridge.rs
+++ b/apps/desktop-tauri/src-tauri/src/tray_bridge.rs
@@ -404,10 +404,15 @@ pub fn update_tray_icon_and_tooltip(
     };
 
     // ── Icon ─────────────────────────────────────────────────────────────
-    let ok_snapshots: Vec<_> = snapshots.iter().filter(|s| s.error.is_none()).collect();
+    let settings = Settings::load();
+    let ordered_snapshots = ordered_snapshot_refs(&settings, snapshots);
+    let ok_snapshots: Vec<_> = ordered_snapshots
+        .iter()
+        .copied()
+        .filter(|s| s.error.is_none())
+        .collect();
     let all_error = ok_snapshots.is_empty() && !snapshots.is_empty();
 
-    let settings = Settings::load();
     let prefer_highest = settings.menu_bar_shows_highest_usage
         || settings.menu_bar_display_mode.as_str() == "minimal";
 
@@ -437,7 +442,11 @@ fn status_labels_for_settings(
     settings: &Settings,
     snapshots: &[crate::commands::ProviderUsageSnapshot],
 ) -> Vec<(String, String)> {
-    let healthy: Vec<_> = snapshots.iter().filter(|s| s.error.is_none()).collect();
+    let ordered_snapshots = ordered_snapshot_refs(settings, snapshots);
+    let healthy: Vec<_> = ordered_snapshots
+        .into_iter()
+        .filter(|s| s.error.is_none())
+        .collect();
     if settings.tray_icon_mode == TrayIconMode::PerProvider {
         return healthy
             .into_iter()
@@ -454,6 +463,30 @@ fn status_labels_for_settings(
 
     let (_, label) = provider_status_label(selected);
     vec![("status_summary".to_string(), label)]
+}
+
+fn ordered_snapshot_refs<'a>(
+    settings: &Settings,
+    snapshots: &'a [crate::commands::ProviderUsageSnapshot],
+) -> Vec<&'a crate::commands::ProviderUsageSnapshot> {
+    let order = settings
+        .provider_display_order_names()
+        .into_iter()
+        .enumerate()
+        .map(|(index, provider_id)| (provider_id, index))
+        .collect::<std::collections::HashMap<_, _>>();
+    let mut ordered = snapshots.iter().collect::<Vec<_>>();
+    ordered.sort_by(|a, b| {
+        let a_order = order.get(&a.provider_id);
+        let b_order = order.get(&b.provider_id);
+        match (a_order, b_order) {
+            (Some(a_order), Some(b_order)) if a_order != b_order => a_order.cmp(b_order),
+            (Some(_), None) => std::cmp::Ordering::Less,
+            (None, Some(_)) => std::cmp::Ordering::Greater,
+            _ => a.display_name.cmp(&b.display_name),
+        }
+    });
+    ordered
 }
 
 fn provider_status_label(snapshot: &crate::commands::ProviderUsageSnapshot) -> (String, String) {
@@ -999,6 +1032,10 @@ mod tests {
     fn status_labels_per_provider_mode_lists_each_healthy_provider() {
         let settings = Settings {
             tray_icon_mode: TrayIconMode::PerProvider,
+            provider_order: codexbar::settings::normalize_provider_order(&[
+                "claude".to_string(),
+                "codex".to_string(),
+            ]),
             ..Settings::default()
         };
         let snapshots = vec![
@@ -1011,8 +1048,8 @@ mod tests {
         assert_eq!(
             labels,
             vec![
-                ("codex".to_string(), "Codex 30%".to_string()),
                 ("claude".to_string(), "Claude 72%".to_string()),
+                ("codex".to_string(), "Codex 30%".to_string()),
             ]
         );
     }

--- a/apps/desktop-tauri/src/i18n/keys.ts
+++ b/apps/desktop-tauri/src/i18n/keys.ts
@@ -436,6 +436,8 @@ export const ALL_LOCALE_KEYS = [
   "ProviderSidebarClearSearch",
   "ProviderSidebarNoMatches",
   "ProviderSidebarReorderHint",
+  "ProviderSidebarMoveUp",
+  "ProviderSidebarMoveDown",
   "ProviderStatusOk",
   "ProviderStatusStale",
   "ProviderStatusError",

--- a/apps/desktop-tauri/src/lib/providerOrder.test.ts
+++ b/apps/desktop-tauri/src/lib/providerOrder.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import { orderProviderSnapshots } from "./providerOrder";
+import type { ProviderCatalogEntry, ProviderUsageSnapshot } from "../types/bridge";
+
+const catalog: ProviderCatalogEntry[] = [
+  { id: "codex", displayName: "Codex", cookieDomain: null },
+  { id: "claude", displayName: "Claude", cookieDomain: null },
+  { id: "gemini", displayName: "Gemini", cookieDomain: null },
+];
+
+function snapshot(providerId: string, displayName: string): ProviderUsageSnapshot {
+  return {
+    providerId,
+    displayName,
+    primary: {
+      usedPercent: 0,
+      remainingPercent: 100,
+      windowMinutes: null,
+      resetsAt: null,
+      resetDescription: null,
+      isExhausted: false,
+      reservePercent: null,
+      reserveDescription: null,
+    },
+    secondary: null,
+    modelSpecific: null,
+    tertiary: null,
+    extraRateWindows: [],
+    cost: null,
+    planName: null,
+    accountEmail: null,
+    sourceLabel: "test",
+    updatedAt: "2026-01-01T00:00:00Z",
+    error: null,
+    pace: null,
+    accountOrganization: null,
+    trayStatusLabel: null,
+  };
+}
+
+describe("orderProviderSnapshots", () => {
+  it("uses persisted provider order before catalog order", () => {
+    const ordered = orderProviderSnapshots(
+      [
+        snapshot("codex", "Codex"),
+        snapshot("claude", "Claude"),
+        snapshot("gemini", "Gemini"),
+      ],
+      catalog,
+      ["codex", "claude", "gemini"],
+      ["gemini", "claude", "codex"],
+    );
+
+    expect(ordered.map((provider) => provider.providerId)).toEqual([
+      "gemini",
+      "claude",
+      "codex",
+    ]);
+  });
+});

--- a/apps/desktop-tauri/src/lib/providerOrder.ts
+++ b/apps/desktop-tauri/src/lib/providerOrder.ts
@@ -4,14 +4,18 @@ export function orderProviderSnapshots(
   providers: ProviderUsageSnapshot[],
   catalog: ProviderCatalogEntry[],
   enabledProviderIds: string[],
+  providerOrder: string[] = [],
 ): ProviderUsageSnapshot[] {
   const order = new Map<string, number>();
-  for (const [index, provider] of catalog.entries()) {
-    order.set(provider.id, index);
+  const orderedIds = providerOrder.length > 0
+    ? providerOrder
+    : catalog.map((provider) => provider.id);
+  for (const [index, providerId] of orderedIds.entries()) {
+    order.set(providerId, index);
   }
   for (const [index, providerId] of enabledProviderIds.entries()) {
     if (!order.has(providerId)) {
-      order.set(providerId, catalog.length + index);
+      order.set(providerId, orderedIds.length + index);
     }
   }
 

--- a/apps/desktop-tauri/src/lib/trayProviders.ts
+++ b/apps/desktop-tauri/src/lib/trayProviders.ts
@@ -24,18 +24,27 @@ export function orderedEnabledProviderSlots(
   catalog: ProviderCatalogEntry[],
   enabledProviderIds: string[],
   snapshots: ProviderUsageSnapshot[],
+  providerOrder: string[] = [],
 ): TrayProviderSlot[] {
   const enabled = new Set(enabledProviderIds);
+  const catalogById = new Map(catalog.map((provider) => [provider.id, provider]));
   const snapshotNames = new Map(
     snapshots.map((provider) => [provider.providerId, provider.displayName]),
   );
   const slots: TrayProviderSlot[] = [];
   const seen = new Set<string>();
+  const orderedIds = providerOrder.length > 0
+    ? providerOrder
+    : catalog.map((provider) => provider.id);
 
-  for (const provider of catalog) {
-    if (!enabled.has(provider.id)) continue;
-    seen.add(provider.id);
-    slots.push({ id: provider.id, displayName: provider.displayName });
+  for (const providerId of orderedIds) {
+    if (!enabled.has(providerId)) continue;
+    seen.add(providerId);
+    slots.push({
+      id: providerId,
+      displayName:
+        catalogById.get(providerId)?.displayName ?? snapshotNames.get(providerId) ?? providerId,
+    });
   }
 
   for (const providerId of enabledProviderIds) {

--- a/apps/desktop-tauri/src/styles.css
+++ b/apps/desktop-tauri/src/styles.css
@@ -2131,7 +2131,7 @@ body:has(.tray-panel-reveal) {
 .providers-sidebar__row {
   position: relative;
   display: grid;
-  grid-template-columns: 8px 24px 1fr auto auto;
+  grid-template-columns: 8px 24px 1fr auto auto auto;
   align-items: center;
   gap: 8px;
   padding: 8px 16px 8px 10px;
@@ -2280,6 +2280,43 @@ body:has(.tray-panel-reveal) {
 .providers-sidebar__row--selected .providers-sidebar__handle,
 .providers-sidebar__row--dragging .providers-sidebar__handle {
   opacity: 0.7;
+}
+
+.providers-sidebar__reorder-controls {
+  display: inline-flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.providers-sidebar__reorder-button {
+  width: 18px;
+  height: 16px;
+  display: inline-grid;
+  place-items: center;
+  padding: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  background: transparent;
+  color: var(--provider-row-text-secondary);
+  cursor: pointer;
+  font-size: 0.62rem;
+  line-height: 1;
+  opacity: 0.72;
+  transition: background 120ms ease, border-color 120ms ease, color 120ms ease, opacity 120ms ease;
+}
+
+.providers-sidebar__reorder-button:hover:not(:disabled),
+.providers-sidebar__reorder-button:focus-visible {
+  background: var(--surface-card-hover);
+  border-color: var(--provider-row-border-selected);
+  color: var(--provider-row-text-primary);
+  opacity: 1;
+  outline: none;
+}
+
+.providers-sidebar__reorder-button:disabled {
+  cursor: default;
+  opacity: 0.2;
 }
 
 .providers-sidebar__checkbox {
@@ -4748,7 +4785,7 @@ html:has(.menu-surface--tray) {
   border: 1px solid rgba(0, 0, 0, 0.10);
 }
 .providers-sidebar__row {
-  grid-template-columns: 12px var(--icon-sidebar) 1fr auto auto;
+  grid-template-columns: 12px var(--icon-sidebar) 1fr auto auto auto;
   padding: 6px 8px;
 }
 .providers-sidebar__name {

--- a/apps/desktop-tauri/src/surfaces/PopOutPanel.tsx
+++ b/apps/desktop-tauri/src/surfaces/PopOutPanel.tsx
@@ -41,8 +41,13 @@ export default function PopOutPanel({
   const { t } = useLocale();
 
   const sorted = useMemo(() => {
-    return orderProviderSnapshots(providers, state.providers, settings.enabledProviders);
-  }, [providers, settings.enabledProviders, state.providers]);
+    return orderProviderSnapshots(
+      providers,
+      state.providers,
+      settings.enabledProviders,
+      settings.providerOrder,
+    );
+  }, [providers, settings.enabledProviders, settings.providerOrder, state.providers]);
   const [selectedProviderId, setSelectedProviderId] = useState<string | null>(
     providerId ?? null,
   );

--- a/apps/desktop-tauri/src/surfaces/TrayPanel.tsx
+++ b/apps/desktop-tauri/src/surfaces/TrayPanel.tsx
@@ -82,12 +82,24 @@ export default function TrayPanel({ state }: { state: BootstrapState }) {
   const surfaceTarget = useSurfaceTarget("trayPanel");
 
   const sorted = useMemo(
-    () => orderProviderSnapshots(providers, state.providers, settings.enabledProviders),
-    [providers, settings.enabledProviders, state.providers],
+    () =>
+      orderProviderSnapshots(
+        providers,
+        state.providers,
+        settings.enabledProviders,
+        settings.providerOrder,
+      ),
+    [providers, settings.enabledProviders, settings.providerOrder, state.providers],
   );
   const denseProviderSlots = useMemo(
-    () => orderedEnabledProviderSlots(state.providers, settings.enabledProviders, sorted),
-    [settings.enabledProviders, sorted, state.providers],
+    () =>
+      orderedEnabledProviderSlots(
+        state.providers,
+        settings.enabledProviders,
+        sorted,
+        settings.providerOrder,
+      ),
+    [settings.enabledProviders, settings.providerOrder, sorted, state.providers],
   );
   const providersById = useMemo(
     () => new Map(sorted.map((provider) => [provider.providerId, provider])),

--- a/apps/desktop-tauri/src/surfaces/settings/providers/ProvidersSidebar.test.tsx
+++ b/apps/desktop-tauri/src/surfaces/settings/providers/ProvidersSidebar.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { LocaleProvider } from "../../../i18n/LocaleProvider";
 import { buildBundle } from "../../../test/localeHarness";
@@ -40,6 +40,8 @@ describe("ProvidersSidebar", () => {
     tauriMocks.getLocaleStrings.mockResolvedValue(buildBundle({
       ProviderSidebarSearch: "Search",
       ProviderSidebarNoMatches: "No matching providers",
+      ProviderSidebarMoveUp: "Move up",
+      ProviderSidebarMoveDown: "Move down",
     }));
     eventMocks.listen.mockResolvedValue(() => {});
   });
@@ -85,5 +87,53 @@ describe("ProvidersSidebar", () => {
 
     expect(await screen.findByRole("searchbox", { name: "Search" })).toBeInTheDocument();
     expect(screen.getByText("No matching providers")).toBeInTheDocument();
+  });
+
+  it("reorders providers through explicit move buttons", async () => {
+    const onReorder = vi.fn();
+    const { container } = render(
+      <LocaleProvider>
+        <ProvidersSidebar
+          providers={rows()}
+          selectedId="codex"
+          searchText=""
+          onSearchTextChange={vi.fn()}
+          onSelect={vi.fn()}
+          onReorder={onReorder}
+          onToggleEnabled={vi.fn()}
+        />
+      </LocaleProvider>,
+    );
+
+    fireEvent.click(await screen.findByRole("button", { name: "Move down Codex" }));
+
+    const names = Array.from(
+      container.querySelectorAll(".providers-sidebar__name"),
+      (node) => node.textContent,
+    );
+    expect(names.slice(0, 3)).toEqual(["Claude", "Codex", "Cursor"]);
+    expect(onReorder).toHaveBeenCalledWith([
+      "claude",
+      "codex",
+      ...TEST_PROVIDER_CATALOG.slice(2).map(([id]) => id),
+    ]);
+  });
+
+  it("does not let the first provider move up", async () => {
+    render(
+      <LocaleProvider>
+        <ProvidersSidebar
+          providers={rows()}
+          selectedId="codex"
+          searchText=""
+          onSearchTextChange={vi.fn()}
+          onSelect={vi.fn()}
+          onReorder={vi.fn()}
+          onToggleEnabled={vi.fn()}
+        />
+      </LocaleProvider>,
+    );
+
+    expect(await screen.findByRole("button", { name: "Move up Codex" })).toBeDisabled();
   });
 });

--- a/apps/desktop-tauri/src/surfaces/settings/providers/ProvidersSidebar.tsx
+++ b/apps/desktop-tauri/src/surfaces/settings/providers/ProvidersSidebar.tsx
@@ -56,6 +56,7 @@ const STATUS_TO_KEY: Record<ProviderSidebarStatus, LocaleKey> = {
  * Responsibilities (Phase 6a only):
  *  - render rows with brand icon + status dot + two-line subtitle + toggle
  *  - drag-and-drop reorder (HTML5 native; emits `onReorder`)
+ *  - button reorder for WebView2/automation paths where HTML5 drag can be brittle
  *  - keyboard reorder: Alt+ArrowUp / Alt+ArrowDown on the selected row
  *  - mount-in reveal animation keyed on row id
  */
@@ -222,12 +223,14 @@ export function ProvidersSidebar({
             {t("ProviderSidebarNoMatches")}
           </li>
         )}
-        {ordered.map((p) => {
+        {ordered.map((p, index) => {
           const isSelected = p.id === selectedId;
           const isDrop = dropTargetId === p.id;
           const isDragging = dragId === p.id;
           const reveal = justMounted.has(p.id);
           const brand = getProviderIcon(p.id).brandColor;
+          const canMoveUp = index > 0 && !disabled;
+          const canMoveDown = index < ordered.length - 1 && !disabled;
           const cls = [
             "providers-sidebar__row",
             isSelected && "providers-sidebar__row--selected",
@@ -284,6 +287,34 @@ export function ProvidersSidebar({
                 title={t("ProviderSidebarReorderHint")}
               >
                 ⋮⋮
+              </span>
+              <span className="providers-sidebar__reorder-controls">
+                <button
+                  type="button"
+                  className="providers-sidebar__reorder-button"
+                  disabled={!canMoveUp}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    moveId(p.id, -1);
+                  }}
+                  aria-label={`${t("ProviderSidebarMoveUp")} ${p.displayName}`}
+                  title={`${t("ProviderSidebarMoveUp")} ${p.displayName}`}
+                >
+                  ↑
+                </button>
+                <button
+                  type="button"
+                  className="providers-sidebar__reorder-button"
+                  disabled={!canMoveDown}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    moveId(p.id, 1);
+                  }}
+                  aria-label={`${t("ProviderSidebarMoveDown")} ${p.displayName}`}
+                  title={`${t("ProviderSidebarMoveDown")} ${p.displayName}`}
+                >
+                  ↓
+                </button>
               </span>
               <input
                 type="checkbox"

--- a/apps/desktop-tauri/src/types/bridge.ts
+++ b/apps/desktop-tauri/src/types/bridge.ts
@@ -161,6 +161,7 @@ export interface ProviderSummary {
 
 export interface SettingsSnapshot {
   enabledProviders: string[];
+  providerOrder?: string[];
   refreshIntervalSecs: number;
   startAtLogin: boolean;
   startMinimized: boolean;

--- a/rust/src/locale.rs
+++ b/rust/src/locale.rs
@@ -620,6 +620,8 @@ pub enum LocaleKey {
     ProviderSidebarClearSearch,
     ProviderSidebarNoMatches,
     ProviderSidebarReorderHint,
+    ProviderSidebarMoveUp,
+    ProviderSidebarMoveDown,
     ProviderStatusOk,
     ProviderStatusStale,
     ProviderStatusError,

--- a/rust/src/locale/chinese.rs
+++ b/rust/src/locale/chinese.rs
@@ -558,6 +558,8 @@ impl LocaleKey {
             LocaleKey::ProviderSidebarClearSearch => "清除提供商搜索",
             LocaleKey::ProviderSidebarNoMatches => "没有匹配的提供商",
             LocaleKey::ProviderSidebarReorderHint => "拖动以重新排序",
+            LocaleKey::ProviderSidebarMoveUp => "上移",
+            LocaleKey::ProviderSidebarMoveDown => "下移",
             LocaleKey::ProviderStatusOk => "已更新",
             LocaleKey::ProviderStatusStale => "已过期",
             LocaleKey::ProviderStatusError => "错误",

--- a/rust/src/locale/english.rs
+++ b/rust/src/locale/english.rs
@@ -596,6 +596,8 @@ impl LocaleKey {
             LocaleKey::ProviderSidebarClearSearch => "Clear provider search",
             LocaleKey::ProviderSidebarNoMatches => "No matching providers",
             LocaleKey::ProviderSidebarReorderHint => "Drag to reorder",
+            LocaleKey::ProviderSidebarMoveUp => "Move up",
+            LocaleKey::ProviderSidebarMoveDown => "Move down",
             LocaleKey::ProviderStatusOk => "Up to date",
             LocaleKey::ProviderStatusStale => "Stale",
             LocaleKey::ProviderStatusError => "Error",

--- a/rust/src/locale/japanese.rs
+++ b/rust/src/locale/japanese.rs
@@ -596,6 +596,8 @@ impl LocaleKey {
             LocaleKey::ProviderSidebarClearSearch => "Clear provider search",
             LocaleKey::ProviderSidebarNoMatches => "No matching providers",
             LocaleKey::ProviderSidebarReorderHint => "Drag to reorder",
+            LocaleKey::ProviderSidebarMoveUp => "Move up",
+            LocaleKey::ProviderSidebarMoveDown => "Move down",
             LocaleKey::ProviderStatusOk => "Up to date",
             LocaleKey::ProviderStatusStale => "Stale",
             LocaleKey::ProviderStatusError => "Error",

--- a/rust/src/locale/keys.rs
+++ b/rust/src/locale/keys.rs
@@ -672,6 +672,11 @@ impl LocaleKey {
             LocaleKey::ProviderSidebarReorderHint,
             "ProviderSidebarReorderHint",
         ),
+        (LocaleKey::ProviderSidebarMoveUp, "ProviderSidebarMoveUp"),
+        (
+            LocaleKey::ProviderSidebarMoveDown,
+            "ProviderSidebarMoveDown",
+        ),
         (LocaleKey::ProviderStatusOk, "ProviderStatusOk"),
         (LocaleKey::ProviderStatusStale, "ProviderStatusStale"),
         (LocaleKey::ProviderStatusError, "ProviderStatusError"),

--- a/rust/src/settings.rs
+++ b/rust/src/settings.rs
@@ -241,6 +241,35 @@ pub fn normalize_float_bar_style(value: &str) -> String {
     }
 }
 
+/// Canonicalize a requested provider display order.
+///
+/// Keeps requested provider IDs that map to a real [`ProviderId`], drops
+/// duplicates, and appends omitted providers in canonical order. An empty
+/// request intentionally returns the full canonical order so display callers
+/// can use one path for default and customized ordering.
+pub fn normalize_provider_order(requested: &[String]) -> Vec<String> {
+    let canonical = ProviderId::all()
+        .iter()
+        .map(|provider| provider.cli_name().to_string())
+        .collect::<Vec<_>>();
+    let valid = canonical.iter().map(String::as_str).collect::<HashSet<_>>();
+    let mut seen = HashSet::new();
+    let mut out = Vec::with_capacity(canonical.len());
+
+    for provider_id in requested {
+        if valid.contains(provider_id.as_str()) && seen.insert(provider_id.clone()) {
+            out.push(provider_id.clone());
+        }
+    }
+    for provider_id in canonical {
+        if seen.insert(provider_id.clone()) {
+            out.push(provider_id);
+        }
+    }
+
+    out
+}
+
 fn default_global_shortcut() -> String {
     "Ctrl+Shift+U".to_string()
 }
@@ -455,23 +484,36 @@ impl Settings {
 
     /// Get list of enabled provider IDs
     pub fn get_enabled_provider_ids(&self) -> Vec<ProviderId> {
-        ProviderId::all()
-            .iter()
-            .filter(|id| self.is_provider_enabled(**id))
-            .copied()
+        self.provider_display_order()
+            .into_iter()
+            .filter(|id| self.is_provider_enabled(*id))
             .collect()
     }
 
     /// Get all available providers with their enabled status
     pub fn get_all_providers_status(&self) -> Vec<ProviderStatus> {
-        ProviderId::all()
-            .iter()
+        self.provider_display_order()
+            .into_iter()
             .map(|id| ProviderStatus {
                 id: id.cli_name().to_string(),
                 name: id.display_name().to_string(),
-                enabled: self.is_provider_enabled(*id),
+                enabled: self.is_provider_enabled(id),
             })
             .collect()
+    }
+
+    /// Provider display order as typed IDs, falling back to canonical order
+    /// when no custom order has been persisted.
+    pub fn provider_display_order(&self) -> Vec<ProviderId> {
+        normalize_provider_order(&self.provider_order)
+            .into_iter()
+            .filter_map(|provider_id| ProviderId::from_cli_name(&provider_id))
+            .collect()
+    }
+
+    /// Provider display order as CLI-name strings.
+    pub fn provider_display_order_names(&self) -> Vec<String> {
+        normalize_provider_order(&self.provider_order)
     }
 
     /// Get the metric preference for a provider

--- a/rust/src/settings/raw.rs
+++ b/rust/src/settings/raw.rs
@@ -443,7 +443,11 @@ impl From<RawSettings> for Settings {
             hide_personal_info: raw.hide_personal_info,
             update_channel: raw.update_channel,
             provider_metrics: raw.provider_metrics,
-            provider_order: raw.provider_order,
+            provider_order: if raw.provider_order.is_empty() {
+                Vec::new()
+            } else {
+                normalize_provider_order(&raw.provider_order)
+            },
             global_shortcut: raw.global_shortcut,
             auto_download_updates: raw.auto_download_updates,
             install_updates_on_quit: raw.install_updates_on_quit,

--- a/rust/src/settings/tests.rs
+++ b/rust/src/settings/tests.rs
@@ -168,6 +168,42 @@ fn test_settings_get_enabled_provider_ids() {
 }
 
 #[test]
+fn provider_order_dedupes_unknowns_and_appends_canonical_ids() {
+    let order = normalize_provider_order(&[
+        "gemini".to_string(),
+        "not-a-provider".to_string(),
+        "claude".to_string(),
+        "gemini".to_string(),
+    ]);
+
+    assert_eq!(order[0], "gemini");
+    assert_eq!(order[1], "claude");
+    assert!(!order.iter().any(|id| id == "not-a-provider"));
+    assert_eq!(order.len(), ProviderId::all().len());
+}
+
+#[test]
+fn enabled_provider_ids_follow_custom_provider_order() {
+    let settings = Settings {
+        enabled_providers: ["claude", "codex", "gemini"]
+            .into_iter()
+            .map(str::to_string)
+            .collect(),
+        provider_order: normalize_provider_order(&[
+            "gemini".to_string(),
+            "claude".to_string(),
+            "codex".to_string(),
+        ]),
+        ..Settings::default()
+    };
+
+    assert_eq!(
+        settings.get_enabled_provider_ids(),
+        vec![ProviderId::Gemini, ProviderId::Claude, ProviderId::Codex]
+    );
+}
+
+#[test]
 fn test_settings_get_all_providers_status() {
     let settings = Settings::default();
     let status = settings.get_all_providers_status();


### PR DESCRIPTION
## Summary

Adds provider display ordering as shared settings state and wires it through Settings, tray panel, pop-out, dense tray slots, native tray bridge, and backend provider snapshots. Also adds reliable accessible Move up / Move down controls for provider rows while keeping drag/drop and keyboard reorder behavior.

Adds contributor issue/PR templates and CONTRIBUTING guidance for future UI visual proof with CUA Driver and pre-submit thermo-nuclear code quality review.

Closes #90

## Affected areas

- [x] Tray panel
- [x] Settings UI
- [x] Config file / settings persistence
- [x] CLI
- [x] Provider-specific behavior
- [ ] Installer / release packaging
- [ ] Startup / background behavior
- [x] Documentation
- [ ] Other:

## Validation

- [x] `cargo test --manifest-path rust\Cargo.toml`
- [x] `cargo test --manifest-path apps\desktop-tauri\src-tauri\Cargo.toml`
- [x] `cargo fmt --all`
- [x] `cargo clippy --manifest-path rust\Cargo.toml --all-targets -- -D warnings`
- [x] `cargo clippy --manifest-path apps\desktop-tauri\src-tauri\Cargo.toml --all-targets -- -D warnings`
- [x] `pnpm --dir apps\desktop-tauri test`
- [x] `pnpm --dir apps\desktop-tauri run build`
- [x] Thermo-nuclear code quality review completed before submitting: https://github.com/cursor/plugins/blob/main/cursor-team-kit/skills/thermo-nuclear-code-quality-review/SKILL.md
- [x] Focused regression checks: backend partial config order tests and `src\lib\providerOrder.test.ts`

## UI / tray proof

- [ ] Not applicable
- [x] CUA Driver visual proof attached
- [ ] CUA Driver could not be used; equivalent manual proof and explanation attached

CUA Driver verified config-file order `Gemini -> Claude -> Codex` in Settings and tray panel, and verified the Settings Move up / Move down controls persist order into the tray panel.

## Notes for reviewers

Provider order is canonicalized in shared Rust settings and then consumed by bridge/catalog/tray/frontend surfaces to avoid per-surface ordering drift.