### PR TITLE
Fix tray panel reveal and floatbar sizing

### DIFF
--- a/apps/desktop-tauri/src-tauri/src/shell/tests.rs
+++ b/apps/desktop-tauri/src-tauri/src/shell/tests.rs
@@ -9,7 +9,8 @@ use super::transition::{
     monitor_for_preserved_visible_position, reclamp_preserved_visible_position,
     recovery_snapshot_for_failed_transition, resolve_transition_position,
     resolve_transition_request, restore_recovery_surface, restore_surface_snapshot,
-    should_hide_tray_panel_on_toggle, should_synthesize_default_position,
+    should_force_tray_panel_reveal, should_hide_tray_panel_on_toggle,
+    should_synthesize_default_position,
 };
 use super::window::{hide_to_tray_state, prepare_hide_to_tray_if_current};
 
@@ -68,6 +69,19 @@ fn tray_toggle_hides_only_when_panel_window_is_visible() {
         false
     ));
     assert!(!should_hide_tray_panel_on_toggle(SurfaceMode::Hidden, true));
+}
+
+#[test]
+fn tray_reveal_fallback_only_for_hidden_tray_panel() {
+    assert!(should_force_tray_panel_reveal(
+        SurfaceMode::TrayPanel,
+        false
+    ));
+    assert!(!should_force_tray_panel_reveal(
+        SurfaceMode::TrayPanel,
+        true
+    ));
+    assert!(!should_force_tray_panel_reveal(SurfaceMode::Hidden, false));
 }
 
 #[test]

--- a/apps/desktop-tauri/src-tauri/src/shell/transition.rs
+++ b/apps/desktop-tauri/src-tauri/src/shell/transition.rs
@@ -26,6 +26,42 @@ fn os_position(_window: &WebviewWindow, x: i32, y: i32) -> tauri::PhysicalPositi
     tauri::PhysicalPosition::new(x, y)
 }
 
+pub(super) fn should_force_tray_panel_reveal(
+    current: SurfaceMode,
+    main_window_visible: bool,
+) -> bool {
+    current == SurfaceMode::TrayPanel && !main_window_visible
+}
+
+fn schedule_tray_panel_reveal_fallback(app: &AppHandle) {
+    const DELAY: std::time::Duration = std::time::Duration::from_millis(500);
+    let app = app.clone();
+    let _ = std::thread::spawn(move || {
+        std::thread::sleep(DELAY);
+        let app_on_main = app.clone();
+        if let Err(error) = app.run_on_main_thread(move || {
+            let Some(state) = app_on_main.try_state::<Mutex<AppState>>() else {
+                return;
+            };
+            let current = state
+                .lock()
+                .map(|guard| guard.surface_machine.current())
+                .unwrap_or(SurfaceMode::Hidden);
+            let Some(window) = app_on_main.get_webview_window("main") else {
+                return;
+            };
+            let visible = window.is_visible().unwrap_or(false);
+            if should_force_tray_panel_reveal(current, visible)
+                && let Err(error) = show_window(&window)
+            {
+                tracing::debug!("shell: tray reveal fallback show failed: {error}");
+            }
+        }) {
+            tracing::debug!("shell: tray reveal fallback could not run: {error}");
+        }
+    });
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(super) struct SurfaceSnapshot {
     pub mode: SurfaceMode,
@@ -461,6 +497,8 @@ pub(super) fn apply_transition(
             // the pre-measure blank/backing frame.
             if needs_show && transition.to != SurfaceMode::TrayPanel {
                 let _ = show_window(window);
+            } else if needs_show {
+                schedule_tray_panel_reveal_fallback(app);
             }
             clamp_current_window_to_work_area(window);
 

--- a/apps/desktop-tauri/src/floatbar/FloatBar.tsx
+++ b/apps/desktop-tauri/src/floatbar/FloatBar.tsx
@@ -2,6 +2,7 @@ import {
   useCallback,
   useEffect,
   useMemo,
+  useRef,
   useState,
   type CSSProperties,
   type MouseEvent,
@@ -204,20 +205,32 @@ export default function FloatBar({ state }: { state: BootstrapState }) {
     return [...list].sort((a, b) => b.primary.usedPercent - a.primary.usedPercent);
   }, [providers, settings.enabledProviders, filterIds]);
 
-  // Resize the window to fit content when the visible set or orientation
-  // changes. The native `resize_float_bar` command owns both the size change
-  // and the Win32 interaction state, so the webview only reports a target size.
-  useEffect(() => {
+  // Keep the native floatbar window fitted when late data/fonts/icons change layout.
+  const lastResizeRef = useRef<{ w: number; h: number } | null>(null);
+  const resizeRafRef = useRef<number | null>(null);
+  const resizeToContent = useCallback(() => {
     const el = document.querySelector<HTMLElement>(".floatbar");
     if (!el) return;
-    requestAnimationFrame(() => {
+    if (resizeRafRef.current !== null) {
+      cancelAnimationFrame(resizeRafRef.current);
+    }
+    resizeRafRef.current = requestAnimationFrame(() => {
+      resizeRafRef.current = null;
       const rect = el.getBoundingClientRect();
       const padding = 8;
       const w = Math.ceil(rect.width + padding);
       const h = Math.ceil(rect.height + padding);
+      const last = lastResizeRef.current;
+      if (last && Math.abs(last.w - w) <= 1 && Math.abs(last.h - h) <= 1) return;
+      lastResizeRef.current = { w, h };
       void resizeFloatBar(w, h).catch(() => {});
     });
+  }, []);
+
+  useEffect(() => {
+    resizeToContent();
   }, [
+    resizeToContent,
     visible.length,
     orientation,
     style,
@@ -225,6 +238,23 @@ export default function FloatBar({ state }: { state: BootstrapState }) {
     showResetInline,
     settings.resetTimeRelative,
   ]);
+
+  useEffect(() => {
+    const el = document.querySelector<HTMLElement>(".floatbar");
+    if (!el || typeof ResizeObserver === "undefined") return;
+    const observer = new ResizeObserver(resizeToContent);
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [resizeToContent]);
+
+  useEffect(
+    () => () => {
+      if (resizeRafRef.current !== null) {
+        cancelAnimationFrame(resizeRafRef.current);
+      }
+    },
+    [],
+  );
 
   const highRemaining = 100 - settings.highUsageThreshold;
   const critRemaining = 100 - settings.criticalUsageThreshold;


### PR DESCRIPTION
Fixes #97.

## Summary
- Re-measure the floating bar with `ResizeObserver` so late data/fonts/icons cannot clip pills.
- Add a guarded tray-panel reveal fallback if the frontend layout reveal never fires.
- Cover the tray reveal guard with a small Rust test.

## Validation
- `pnpm --dir apps\desktop-tauri run build`
- `pnpm --dir apps\desktop-tauri test`
- `cargo test --manifest-path apps\desktop-tauri\src-tauri\Cargo.toml`
- `cargo test --manifest-path apps\desktop-tauri\src-tauri\Cargo.toml shell::tests::tray_reveal_fallback_only_for_hidden_tray_panel`
- `cargo clippy --manifest-path apps\desktop-tauri\src-tauri\Cargo.toml --all-targets -- -D warnings`