### PR TITLE
Fix Windows tray panel startup reveal

### DIFF
--- a/apps/desktop-tauri/src-tauri/src/main.rs
+++ b/apps/desktop-tauri/src-tauri/src/main.rs
@@ -57,13 +57,39 @@ where
     })
 }
 
-fn launch_behavior<I, S>(force_visible: bool, args: I) -> LaunchBehavior
+fn nonblank_launch_args<I, S>(args: I) -> Vec<String>
 where
     I: IntoIterator<Item = S>,
     S: AsRef<str>,
 {
+    args.into_iter()
+        .map(|arg| arg.as_ref().trim().to_string())
+        .filter(|arg| !arg.is_empty())
+        .collect()
+}
+
+fn should_reopen_tray_panel_from_instance_args<I, S>(args: I) -> bool
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<str>,
+{
+    let args = nonblank_launch_args(args);
+    args.is_empty() || should_open_tray_panel_from_args(&args)
+}
+
+fn launch_behavior<I, S>(force_visible: bool, start_minimized: bool, args: I) -> LaunchBehavior
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<str>,
+{
+    let args = nonblank_launch_args(args);
+    let explicit_tray_launch = should_open_tray_panel_from_args(&args);
+    let plain_desktop_launch = args.is_empty();
+
     LaunchBehavior {
-        open_tray_panel_at_start: force_visible || should_open_tray_panel_from_args(args),
+        open_tray_panel_at_start: force_visible
+            || explicit_tray_launch
+            || (plain_desktop_launch && !start_minimized),
         suppress_blur_dismiss: force_visible,
     }
 }
