### PR TITLE
Fix dev prerequisite guidance

### DIFF
--- a/dev.ps1
+++ b/dev.ps1
@@ -4,9 +4,8 @@
     Build and run the CodexBar Tauri desktop shell for Windows.
 
 .DESCRIPTION
-    Checks that build prerequisites are installed (Rust, MinGW-w64),
-    installs them if missing, then builds the Tauri desktop shell through the
-    Tauri CLI and launches it.
+    Checks that build prerequisites are installed, then builds the Tauri desktop
+    shell through the Tauri CLI and launches it.
 
 .PARAMETER Release
     Build in release mode (optimised). Default is debug.
@@ -74,6 +73,26 @@ function Get-DesktopBinaryCandidates {
     return $candidates | Select-Object -Unique
 }
 
+function Write-PrerequisiteHelp {
+    param(
+        [string[]]$Missing
+    )
+
+    Write-Host "Missing prerequisites: $($Missing -join ', ')" -ForegroundColor Yellow
+    Write-Host ""
+    Write-Host "Install the required tools, restart your terminal, then rerun .\dev.ps1." -ForegroundColor Yellow
+    Write-Host ""
+    Write-Host "Required:" -ForegroundColor Cyan
+    Write-Host "  - Rust/Cargo: https://rustup.rs/ or 'mise install rust@stable'" -ForegroundColor Cyan
+    Write-Host "  - Node.js + pnpm: https://nodejs.org/ and 'corepack enable pnpm', or mise-managed node/pnpm" -ForegroundColor Cyan
+    Write-Host "  - Microsoft Visual Studio Build Tools with the Desktop development with C++ workload" -ForegroundColor Cyan
+    if ($Missing -contains "dlltool (MinGW-w64)") {
+        Write-Host ""
+        Write-Host "This shell is using a GNU Rust target, which also needs MinGW-w64 dlltool." -ForegroundColor Yellow
+        Write-Host "Install MinGW-w64 or switch Rust to the MSVC target: rustup default stable-x86_64-pc-windows-msvc" -ForegroundColor Yellow
+    }
+}
+
 # ── Ensure known tool paths are in current session PATH ─────────────────────
 
 $knownPaths = @("$env:USERPROFILE\.cargo\bin", "C:\mingw64\bin")
@@ -94,29 +113,8 @@ if (-not $hasCargo -or ($needsDlltool -and -not $hasDlltool)) {
     $missing = @()
     if (-not $hasCargo)   { $missing += "cargo (Rust)" }
     if ($needsDlltool -and -not $hasDlltool) { $missing += "dlltool (MinGW-w64)" }
-    Write-Host "Missing prerequisites: $($missing -join ', ')" -ForegroundColor Yellow
-    Write-Host "Running setup script..." -ForegroundColor Cyan
-    Write-Host ""
-
-    $setupScript = Join-Path $RepoRoot "scripts\setup-windows.ps1"
-    if (-not (Test-Path $setupScript)) {
-        Write-Host "ERROR: Setup script not found at $setupScript" -ForegroundColor Red
-        exit 1
-    }
-
-    & $setupScript
-
-    # Re-check after setup
-    $hasCargo = [bool](Get-Command cargo -ErrorAction SilentlyContinue)
-    $rustHostTriple = Get-RustHostTriple
-    $needsDlltool = $rustHostTriple -like '*-windows-gnu'
-    $hasDlltool = [bool](Get-Command dlltool -ErrorAction SilentlyContinue)
-    if (-not $hasCargo -or ($needsDlltool -and -not $hasDlltool)) {
-        Write-Host ""
-        Write-Host "ERROR: Prerequisites still missing after setup." -ForegroundColor Red
-        Write-Host "Please restart your terminal and try again." -ForegroundColor Yellow
-        exit 1
-    }
+    Write-PrerequisiteHelp -Missing $missing
+    exit 1
 }
 
 $pnpmCommand = Get-Command pnpm.cmd -ErrorAction SilentlyContinue

--- a/extra-docs/BUILDING.md
+++ b/extra-docs/BUILDING.md
@@ -2,14 +2,12 @@
 
 ## Prerequisites
 
-- **Rust** 1.70+ with `x86_64-pc-windows-gnu` target
-- **MinGW-w64** (for the GNU linker)
-- **Node.js** 18+ and pnpm
+- **Rust** stable with the `x86_64-pc-windows-msvc` target
+- **Microsoft Visual Studio Build Tools** with the **Desktop development with C++** workload
+- **Node.js** 20+ and pnpm
 
-Install prerequisites automatically:
-```powershell
-.\scripts\setup-windows.ps1
-```
+Install the tools manually with rustup/winget/corepack, or use a tool manager
+such as mise. There is no automatic Windows bootstrap script in this port.
 
 ## Build the Desktop App
 


### PR DESCRIPTION
## Summary

Fixes `dev.ps1` so missing Rust/MinGW prerequisites no longer try to run the deleted `scripts\setup-windows.ps1` bootstrap script. The script now exits with current prerequisite guidance for Rust/Cargo, Node/pnpm, Visual Studio Build Tools, and MinGW only when the shell is using a GNU Rust target.

Also updates the stale source-build doc to describe the current MSVC-based Windows prerequisites instead of the removed setup script.

Closes #92

## Affected areas

- [ ] Tray panel
- [ ] Settings UI
- [ ] Config file / settings persistence
- [ ] CLI
- [ ] Provider-specific behavior
- [x] Installer / release packaging
- [x] Startup / background behavior
- [x] Documentation
- [ ] Other:

## Validation

- [ ] `cargo test --manifest-path rust\Cargo.toml`
- [ ] `cargo test --manifest-path apps\desktop-tauri\src-tauri\Cargo.toml`
- [ ] `cargo fmt --all`
- [ ] `cargo clippy --all-targets -- -D warnings`
- [ ] `pnpm --dir apps\desktop-tauri test`
- [ ] `pnpm --dir apps\desktop-tauri run build`
- [ ] Thermo-nuclear code quality review completed before submitting: https://github.com/cursor/plugins/blob/main/cursor-team-kit/skills/thermo-nuclear-code-quality-review/SKILL.md
- [x] Parsed `dev.ps1` with PowerShell parser
- [x] `git diff --check -- dev.ps1 extra-docs\BUILDING.md`
- [x] Verified no remaining `setup-windows.ps1` / `Setup script not found` references in `dev.ps1`, docs, or READMEs

## UI / tray proof

- [x] Not applicable
- [ ] CUA Driver visual proof attached
- [ ] CUA Driver could not be used; equivalent manual proof and explanation attached

## Notes for reviewers

This is a script/docs fix for a removed bootstrap file, not a runtime app behavior change.