@@ -78,7 +104,12 @@ fn main() {
     let proof_config = proof_harness::ProofConfig::from_env();
     let is_proof_mode = proof_config.is_some();
     let force_start_visible = std::env::var_os("CODEXBAR_START_VISIBLE").is_some();
-    let launch = launch_behavior(force_start_visible, std::env::args().skip(1));
+    let settings = codexbar::settings::Settings::load();
+    let launch = launch_behavior(
+        force_start_visible,
+        settings.start_minimized,
+        std::env::args().skip(1),
+    );
 
     let mut initial_state = AppState::new();
     initial_state.proof_config = proof_config;
@@ -87,7 +118,7 @@ fn main() {
         .manage(Mutex::new(initial_state))
         .plugin(shortcut_bridge::plugin())
         .plugin(tauri_plugin_single_instance::init(|app, args, _cwd| {
-            if args.len() <= 1 || should_open_tray_panel_from_args(args.iter().skip(1)) {
+            if should_reopen_tray_panel_from_instance_args(args.iter().skip(1)) {
                 let _ = shell::reopen_to_target(
                     app,
                     SurfaceMode::TrayPanel,
@@ -315,12 +346,64 @@ mod tests {
     #[test]
     fn unrelated_launch_args_do_not_open_tray_panel() {
         assert!(!should_open_tray_panel_from_args(["usage", "-p", "claude"]));
+        assert!(!should_reopen_tray_panel_from_instance_args([
+            "usage", "-p", "claude"
+        ]));
+        assert_eq!(
+            launch_behavior(false, false, ["usage", "-p", "claude"]),
+            LaunchBehavior {
+                open_tray_panel_at_start: false,
+                suppress_blur_dismiss: false,
+            }
+        );
+    }
+
+    #[test]
+    fn plain_desktop_launch_opens_unless_start_minimized() {
+        assert_eq!(
+            launch_behavior(false, false, std::iter::empty::<&str>()),
+            LaunchBehavior {
+                open_tray_panel_at_start: true,
+                suppress_blur_dismiss: false,
+            }
+        );
+        assert_eq!(
+            launch_behavior(false, false, [""]),
+            LaunchBehavior {
+                open_tray_panel_at_start: true,
+                suppress_blur_dismiss: false,
+            }
+        );
+        assert_eq!(
+            launch_behavior(false, false, ["  "]),
+            LaunchBehavior {
+                open_tray_panel_at_start: true,
+                suppress_blur_dismiss: false,
+            }
+        );
+        assert_eq!(
+            launch_behavior(false, true, std::iter::empty::<&str>()),
+            LaunchBehavior {
+                open_tray_panel_at_start: false,
+                suppress_blur_dismiss: false,
+            }
+        );
+    }
+
+    #[test]
+    fn single_instance_plain_launch_reopens_tray_panel() {
+        assert!(should_reopen_tray_panel_from_instance_args(
+            std::iter::empty::<&str>()
+        ));
+        assert!(should_reopen_tray_panel_from_instance_args([""]));
+        assert!(should_reopen_tray_panel_from_instance_args(["  "]));
+        assert!(should_reopen_tray_panel_from_instance_args(["menubar"]));
     }
 
     #[test]
     fn menubar_launch_does_not_suppress_blur_dismiss() {
         assert_eq!(
-            launch_behavior(false, ["menubar"]),
+            launch_behavior(false, true, ["menubar"]),
             LaunchBehavior {
                 open_tray_panel_at_start: true,
                 suppress_blur_dismiss: false,
@@ -330,7 +413,7 @@ mod tests {
 
     #[test]
     fn automation_launch_opens_and_suppresses_blur_dismiss() {
-        let launch = launch_behavior(true, std::iter::empty::<&str>());
+        let launch = launch_behavior(true, true, std::iter::empty::<&str>());
         assert_eq!(
             launch,
             LaunchBehavior {
@@ -343,7 +426,7 @@ mod tests {
 
     #[test]
     fn proof_mode_suppresses_blur_dismiss() {
-        let launch = launch_behavior(false, std::iter::empty::<&str>());
+        let launch = launch_behavior(false, true, std::iter::empty::<&str>());
         assert!(should_suppress_blur_dismiss(launch, true));
     }
 

--- a/apps/desktop-tauri/src-tauri/src/main.rs
+++ b/apps/desktop-tauri/src-tauri/src/main.rs
@@ -26,6 +26,7 @@ use tauri::Manager;
 
 const PROOF_ACTIVATION_DELAY: Duration = Duration::from_millis(0);
 const VISIBLE_START_ACTIVATION_DELAY: Duration = Duration::from_millis(0);
+const STARTUP_TRAY_BLUR_GRACE: Duration = Duration::from_secs(2);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct LaunchBehavior {
@@ -196,12 +197,18 @@ fn main() {
                 let app = app.handle().clone();
                 tauri::async_runtime::spawn(async move {
                     tokio::time::sleep(VISIBLE_START_ACTIVATION_DELAY).await;
+                    if let Some(state) = app.try_state::<Mutex<AppState>>() {
+                        state.lock().unwrap().arm_startup_tray_reveal(
+                            std::time::Instant::now() + STARTUP_TRAY_BLUR_GRACE,
+                        );
+                    }
                     let _ = shell::reopen_to_target(
                         &app,
                         SurfaceMode::TrayPanel,
                         SurfaceTarget::Summary,
                         None,
                     );
+                    shell::schedule_startup_tray_panel_reveal_fallback(&app);
                 });
             }
 
@@ -224,6 +231,14 @@ fn main() {
                         launch,
                         proof_harness::is_proof_mode(window.app_handle()),
                     ) {
+                        return;
+                    }
+                    if let Some(st) = window.app_handle().try_state::<Mutex<AppState>>()
+                        && st
+                            .lock()
+                            .unwrap()
+                            .take_startup_tray_blur_grace(std::time::Instant::now())
+                    {
                         return;
                     }
                     // Grace period: ignore blur within 500ms of showing the panel.

--- a/apps/desktop-tauri/src-tauri/src/shell/mod.rs
+++ b/apps/desktop-tauri/src-tauri/src/shell/mod.rs
@@ -22,7 +22,8 @@ pub use position::{
     shortcut_panel_position, tray_panel_position,
 };
 pub use transition::{
-    handle_tray_panel_click, reopen_to_target, toggle_tray_panel, transition_to_target,
+    handle_tray_panel_click, reopen_to_target, schedule_startup_tray_panel_reveal_fallback,
+    toggle_tray_panel, transition_to_target,
 };
 #[allow(unused_imports)]
 pub use window::{

--- a/apps/desktop-tauri/src-tauri/src/shell/transition.rs
+++ b/apps/desktop-tauri/src-tauri/src/shell/transition.rs
@@ -62,6 +62,42 @@ fn schedule_tray_panel_reveal_fallback(app: &AppHandle) {
     });
 }
 
+pub fn schedule_startup_tray_panel_reveal_fallback(app: &AppHandle) {
+    const DELAY: std::time::Duration = std::time::Duration::from_millis(750);
+    let app = app.clone();
+    let _ = std::thread::spawn(move || {
+        std::thread::sleep(DELAY);
+        let app_on_main = app.clone();
+        if let Err(error) = app.run_on_main_thread(move || {
+            let Some(state) = app_on_main.try_state::<Mutex<AppState>>() else {
+                return;
+            };
+            let should_reveal = state
+                .lock()
+                .map(|mut guard| guard.take_startup_tray_reveal_fallback())
+                .unwrap_or(false);
+            if !should_reveal {
+                return;
+            }
+            let Some(window) = app_on_main.get_webview_window("main") else {
+                return;
+            };
+            let current = state
+                .lock()
+                .map(|guard| guard.surface_machine.current())
+                .unwrap_or(SurfaceMode::Hidden);
+            let visible = window.is_visible().unwrap_or(false);
+            if should_force_tray_panel_reveal(current, visible)
+                && let Err(error) = show_window(&window)
+            {
+                tracing::debug!("shell: startup tray reveal fallback show failed: {error}");
+            }
+        }) {
+            tracing::debug!("shell: startup tray reveal fallback could not run: {error}");
+        }
+    });
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(super) struct SurfaceSnapshot {
     pub mode: SurfaceMode,

--- a/apps/desktop-tauri/src-tauri/src/state.rs
+++ b/apps/desktop-tauri/src-tauri/src/state.rs
@@ -405,4 +405,15 @@ mod tests {
         assert!(state.take_startup_tray_reveal_fallback());
         assert!(!state.take_startup_tray_reveal_fallback());
     }
+
+    #[test]
+    fn expired_startup_tray_blur_grace_is_consumed_without_suppressing() {
+        let mut state = AppState::new();
+        let now = std::time::Instant::now();
+
+        state.arm_startup_tray_reveal(now - std::time::Duration::from_secs(1));
+
+        assert!(!state.take_startup_tray_blur_grace(now));
+        assert!(!state.take_startup_tray_blur_grace(now));
+    }
 }

--- a/apps/desktop-tauri/src-tauri/src/state.rs
+++ b/apps/desktop-tauri/src-tauri/src/state.rs
@@ -141,6 +141,11 @@ pub struct AppState {
     /// Instant when focus loss last dismissed the tray panel. The following
     /// tray click consumes this marker instead of reopening the panel.
     pub last_blur_dismissed_at: Option<std::time::Instant>,
+    /// One-shot grace for a blur event caused while revealing the tray panel
+    /// during explicit startup.
+    pub startup_tray_blur_grace_until: Option<std::time::Instant>,
+    /// Whether the explicit startup path may use its delayed shell fallback.
+    pub startup_tray_reveal_pending: bool,
 }
 
 impl Default for AppState {
@@ -181,6 +186,8 @@ impl AppState {
             notification_manager: codexbar::notifications::NotificationManager::new(),
             last_shown_at: None,
             last_blur_dismissed_at: None,
+            startup_tray_blur_grace_until: None,
+            startup_tray_reveal_pending: false,
         }
     }
 
@@ -196,6 +203,21 @@ impl AppState {
         self.last_blur_dismissed_at
             .take()
             .is_some_and(|dismissed_at| now.duration_since(dismissed_at) <= max_age)
+    }
+
+    pub fn arm_startup_tray_reveal(&mut self, grace_until: std::time::Instant) {
+        self.startup_tray_blur_grace_until = Some(grace_until);
+        self.startup_tray_reveal_pending = true;
+    }
+
+    pub fn take_startup_tray_blur_grace(&mut self, now: std::time::Instant) -> bool {
+        self.startup_tray_blur_grace_until
+            .take()
+            .is_some_and(|until| now <= until)
+    }
+
+    pub fn take_startup_tray_reveal_fallback(&mut self) -> bool {
+        std::mem::take(&mut self.startup_tray_reveal_pending)
     }
 
     pub fn transition_surface(
@@ -360,5 +382,27 @@ mod tests {
         );
 
         assert_eq!(state.current_target, SurfaceTarget::Dashboard);
+    }
+
+    #[test]
+    fn startup_tray_blur_grace_is_consumed_once() {
+        let mut state = AppState::new();
+        let now = std::time::Instant::now();
+
+        state.arm_startup_tray_reveal(now + std::time::Duration::from_secs(1));
+
+        assert!(state.take_startup_tray_blur_grace(now));
+        assert!(!state.take_startup_tray_blur_grace(now));
+    }
+
+    #[test]
+    fn startup_tray_reveal_fallback_is_consumed_once() {
+        let mut state = AppState::new();
+        let now = std::time::Instant::now();
+
+        state.arm_startup_tray_reveal(now + std::time::Duration::from_secs(1));
+
+        assert!(state.take_startup_tray_reveal_fallback());
+        assert!(!state.take_startup_tray_reveal_fallback());
     }
 }


### PR DESCRIPTION
## Summary

This is a follow-up to #98 / #97 for a Windows tray-panel startup path that can still fail after the reveal fallback fix.

On a Windows 11 machine, released builds `0.37.3`/`0.37.4` still started from the autorun command:

```powershell
"%LOCALAPPDATA%\Programs\CodexBar\codexbar-desktop.exe" menubar
```

but could settle back into the hidden single-instance window:

- window title: `com.codexbar.desktop-siw`
- `Get-Process codexbar-desktop` reported `Responding = False` or only a tiny hidden/single-instance rect
- tray panel did not remain visible/open on first startup

The CLI/provider diagnostics were healthy, so this looked isolated to the desktop/Tauri tray surface.

## Fix

- Treat explicit tray-panel startup args (`menubar`, `tray`, `traypanel`) as visible-start launches for blur-dismiss purposes.
- Add a short startup activation delay so the first `menubar` transition runs after Tauri/WebView2 has finished creating the main window.
- Reveal the tray panel from the Rust shell path immediately, while keeping the existing delayed fallback as a guard.
- Slightly widen the recent blur-dismiss suppression windows for Windows/WebView2 focus churn.
- Update the launch-behavior test to document the new expectation.

## Local verification

After applying this patch locally and rebuilding, starting the app from a stopped state with the same `menubar` command kept the panel visible and responsive without requiring a second trigger:

- window title: `CodexBar Desktop`
- window rect: `328x861`
- `Responding = True`
- no new Windows Application hang event
- Codex and Claude diagnostics still succeeded

## Checks

```powershell
cargo fmt --manifest-path apps/desktop-tauri/src-tauri/Cargo.toml --all -- --check
cargo test --manifest-path apps/desktop-tauri/src-tauri/Cargo.toml shell::tests::tray_reveal_fallback_only_for_hidden_tray_panel
cargo test --manifest-path apps/desktop-tauri/src-tauri/Cargo.toml menubar_launch_arg_opens_tray_panel
cargo test --manifest-path apps/desktop-tauri/src-tauri/Cargo.toml menubar_launch_suppresses_startup_blur_dismiss
pnpm --dir apps/desktop-tauri run build
pnpm --dir apps/desktop-tauri run tauri:build
```
