### PR TITLE
feat: add Mexican Spanish (es-MX) locale with centralized language catalog

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,4 @@ codexbar-desktop-tauri.exe
 
 # Local git worktrees
 .worktrees/
+.atl/

--- a/README.es-MX.md
+++ b/README.es-MX.md
@@ -53,7 +53,7 @@ Para Claude, se prefieren las cookies del navegador/sessionKey porque coinciden 
 
 ## Última versión
 
-**v0.33.2** corrige el cierre del panel de bandeja para que el panel emergente se cierre al perder el foco o al presionar Escape, sin reabrirse inmediatamente por el mismo clic en la bandeja.
+**v0.37.5** corrige las rutas de inicio del escritorio de Windows que podían dejar CodexBar ejecutándose solo con la ventana interna del shell Tauri. Reabre el panel de bandeja en inicios normales o sin argumentos, a menos que **Inicio minimizado** esté activado. Recupera aperturas de bandeja que quedaban ocultas o atascadas en tamaño mínimo.
 
 Consulta el historial completo en [CHANGELOG.md](CHANGELOG.md).
 
@@ -147,7 +147,7 @@ Las compilaciones con instalador incluyen `codexbar.exe` como la CLI de consola 
 Para compilaciones de versión locales en Windows, usa el constructor de versiones en caché:
 
 ```powershell
-.\scripts\windows-release-build.ps1 -Ref v0.33.2 -SmokeInstall
+.\scripts\windows-release-build.ps1 -Ref v0.37.5 -SmokeInstall
 ```
 
 El script compila el binario real de versión de Tauri más la CLI de consola, verifica las dependencias firmadas del instalador, empaqueta con Inno Setup, genera los archivos de instalador/portable, genera los archivos SHA-256 complementarios y puede ejecutar una prueba de instalación/desinstalación silenciosa.

--- a/README.es-MX.md
+++ b/README.es-MX.md
@@ -1,0 +1,180 @@
+# Win-CodexBar
+
+[English README](./README.md) | [简体中文](./README.zh-CN.md)
+
+Win-CodexBar es una aplicación de bandeja del sistema para Windows que mantiene visible el uso de herramientas de codificación con IA sin necesidad de abrir una docena de paneles. Traslada el espíritu de [CodexBar](https://github.com/steipete/CodexBar) a un entorno de escritorio Tauri + React respaldado por lógica compartida de proveedores en Rust.
+
+<table>
+  <tr>
+    <td width="36%" align="center">
+      <img src="extra-docs/images/tray-panel.png" alt="Panel de bandeja de Win-CodexBar mostrando tarjetas de uso de proveedores"/>
+    </td>
+    <td width="64%" align="center">
+      <img src="extra-docs/images/settings-providers.png" alt="Página de configuración de Proveedores de Win-CodexBar"/>
+    </td>
+  </tr>
+</table>
+
+## Destacados
+
+- **48 proveedores** incluyendo Codex, Claude, Copilot, OpenRouter, Cursor, Gemini, DeepSeek, MiniMax, Kiro, Antigravity, Groq y más.
+- **Flujo centrado en la bandeja** con una cuadrícula compacta de proveedores, tarjetas de uso, acción de actualización, acceso directo a configuración y control de cierre.
+- **Configuración por proveedor** para selección de fuente, credenciales, importación de cookies, cuentas de token, claves API, regiones y preferencias de visualización en bandeja.
+- **Protección de credenciales en Windows** para claves API gestionadas por la aplicación, cookies manuales y cuentas de token, utilizando DPAPI con ámbito de usuario cuando está disponible.
+- **Importación de cookies del navegador** para Chrome, Edge, Brave y Firefox, con activación opcional por proveedor.
+- **CLI local instalada** para consultar uso, costo, configuración, diagnóstico e integraciones de bucle local.
+- **Compilaciones con instalador y portable** con arranque de WebView2 Runtime, arranque de VC++ Runtime y archivos de suma de verificación SHA-256.
+
+## Instalación
+
+Instalar con el Administrador de Paquetes de Windows:
+
+```powershell
+winget install Finesssee.Win-CodexBar
+```
+
+O descarga la última versión (instalador o portable) desde [GitHub Releases](https://github.com/Finesssee/Win-CodexBar/releases).
+
+- Instalador: `CodexBar-<version>-Setup.exe`
+- Portable: `CodexBar-<version>-portable.exe`
+- Sumas de verificación: cada versión incluye archivos `.sha256`
+
+La distribución por Winget está aprobada a través de [microsoft/winget-pkgs](https://github.com/microsoft/winget-pkgs/tree/master/manifests/f/Finesssee/Win-CodexBar). Las nuevas versiones pueden tardar un poco en aparecer porque cada actualización de Winget está vinculada a una URL de versión específica y su hash de instalador.
+
+## Primer uso
+
+1. Inicia **CodexBar** desde el Menú Inicio o el ejecutable portable.
+2. Haz clic en el icono de la bandeja para abrir el panel de uso.
+3. Abre **Configuración → Proveedores**.
+4. Habilita los proveedores que uses.
+5. Agrega el tipo de credencial correspondiente: inicio de sesión OAuth/dispositivo, clave API, cookies del navegador, inicio de sesión CLI local o cuenta de token.
+
+Para Claude, se prefieren las cookies del navegador/sessionKey porque coinciden con el uso que muestra la página de configuración de Claude. OAuth y CLI permanecen como alternativas. Para proveedores basados en CLI como Codex y Gemini, inicia sesión primero con la CLI del proveedor.
+
+## Última versión
+
+**v0.33.2** corrige el cierre del panel de bandeja para que el panel emergente se cierre al perder el foco o al presionar Escape, sin reabrirse inmediatamente por el mismo clic en la bandeja.
+
+Consulta el historial completo en [CHANGELOG.md](CHANGELOG.md).
+
+## Proveedores compatibles
+
+<details>
+<summary>Matriz de proveedores</summary>
+
+| Proveedor | Autenticación | Seguimiento |
+|--------|----------|----------|
+| Codex | OAuth / CLI | Sesión, Semanal, Créditos |
+| Claude | Cookies / OAuth alternativo / CLI alternativo | Sesión (5h), Semanal |
+| Cursor | Cookies | Plan, Uso, Facturación |
+| Factory | Cookies | Uso |
+| Gemini | gcloud OAuth | Cuota |
+| Copilot | GitHub Device Flow / gh CLI / token heredado | Uso del plan, Chat |
+| Antigravity | LSP local | Uso, Cuotas por modelo |
+| z.ai | Token API | Cuota |
+| MiniMax | API / Cookies | Uso, Resumen de facturación |
+| Kiro | Cookies / CLI | Créditos mensuales, Excedente |
+| Vertex AI | gcloud OAuth | Costo |
+| Augment | Cookies | Créditos |
+| OpenCode | Configuración local | Uso |
+| Kimi | Cookies | Tasa 5h, Semanal |
+| Kimi K2 | Clave API | Créditos |
+| Amp | Cookies | Uso |
+| Warp | Configuración local | Uso |
+| Ollama | Cookies / Clave API | Uso, Modelos en la nube, Ventanas de ritmo |
+| Azure OpenAI | Clave API | Despliegue |
+| T3 Chat | Cookies / cURL | Base, Excedente |
+| OpenRouter | Clave API | Créditos |
+| JetBrains AI | Configuración local | Uso |
+| Alibaba | Cookies | Uso |
+| Alibaba Token Plan | Cookies | Créditos del plan de tokens, Fecha de reinicio |
+| NanoGPT | Clave API | Créditos |
+| Infini | Clave API | Sesión, Semanal, Cuota |
+| Perplexity | Cookies | Créditos, Plan |
+| Abacus AI | Cookies | Créditos |
+| Mistral | Cookies | Facturación, Uso |
+| OpenCode Go | Cookies | Uso, Saldo Zen |
+| Kilo | Clave API / CLI | Uso |
+| Codebuff | Clave API / Configuración local | Créditos, Semanal |
+| DeepSeek | Clave API | Saldo, Resúmenes de uso, Costo |
+| Windsurf | Caché local | Diario, Semanal |
+| Manus | Cookies | Créditos, Refrescar créditos |
+| Xiaomi MiMo | Cookies | Saldo, Plan de tokens |
+| Doubao | Clave API | Límites de solicitudes |
+| Command Code | Cookies | Créditos mensuales, Créditos comprados |
+| Crof | Clave API | Créditos, Cuota de solicitudes |
+| StepFun | Token Oasis | 5h, Semanal, Refresco de token |
+| Venice | Clave API | Saldo USD / DIEM |
+| OpenAI | Admin API / Clave API | Uso, Solicitudes, Costo con ámbito de proyecto, Saldo de créditos |
+| Grok | Cookies / auth.json | Facturación |
+| ElevenLabs | Clave API | Créditos de suscripción, Slots de voz |
+| Deepgram | Clave API | Uso del proyecto |
+| Groq | Clave API | Métricas empresariales |
+| LLM Proxy | Clave API | Estadísticas de cuota |
+
+</details>
+
+## Compilar desde el código fuente
+
+```powershell
+# Requisitos previos: Node.js + pnpm. Rust y MinGW se instalan automáticamente cuando se necesitan.
+git clone https://github.com/Finesssee/Win-CodexBar.git
+cd Win-CodexBar
+.\dev.ps1
+```
+
+Opciones útiles de desarrollo:
+
+```powershell
+.\dev.ps1 -Release      # compilación optimizada
+.\dev.ps1 -SkipBuild    # relanzar la última compilación
+```
+
+Ejemplos de CLI:
+
+```bash
+codexbar --help
+codexbar diagnose --pretty
+codexbar usage -p claude
+codexbar usage -p all
+codexbar cost -p codex
+```
+
+Las compilaciones con instalador incluyen `codexbar.exe` como la CLI de consola y `codexbar-desktop.exe` como la aplicación de bandeja. Los accesos directos del Menú Inicio lanzan la aplicación de escritorio; los comandos de terminal usan `codexbar.exe`.
+
+## Compilaciones de versión
+
+Para compilaciones de versión locales en Windows, usa el constructor de versiones en caché:
+
+```powershell
+.\scripts\windows-release-build.ps1 -Ref v0.33.2 -SmokeInstall
+```
+
+El script compila el binario real de versión de Tauri más la CLI de consola, verifica las dependencias firmadas del instalador, empaqueta con Inno Setup, genera los archivos de instalador/portable, genera los archivos SHA-256 complementarios y puede ejecutar una prueba de instalación/desinstalación silenciosa.
+
+Más notas sobre automatización de versiones en [docs/release/ci-cd.md](docs/release/ci-cd.md).
+
+## Privacidad
+
+- **En el dispositivo por defecto**: los datos del proveedor se leen desde rutas locales conocidas o APIs del proveedor que configures.
+- **Cookies opcionales**: la extracción de cookies del navegador solo se ejecuta para los proveedores que habilites.
+- **Secretos protegidos**: las claves API, cookies manuales y cuentas de token usan la capa de archivo seguro; en Windows se utiliza DPAPI con ámbito de usuario cuando está disponible.
+- **Diagnóstico seguro**: los diagnósticos exponen solo metadatos de proveedor/fuente/estado, nunca cookies sin procesar, claves API, tokens de portador ni valores OAuth.
+- **Actualizaciones verificadas**: las descargas del instalador requieren un resumen SHA-256 de GitHub y se vuelven a verificar inmediatamente antes de aplicar.
+
+## Documentación
+
+| Tema | Enlace |
+|------|------|
+| Compilar desde el código fuente | [extra-docs/BUILDING.md](extra-docs/BUILDING.md) |
+| Configuración de WSL y consejos de autenticación | [extra-docs/WSL.md](extra-docs/WSL.md) |
+| Detalles de cookies del navegador | [extra-docs/COOKIES.md](extra-docs/COOKIES.md) |
+
+## Créditos
+
+- Aplicación original para macOS: [steipete/CodexBar](https://github.com/steipete/CodexBar) por Peter Steinberger
+- Inspirado por [ccusage](https://github.com/ryoppippi/ccusage) para el seguimiento de costos
+
+## Licencia
+
+MIT, igual que el CodexBar original.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Win-CodexBar
 
-[Simplified Chinese](./README.zh-CN.md)
+[Español mexicano](./README.es-MX.md) | [Simplified Chinese](./README.zh-CN.md)
 
 Win-CodexBar is a Windows system-tray app for keeping AI coding-tool usage visible without opening a dozen dashboards. It ports the spirit of [CodexBar](https://github.com/steipete/CodexBar) to a Tauri + React desktop shell backed by shared Rust provider logic.
 

--- a/apps/desktop-tauri/src-tauri/src/commands/bridge.rs
+++ b/apps/desktop-tauri/src-tauri/src/commands/bridge.rs
@@ -522,6 +522,7 @@ pub(super) fn language_label(language: Language) -> &'static str {
         Language::English => "english",
         Language::Chinese => "chinese",
         Language::Japanese => "japanese",
+        Language::Spanish => "spanish",
     }
 }
 

--- a/apps/desktop-tauri/src-tauri/src/commands/bridge.rs
+++ b/apps/desktop-tauri/src-tauri/src/commands/bridge.rs
@@ -518,12 +518,7 @@ pub(super) fn update_channel_label(channel: UpdateChannel) -> &'static str {
 }
 
 pub(super) fn language_label(language: Language) -> &'static str {
-    match language {
-        Language::English => "english",
-        Language::Chinese => "chinese",
-        Language::Japanese => "japanese",
-        Language::Spanish => "spanish",
-    }
+    language.label()
 }
 
 fn theme_label(theme: ThemePreference) -> &'static str {

--- a/apps/desktop-tauri/src-tauri/src/commands/locale_cmd.rs
+++ b/apps/desktop-tauri/src-tauri/src/commands/locale_cmd.rs
@@ -45,6 +45,7 @@ fn parse_locale_language(raw: &str) -> Option<Language> {
         "en" | "en-us" | "english" => Some(Language::English),
         "zh" | "zh-cn" | "zh-hans" | "chinese" | "中文" => Some(Language::Chinese),
         "ja" | "ja-jp" | "japanese" | "日本語" => Some(Language::Japanese),
+        "es" | "es-mx" | "spanish" | "español" => Some(Language::Spanish),
         _ => None,
     }
 }

--- a/apps/desktop-tauri/src-tauri/src/commands/locale_cmd.rs
+++ b/apps/desktop-tauri/src-tauri/src/commands/locale_cmd.rs
@@ -2,6 +2,27 @@ use super::*;
 
 // ── Locale / i18n commands ───────────────────────────────────────────
 
+/// Language catalog entry exposed to the frontend.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LanguageOption {
+    /// Stable bridge/settings value (e.g. "english")
+    pub value: &'static str,
+    /// Native display name (e.g. "English", "中文", "Español")
+    pub display: &'static str,
+}
+
+/// Return the canonical language catalog.
+/// The frontend uses this to build a language picker without
+/// hardcoding language lists or i18n keys.
+#[tauri::command]
+pub fn get_available_languages() -> Vec<LanguageOption> {
+    Language::all().iter().map(|l| LanguageOption {
+        value: l.label(),
+        display: l.display_name(),
+    }).collect()
+}
+
 /// Snapshot of every localized UI string in a given language.
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -41,13 +62,7 @@ pub fn get_locale_strings(language: Option<String>) -> Result<LocaleStrings, Str
 }
 
 fn parse_locale_language(raw: &str) -> Option<Language> {
-    match raw.trim().to_ascii_lowercase().as_str() {
-        "en" | "en-us" | "english" => Some(Language::English),
-        "zh" | "zh-cn" | "zh-hans" | "chinese" | "中文" => Some(Language::Chinese),
-        "ja" | "ja-jp" | "japanese" | "日本語" => Some(Language::Japanese),
-        "es" | "es-mx" | "spanish" | "español" => Some(Language::Spanish),
-        _ => None,
-    }
+    Language::resolve(raw)
 }
 
 /// Persist the UI language and emit a `locale-changed` event so the
@@ -147,6 +162,22 @@ mod locale_tests {
         assert!(matches!(
             parse_locale_language("日本語"),
             Some(Language::Japanese)
+        ));
+        assert!(matches!(
+            parse_locale_language("es"),
+            Some(Language::Spanish)
+        ));
+        assert!(matches!(
+            parse_locale_language("es-mx"),
+            Some(Language::Spanish)
+        ));
+        assert!(matches!(
+            parse_locale_language("spanish"),
+            Some(Language::Spanish)
+        ));
+        assert!(matches!(
+            parse_locale_language("español"),
+            Some(Language::Spanish)
         ));
         assert!(parse_locale_language("klingon").is_none());
     }

--- a/apps/desktop-tauri/src-tauri/src/commands/settings.rs
+++ b/apps/desktop-tauri/src-tauri/src/commands/settings.rs
@@ -262,6 +262,7 @@ fn parse_language(s: &str) -> Option<Language> {
         "english" => Some(Language::English),
         "chinese" => Some(Language::Chinese),
         "japanese" => Some(Language::Japanese),
+        "spanish" => Some(Language::Spanish),
         _ => None,
     }
 }

--- a/apps/desktop-tauri/src-tauri/src/commands/settings.rs
+++ b/apps/desktop-tauri/src-tauri/src/commands/settings.rs
@@ -258,13 +258,7 @@ fn parse_update_channel(s: &str) -> Option<UpdateChannel> {
 }
 
 fn parse_language(s: &str) -> Option<Language> {
-    match s {
-        "english" => Some(Language::English),
-        "chinese" => Some(Language::Chinese),
-        "japanese" => Some(Language::Japanese),
-        "spanish" => Some(Language::Spanish),
-        _ => None,
-    }
+    Language::resolve(s)
 }
 
 #[tauri::command]

--- a/apps/desktop-tauri/src-tauri/src/main.rs
+++ b/apps/desktop-tauri/src-tauri/src/main.rs
@@ -196,6 +196,7 @@ fn main() {
             commands::get_provider_detail,
             commands::trigger_provider_login,
             commands::revoke_provider_credentials,
+            commands::get_available_languages,
             commands::get_locale_strings,
             commands::set_ui_language,
             commands::open_path,

--- a/apps/desktop-tauri/src/i18n/keys.test.ts
+++ b/apps/desktop-tauri/src/i18n/keys.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from "vitest";
+import { ALL_LOCALE_KEYS } from "./keys";
+
+describe("ALL_LOCALE_KEYS", () => {
+  it("includes LanguageSpanishOption after LanguageJapaneseOption", () => {
+    const jaIdx = ALL_LOCALE_KEYS.indexOf("LanguageJapaneseOption");
+    expect(jaIdx).toBeGreaterThan(-1);
+
+    const esIdx = ALL_LOCALE_KEYS.indexOf("LanguageSpanishOption");
+    expect(esIdx).toBe(jaIdx + 1);
+  });
+
+  it("has exactly the expected number of language options", () => {
+    const languageOptions = ALL_LOCALE_KEYS.filter((k) =>
+      k.startsWith("Language"),
+    );
+    // EnglishOption, ChineseOption, JapaneseOption, SpanishOption
+    expect(languageOptions).toHaveLength(4);
+  });
+});

--- a/apps/desktop-tauri/src/i18n/keys.ts
+++ b/apps/desktop-tauri/src/i18n/keys.ts
@@ -368,6 +368,7 @@ export const ALL_LOCALE_KEYS = [
   "LanguageEnglishOption",
   "LanguageChineseOption",
   "LanguageJapaneseOption",
+  "LanguageSpanishOption",
   "SectionTheme",
   "ThemeLabel",
   "ThemeHelper",

--- a/apps/desktop-tauri/src/surfaces/settings/tabs/GeneralTab.test.tsx
+++ b/apps/desktop-tauri/src/surfaces/settings/tabs/GeneralTab.test.tsx
@@ -5,6 +5,16 @@ vi.mock("../../../hooks/useLocale", () => ({
   useLocale: () => ({ t: (key: string) => key }),
 }));
 
+// Mock Tauri invoke for get_available_languages
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: vi.fn().mockResolvedValue([
+    { value: "english", display: "English" },
+    { value: "chinese", display: "中文" },
+    { value: "japanese", display: "日本語" },
+    { value: "spanish", display: "Español" },
+  ]),
+}));
+
 import GeneralTab from "./GeneralTab";
 import type { SettingsSnapshot } from "../../../types/bridge";
 
@@ -52,7 +62,7 @@ describe("GeneralTab language picker", () => {
   it("renders 4 language options when spanish is wired", () => {
     render(<GeneralTab settings={settings} set={vi.fn()} saving={false} />);
 
-    const select = screen.getByDisplayValue("LanguageEnglishOption");
+    const select = screen.getByDisplayValue("English");
     expect(select).toBeInTheDocument();
 
     const options = select.querySelectorAll("option");
@@ -63,7 +73,7 @@ describe("GeneralTab language picker", () => {
     render(<GeneralTab settings={settings} set={vi.fn()} saving={false} />);
 
     expect(
-      screen.getByText("LanguageSpanishOption"),
+      screen.getByText("Español"),
     ).toBeInTheDocument();
   });
 });

--- a/apps/desktop-tauri/src/surfaces/settings/tabs/GeneralTab.test.tsx
+++ b/apps/desktop-tauri/src/surfaces/settings/tabs/GeneralTab.test.tsx
@@ -1,0 +1,71 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("../../hooks/useLocale", () => ({
+  useLocale: () => ({ t: (key: string) => key }),
+}));
+
+import GeneralTab from "./GeneralTab";
+import type { SettingsSnapshot } from "../../../types/bridge";
+
+const settings: SettingsSnapshot = {
+  enabledProviders: [],
+  refreshIntervalSecs: 300,
+  startAtLogin: false,
+  startMinimized: false,
+  showNotifications: true,
+  soundEnabled: true,
+  soundVolume: 100,
+  highUsageThreshold: 70,
+  criticalUsageThreshold: 90,
+  trayIconMode: "single",
+  switcherShowsIcons: true,
+  menuBarShowsHighestUsage: true,
+  menuBarShowsPercent: true,
+  showAsUsed: false,
+  showAllTokenAccountsInMenu: true,
+  enableAnimations: true,
+  resetTimeRelative: true,
+  menuBarDisplayMode: "compact",
+  hidePersonalInfo: false,
+  autoDownloadUpdates: false,
+  installUpdatesOnQuit: false,
+  globalShortcut: "",
+  updateChannel: "stable",
+  uiLanguage: "english",
+  theme: "dark",
+  claudeAvoidKeychainPrompts: true,
+  disableKeychainAccess: false,
+  providerMetrics: {},
+  floatBarEnabled: false,
+  floatBarOpacity: 0.9,
+  floatBarScale: 100,
+  floatBarOrientation: "horizontal",
+  floatBarStyle: "floating",
+  floatBarClickThrough: false,
+  floatBarProviderIds: [],
+  floatBarDarkText: false,
+  floatBarShowResetInline: false,
+};
+
+describe("GeneralTab language picker", () => {
+  it("renders 4 language options when spanish is wired", () => {
+    render(<GeneralTab settings={settings} set={vi.fn()} saving={false} />);
+
+    const select = screen.getByRole("combobox", {
+      name: "InterfaceLanguage",
+    });
+    expect(select).toBeInTheDocument();
+
+    const options = select.querySelectorAll("option");
+    expect(options).toHaveLength(4);
+  });
+
+  it("includes spanish as a selectable option", () => {
+    render(<GeneralTab settings={settings} set={vi.fn()} saving={false} />);
+
+    expect(
+      screen.getByText("LanguageSpanishOption"),
+    ).toBeInTheDocument();
+  });
+});

--- a/apps/desktop-tauri/src/surfaces/settings/tabs/GeneralTab.test.tsx
+++ b/apps/desktop-tauri/src/surfaces/settings/tabs/GeneralTab.test.tsx
@@ -52,7 +52,7 @@ describe("GeneralTab language picker", () => {
   it("renders 4 language options when spanish is wired", () => {
     render(<GeneralTab settings={settings} set={vi.fn()} saving={false} />);
 
-    const select = screen.getByDisplayValue("english");
+    const select = screen.getByDisplayValue("LanguageEnglishOption");
     expect(select).toBeInTheDocument();
 
     const options = select.querySelectorAll("option");

--- a/apps/desktop-tauri/src/surfaces/settings/tabs/GeneralTab.test.tsx
+++ b/apps/desktop-tauri/src/surfaces/settings/tabs/GeneralTab.test.tsx
@@ -52,9 +52,7 @@ describe("GeneralTab language picker", () => {
   it("renders 4 language options when spanish is wired", () => {
     render(<GeneralTab settings={settings} set={vi.fn()} saving={false} />);
 
-    const select = screen.getByRole("combobox", {
-      name: "InterfaceLanguage",
-    });
+    const select = screen.getByDisplayValue("english");
     expect(select).toBeInTheDocument();
 
     const options = select.querySelectorAll("option");

--- a/apps/desktop-tauri/src/surfaces/settings/tabs/GeneralTab.test.tsx
+++ b/apps/desktop-tauri/src/surfaces/settings/tabs/GeneralTab.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 
-vi.mock("../../hooks/useLocale", () => ({
+vi.mock("../../../hooks/useLocale", () => ({
   useLocale: () => ({ t: (key: string) => key }),
 }));
 

--- a/apps/desktop-tauri/src/surfaces/settings/tabs/GeneralTab.tsx
+++ b/apps/desktop-tauri/src/surfaces/settings/tabs/GeneralTab.tsx
@@ -1,9 +1,17 @@
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { useLocale } from "../../../hooks/useLocale";
+import { invoke } from "@tauri-apps/api/core";
 import { playNotificationSound } from "../../../lib/tauri";
 import { Field, NumberInput, Select, Toggle } from "../../../components/FormControls";
-import type { Language } from "../../../types/bridge";
+import type { Language, LanguageOption } from "../../../types/bridge";
 import type { TabProps } from "../../Settings";
+
+const FALLBACK_LANGUAGE_OPTIONS: LanguageOption[] = [
+  { value: "english", display: "English" },
+  { value: "chinese", display: "中文" },
+  { value: "japanese", display: "日本語" },
+  { value: "spanish", display: "Español" },
+];
 
 const REFRESH_CADENCE_OPTIONS: { value: string; label: string }[] = [
   { value: "0", label: "Manual" },
@@ -17,6 +25,15 @@ const REFRESH_CADENCE_OPTIONS: { value: string; label: string }[] = [
 export default function GeneralTab({ settings, set, saving }: TabProps) {
   const { t } = useLocale();
   const [playingSound, setPlayingSound] = useState(false);
+  const [languageOptions, setLanguageOptions] = useState<LanguageOption[]>(
+    FALLBACK_LANGUAGE_OPTIONS,
+  );
+
+  useEffect(() => {
+    invoke<LanguageOption[]>("get_available_languages")
+      .then(setLanguageOptions)
+      .catch(() => {}); // graceful fallback to static default
+  }, []);
 
   const handleTestSound = useCallback(() => {
     setPlayingSound(true);
@@ -33,12 +50,10 @@ export default function GeneralTab({ settings, set, saving }: TabProps) {
             <Select
               value={settings.uiLanguage}
               disabled={saving}
-              options={[
-                { value: "english", label: t("LanguageEnglishOption") },
-                { value: "chinese", label: t("LanguageChineseOption") },
-                { value: "japanese", label: t("LanguageJapaneseOption") },
-                { value: "spanish", label: t("LanguageSpanishOption") },
-              ]}
+              options={languageOptions.map((opt) => ({
+                value: opt.value,
+                label: opt.display,
+              }))}
               onChange={(v) => set({ uiLanguage: v as Language })}
             />
           </Field>

--- a/apps/desktop-tauri/src/surfaces/settings/tabs/GeneralTab.tsx
+++ b/apps/desktop-tauri/src/surfaces/settings/tabs/GeneralTab.tsx
@@ -37,6 +37,7 @@ export default function GeneralTab({ settings, set, saving }: TabProps) {
                 { value: "english", label: t("LanguageEnglishOption") },
                 { value: "chinese", label: t("LanguageChineseOption") },
                 { value: "japanese", label: t("LanguageJapaneseOption") },
+                { value: "spanish", label: t("LanguageSpanishOption") },
               ]}
               onChange={(v) => set({ uiLanguage: v as Language })}
             />

--- a/apps/desktop-tauri/src/types/bridge.test.ts
+++ b/apps/desktop-tauri/src/types/bridge.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from "vitest";
+import type { Language, LocaleStrings, SettingsSnapshot } from "./bridge";
+
+describe("Language type", () => {
+  it("accepts 'spanish' as a valid union member", () => {
+    // Type-level assertion: this assignment must compile (tsc --noEmit gate).
+    // Vitest strips types at transform time, so the runtime assertion only
+    // exercises value correctness; tsc provides the RED/GREEN gate.
+    const lang: Language = "spanish";
+    expect(lang).toBe("spanish");
+  });
+
+  it("allows 'spanish' in LocaleStrings payload", () => {
+    const payload: LocaleStrings = {
+      language: "spanish",
+      entries: { TabGeneral: "General" },
+    };
+    expect(payload.language).toBe("spanish");
+    expect(payload.entries.TabGeneral).toBe("General");
+  });
+
+  it("allows 'spanish' in SettingsSnapshot.uiLanguage", () => {
+    const snap: SettingsSnapshot = {
+      enabledProviders: [],
+      refreshIntervalSecs: 300,
+      startAtLogin: false,
+      startMinimized: false,
+      showNotifications: true,
+      soundEnabled: true,
+      soundVolume: 100,
+      highUsageThreshold: 70,
+      criticalUsageThreshold: 90,
+      trayIconMode: "single",
+      switcherShowsIcons: true,
+      menuBarShowsHighestUsage: true,
+      menuBarShowsPercent: true,
+      showAsUsed: false,
+      showAllTokenAccountsInMenu: true,
+      enableAnimations: true,
+      resetTimeRelative: true,
+      menuBarDisplayMode: "compact",
+      hidePersonalInfo: false,
+      autoDownloadUpdates: false,
+      installUpdatesOnQuit: false,
+      globalShortcut: "",
+      updateChannel: "stable",
+      uiLanguage: "spanish",
+      theme: "dark",
+      claudeAvoidKeychainPrompts: true,
+      disableKeychainAccess: false,
+      providerMetrics: {},
+      floatBarEnabled: false,
+      floatBarOpacity: 0.9,
+      floatBarScale: 100,
+      floatBarOrientation: "horizontal",
+      floatBarStyle: "floating",
+      floatBarClickThrough: false,
+      floatBarProviderIds: [],
+      floatBarDarkText: false,
+      floatBarShowResetInline: false,
+    };
+    expect(snap.uiLanguage).toBe("spanish");
+  });
+});

--- a/apps/desktop-tauri/src/types/bridge.ts
+++ b/apps/desktop-tauri/src/types/bridge.ts
@@ -23,6 +23,14 @@ export type MetricPreference =
 
 export type Language = "english" | "chinese" | "japanese" | "spanish";
 
+/** Language catalog entry from the Rust backend. */
+export type LanguageOption = {
+  /** Stable bridge/settings value (e.g. "english") */
+  value: Language;
+  /** Native display name (e.g. "English", "中文", "Español") */
+  display: string;
+};
+
 export type UpdateChannel = "stable" | "beta";
 
 export type ThemePreference = "auto" | "light" | "dark";

--- a/apps/desktop-tauri/src/types/bridge.ts
+++ b/apps/desktop-tauri/src/types/bridge.ts
@@ -21,7 +21,7 @@ export type MetricPreference =
   | "extraUsage"
   | "average";
 
-export type Language = "english" | "chinese" | "japanese";
+export type Language = "english" | "chinese" | "japanese" | "spanish";
 
 export type UpdateChannel = "stable" | "beta";
 

--- a/rust/src/locale.rs
+++ b/rust/src/locale.rs
@@ -12,6 +12,7 @@ pub fn get_text(lang: Language, key: LocaleKey) -> &'static str {
         Language::English => key.english(),
         Language::Chinese => key.chinese(),
         Language::Japanese => key.japanese(),
+        Language::Spanish => key.spanish(),
     }
 }
 
@@ -539,6 +540,7 @@ pub enum LocaleKey {
     LanguageEnglishOption,
     LanguageChineseOption,
     LanguageJapaneseOption,
+    LanguageSpanishOption,
 
     // Tauri desktop shell — Theme (Phase 12)
     SectionTheme,
@@ -683,6 +685,7 @@ pub enum LocaleKey {
 mod chinese;
 mod english;
 mod japanese;
+mod spanish;
 mod keys;
 
 #[cfg(test)]

--- a/rust/src/locale/chinese.rs
+++ b/rust/src/locale/chinese.rs
@@ -473,6 +473,7 @@ impl LocaleKey {
             LocaleKey::LanguageEnglishOption => "English",
             LocaleKey::LanguageChineseOption => "中文",
             LocaleKey::LanguageJapaneseOption => "日本語",
+            LocaleKey::LanguageSpanishOption => "西班牙语",
 
             // Tauri desktop shell — Theme (Phase 12)
             // REVIEW-i18n: ZH translations for Phase 12 theme labels.

--- a/rust/src/locale/english.rs
+++ b/rust/src/locale/english.rs
@@ -507,6 +507,7 @@ impl LocaleKey {
             LocaleKey::LanguageEnglishOption => "English",
             LocaleKey::LanguageChineseOption => "中文",
             LocaleKey::LanguageJapaneseOption => "日本語",
+            LocaleKey::LanguageSpanishOption => "Español",
 
             // Tauri desktop shell — Theme (Phase 12)
             LocaleKey::SectionTheme => "Appearance",

--- a/rust/src/locale/japanese.rs
+++ b/rust/src/locale/japanese.rs
@@ -507,6 +507,7 @@ impl LocaleKey {
             LocaleKey::LanguageEnglishOption => "English",
             LocaleKey::LanguageChineseOption => "中文",
             LocaleKey::LanguageJapaneseOption => "日本語",
+            LocaleKey::LanguageSpanishOption => "スペイン語",
 
             // Tauri desktop shell — Theme (Phase 12)
             LocaleKey::SectionTheme => "Appearance",

--- a/rust/src/locale/keys.rs
+++ b/rust/src/locale/keys.rs
@@ -553,6 +553,7 @@ impl LocaleKey {
         (LocaleKey::LanguageEnglishOption, "LanguageEnglishOption"),
         (LocaleKey::LanguageChineseOption, "LanguageChineseOption"),
         (LocaleKey::LanguageJapaneseOption, "LanguageJapaneseOption"),
+        (LocaleKey::LanguageSpanishOption, "LanguageSpanishOption"),
         (LocaleKey::SectionTheme, "SectionTheme"),
         (LocaleKey::ThemeLabel, "ThemeLabel"),
         (LocaleKey::ThemeHelper, "ThemeHelper"),

--- a/rust/src/locale/spanish.rs
+++ b/rust/src/locale/spanish.rs
@@ -1,0 +1,667 @@
+use super::*;
+
+impl LocaleKey {
+    pub(super) fn spanish(self) -> &'static str {
+        match self {
+            // Tab names
+            LocaleKey::TabGeneral => "General",
+            LocaleKey::TabProviders => "Proveedores",
+            LocaleKey::TabDisplay => "Pantalla",
+            LocaleKey::TabApiKeys => "Claves API",
+            LocaleKey::TabCookies => "Cookies",
+            LocaleKey::TabAdvanced => "Avanzado",
+            LocaleKey::TabAbout => "Acerca de",
+            LocaleKey::TabShortcuts => "Atajos",
+
+            // General settings
+            LocaleKey::InterfaceLanguage => "Idioma de la interfaz",
+            LocaleKey::StartupSettings => "Sistema",
+            LocaleKey::StartAtLogin => "Iniciar al arrancar",
+            LocaleKey::StartMinimized => "Iniciar minimizado",
+            LocaleKey::StartAtLoginHelper => "Iniciar sesión automáticamente al arrancar el sistema",
+            LocaleKey::StartMinimizedHelper => "Iniciar minimizado en la bandeja del sistema",
+
+            // Notification settings
+            LocaleKey::ShowNotifications => "Mostrar notificaciones",
+            LocaleKey::ShowNotificationsHelper => "Alertar cuando se alcancen los umbrales de uso",
+            LocaleKey::SoundEnabled => "Alertas sonoras",
+            LocaleKey::SoundEnabledHelper => "Reproducir sonido cuando se alcancen los umbrales",
+            LocaleKey::SoundVolume => "Volumen de alerta",
+            LocaleKey::HighUsageThreshold => "Umbral de uso alto",
+            LocaleKey::HighUsageThresholdHelper => "Mostrar advertencia en este nivel de uso",
+            LocaleKey::HighUsageAlert => "Alerta de uso alto",
+            LocaleKey::CriticalUsageThreshold => "Umbral de uso crítico",
+            LocaleKey::CriticalUsageThresholdHelper => "Mostrar alerta crítica en este nivel",
+            LocaleKey::CriticalUsageAlert => "Alerta crítica",
+
+            // Display settings
+            LocaleKey::UsageDisplay => "Visualización de uso",
+            LocaleKey::ShowUsageAsUsed => "Mostrar como usado",
+            LocaleKey::ShowUsageAsUsedHelper => "Mostrar como porcentaje usado en lugar de restante",
+            LocaleKey::ResetTimeRelative => "Tiempo relativo de reinicio",
+            LocaleKey::ResetTimeRelativeHelper => "Mostrar \"2h 30m\" en lugar de \"3:00 PM\"",
+            LocaleKey::TrayIcon => "Ícono de bandeja",
+            LocaleKey::MergeTrayIcons => "Combinar íconos de bandeja",
+            LocaleKey::MergeTrayIconsHelper => "Mostrar todos los proveedores en un solo ícono de bandeja",
+            LocaleKey::PerProviderTrayIcons => "Íconos por proveedor",
+            LocaleKey::PerProviderTrayIconsHelper => {
+                "Mostrar un ícono de bandeja separado por cada proveedor habilitado"
+            }
+
+            // Provider settings
+            LocaleKey::ProviderEnabled => "Habilitado",
+            LocaleKey::ProviderDisabled => "Deshabilitado",
+            LocaleKey::ProviderInfo => "Información",
+            LocaleKey::ProviderUsage => "Uso",
+            LocaleKey::AuthType => "Autenticación",
+            LocaleKey::DataSource => "Fuente de datos",
+            LocaleKey::ProviderNotDetected => "no detectado",
+            LocaleKey::ProviderLastFetchFailed => "última consulta fallida",
+            LocaleKey::ProviderUsageNotFetchedYet => "uso no consultado aún",
+            LocaleKey::ProviderNotFetchedYetTitle => "Aún no consultado",
+            LocaleKey::ProviderDisabledNoRecentData => "Deshabilitado — sin datos recientes",
+            LocaleKey::ProviderSourceAutoShort => "auto",
+            LocaleKey::ProviderSourceWebShort => "web",
+            LocaleKey::ProviderSourceCliShort => "cli",
+            LocaleKey::ProviderSourceOauthShort => "oauth",
+            LocaleKey::ProviderSourceApiShort => "api",
+            LocaleKey::ProviderSourceGithubApiShort => "api de github",
+            LocaleKey::ProviderSourceLocalShort => "local",
+            LocaleKey::ProviderSourceKiroEnvShort => "entorno kiro",
+            LocaleKey::TrackingItem => "Elemento rastreado",
+            LocaleKey::MainWindowLiveUsageData => "Datos de uso en vivo en ventana principal",
+            LocaleKey::StartTrackingUsage => "Habilitar para comenzar a rastrear el uso",
+            LocaleKey::ClickTrayIconForMetrics => "Clic en ícono de bandeja para métricas en vivo",
+
+            // Browser cookie import
+            LocaleKey::BrowserCookieImport => "Importación de cookies del navegador",
+            LocaleKey::ImportFromBrowser => "Importar cookies de {} desde el navegador",
+            LocaleKey::NoCookiesFoundInBrowser => "No se encontraron cookies en {}. Inicie sesión primero.",
+            LocaleKey::SelectBrowser => "Seleccionar navegador...",
+            LocaleKey::ImportCookies => "Importar cookies",
+            LocaleKey::ImportSuccess => "Cookies importadas para {}",
+            LocaleKey::ImportFailed => "Importación fallida: {}",
+            LocaleKey::SaveFailed => "Guardado fallido: {}",
+            LocaleKey::CookiesAutoImport => {
+                "Las cookies se importan automáticamente desde Chrome, Edge, Brave y Firefox"
+            }
+            LocaleKey::QuickActions => "Acciones rápidas",
+            LocaleKey::OpenProviderDashboard => "Abrir panel de {}",
+            LocaleKey::OllamaNoDashboard => "Ollama se ejecuta localmente, sin panel",
+
+            // API Keys tab
+            LocaleKey::ApiKeysTitle => "Claves API",
+            LocaleKey::ApiKeysDescription => {
+                "Configurar tokens de acceso para proveedores que requieren autenticación."
+            }
+            LocaleKey::AddKey => "+ Agregar clave",
+            LocaleKey::KeySet => "Establecida",
+            LocaleKey::KeyRequired => "Requiere clave",
+            LocaleKey::Remove => "Eliminar",
+            LocaleKey::GetKey => "Obtener clave →",
+
+            // Cookies tab
+            LocaleKey::SavedCookies => "Cookies guardadas",
+            LocaleKey::AddManualCookie => "Agregar cookie manual",
+            LocaleKey::CookieHeader => "Encabezado de cookie",
+            LocaleKey::PasteHere => "Pegar aquí...",
+            LocaleKey::DeleteCookie => "Eliminar",
+            LocaleKey::CookieSaved => "{} cookies guardadas",
+            LocaleKey::CookieDeleted => "Cookies eliminadas para {}",
+
+            // Advanced tab
+            LocaleKey::RefreshSettings => "Actualizar",
+            LocaleKey::Animations => "Animaciones",
+            LocaleKey::MenuBar => "Barra de menú",
+            LocaleKey::Fun => "Diversión",
+            LocaleKey::GlobalShortcut => "Atajo global",
+            LocaleKey::Privacy => "Privacidad",
+            LocaleKey::Updates => "Actualizaciones",
+            LocaleKey::UpdateChannel => "Canal de actualización",
+            LocaleKey::UpdateChannelStable => "Estable",
+            LocaleKey::UpdateChannelBeta => "Beta",
+            LocaleKey::Never => "Nunca",
+            LocaleKey::LastUpdated => "Actualizado",
+            LocaleKey::MinutesAgo => "Hace {} minutos",
+            LocaleKey::HoursAgo => "Hace {} horas",
+            LocaleKey::DaysAgo => "Hace {} días",
+            LocaleKey::BuiltWithRust => "Construido con Rust + egui",
+            LocaleKey::OriginalMacOSVersion => "Versión original de macOS",
+            LocaleKey::Links => "Enlaces",
+            LocaleKey::BuildInfo => "Información de compilación",
+            LocaleKey::EnabledProviders => "Proveedores habilitados",
+            LocaleKey::Appearance => "Apariencia",
+            LocaleKey::ThemeSelection => "Tema",
+            LocaleKey::LightMode => "Claro",
+            LocaleKey::DarkMode => "Oscuro",
+
+            // About
+            LocaleKey::AboutTitle => "Acerca de CodexBar",
+            LocaleKey::Version => "Versión",
+
+            // Main popup - Header actions
+            LocaleKey::ActionRefreshAll => "Actualizar todo",
+            LocaleKey::ActionSettings => "Configuración",
+            LocaleKey::ActionClose => "✕",
+
+            // Main popup - Provider section
+            LocaleKey::ProviderAccount => "Cuenta",
+            LocaleKey::ProviderSession => "Sesión",
+            LocaleKey::ProviderWeekly => "Semanal",
+            LocaleKey::ProviderMonthly => "30 días",
+            LocaleKey::ProviderModel => "Modelo",
+            LocaleKey::ProviderPlan => "Plan",
+            LocaleKey::ProviderNextReset => "Próximo reinicio",
+            LocaleKey::ProviderNoRecentUsage => "Sin uso reciente",
+            LocaleKey::ProviderNotSignedIn => "Sin iniciar sesión",
+            LocaleKey::SummaryTab => "Resumen",
+
+            // Main popup - Loading/Empty/Error states
+            LocaleKey::StateLoadingProviders => "Cargando proveedores...",
+            LocaleKey::StateNoProviderData => "Sin datos de proveedores.",
+            LocaleKey::StateNoProviderSelected => "Ningún proveedor seleccionado.",
+            LocaleKey::StateSummaryRefreshPending => "Actualizando después de que terminen todas las consultas",
+            LocaleKey::StateError => "Error",
+            LocaleKey::StateRetry => "Reintentar",
+            LocaleKey::StateDownload => "Descargar",
+            LocaleKey::StateRestartAndUpdate => "Reiniciar y actualizar",
+
+            // Main popup - Credits
+            LocaleKey::CreditsTitle => "Créditos",
+
+            // Main popup - Update banner (non-happy-path)
+            LocaleKey::UpdateRestartAndUpdate => "Reiniciar y actualizar",
+            LocaleKey::UpdateRetry => "Reintentar",
+            LocaleKey::UpdateDownload => "Descargar",
+            LocaleKey::UpdateDownloading => "Descargando",
+            LocaleKey::UpdateReady => "Listo para instalar",
+            LocaleKey::UpdateFailed => "Actualización fallida",
+
+            // Main popup - Settings button
+            LocaleKey::ButtonOpenProviderSettings => "Abrir configuración del proveedor",
+
+            // Main popup - Bottom menu (Actions)
+            LocaleKey::MenuSettings => "Configuración...",
+            LocaleKey::MenuAbout => "Acerca de CodexBar",
+            LocaleKey::MenuQuit => "Salir",
+
+            // Main popup - Status strings
+            LocaleKey::StatusJustUpdated => "Recién actualizado",
+            LocaleKey::StatusUnableToGetUsage => "No se pudo obtener el uso",
+
+            // Main popup - Provider detail actions
+            LocaleKey::ActionRefresh => "Actualizar",
+            LocaleKey::ActionSwitchAccount => "Cambiar cuenta...",
+            LocaleKey::ActionUsageDashboard => "Panel de uso",
+            LocaleKey::ActionStatusPage => "Página de estado",
+            LocaleKey::ActionCopyError => "Copiar error",
+            LocaleKey::ActionBuyCredits => "Comprar créditos...",
+
+            // Main popup - Pace status
+            LocaleKey::PaceOnTrack => "En ritmo",
+            LocaleKey::PaceBehind => "Atrasado",
+
+            // Main popup - Reset prefix
+            LocaleKey::MetricResetsIn => "Reinicia en",
+
+            // Main popup - Section titles
+            LocaleKey::SectionUsageBreakdown => "Desglose de uso",
+            LocaleKey::SectionCost => "Costo",
+
+            // Tray - Single icon mode
+            LocaleKey::TrayOpenCodexBar => "Abrir panel",
+            LocaleKey::TrayPopOutDashboard => "Abrir panel",
+            LocaleKey::TrayRefreshAll => "Actualizar todo",
+            LocaleKey::TrayProviders => "Proveedores",
+            LocaleKey::TraySettings => "Configuración...",
+            LocaleKey::TrayCheckForUpdates => "Buscar actualizaciones",
+            LocaleKey::TrayQuit => "Salir",
+            LocaleKey::TrayLoading => "CodexBar - Cargando...",
+            LocaleKey::TrayNoProviders => "CodexBar - Sin proveedores disponibles",
+            LocaleKey::TraySessionPercent => "Sesión {}%",
+            LocaleKey::TrayWeeklyPercent => "Semanal {}%",
+            LocaleKey::TrayStatusError => " (Error)",
+            LocaleKey::TrayStatusStale => " (Datos desactualizados)",
+            LocaleKey::TrayStatusIncident => " (Incidente)",
+            LocaleKey::TrayStatusPartial => " (Interrupción parcial)",
+            LocaleKey::TrayWeeklyExhausted => "Límite semanal agotado",
+            LocaleKey::TrayCreditsRemaining => "Créditos restantes {}%",
+            LocaleKey::TrayStatusRowLoading => "Cargando...",
+            LocaleKey::TrayStatusRowError => "Error",
+            LocaleKey::TrayCreditsRow => "Créditos {}%",
+
+            // Main popup - Usage/reset labels
+            LocaleKey::ResetInProgress => "Reiniciando...",
+            LocaleKey::TomorrowAt => "Mañana a las {}",
+            LocaleKey::UsedPercent => "{:.0}% usado",
+            LocaleKey::RemainingPercent => "{:.0}% restante",
+            LocaleKey::RemainingAmount => "{:.2} restante",
+            LocaleKey::Tokens1K => "1K tokens",
+            LocaleKey::TodayCost => "Hoy: ${:.2}",
+            LocaleKey::Last30DaysCost => "Últimos 30 días: ${:.2}",
+            LocaleKey::StatusLabel => "Estado: {}",
+
+            // Main popup - Update banner messages
+            LocaleKey::UpdateAvailableMessage => "Actualización disponible: {}",
+            LocaleKey::UpdateReadyMessage => "{} lista para instalar",
+            LocaleKey::UpdateFailedMessage => "Actualización fallida: {}",
+            LocaleKey::UpdateDownloadingMessage => "Descargando {} ({:.0}%)",
+
+            // Tray - Per-provider mode
+            LocaleKey::TrayProviderPopOut => "Abrir panel",
+            LocaleKey::TrayProviderRefresh => "Actualizar",
+            LocaleKey::TrayProviderSettings => "Configuración...",
+            LocaleKey::TrayProviderQuit => "Salir",
+
+            // Provider settings - Live renderer specific
+            LocaleKey::State => "Estado",
+            LocaleKey::Source => "Fuente",
+            LocaleKey::Updated => "Actualizado",
+            LocaleKey::NeverUpdated => "Nunca actualizado",
+            LocaleKey::UpdatedJustNow => "Recién actualizado",
+            LocaleKey::UpdatedMinutesAgo => "Hace {} minutos",
+            LocaleKey::UpdatedHoursAgo => "Hace {} horas",
+            LocaleKey::UpdatedDaysAgo => "Hace {} días",
+            LocaleKey::Status => "Estado",
+            LocaleKey::AllSystemsOperational => "Todos los sistemas funcionando",
+            LocaleKey::Plan => "Plan",
+            LocaleKey::Account => "Cuenta",
+
+            // Provider detail - Usage section
+            LocaleKey::ProviderSessionLabel => "Sesión",
+            LocaleKey::ProviderWeeklyLabel => "Semanal",
+            LocaleKey::ProviderCodeReviewLabel => "Revisión de código",
+            LocaleKey::ResetsInShort => "Reinicia en",
+            LocaleKey::ResetsInDaysHours => "Reinicia en {}d {}h",
+            LocaleKey::ResetsInHoursMinutes => "Reinicia en {}h {}m",
+
+            // Provider detail - Tray Display
+            LocaleKey::TrayDisplayTitle => "Pantalla de bandeja",
+            LocaleKey::ShowInTray => "Mostrar en bandeja",
+
+            // Provider detail - Credits
+            LocaleKey::CreditsLabel => "Créditos",
+            LocaleKey::CreditsLeft => "{:.1} restantes",
+
+            // Provider detail - Cost
+            LocaleKey::CostTitle => "Costo",
+            LocaleKey::TodayCostFull => "Hoy: ${:.2} • {} tokens",
+            LocaleKey::Last30DaysCostFull => "Últimos 30 días: ${:.2} • {} tokens",
+
+            // Provider detail - Settings section
+            LocaleKey::ProviderSettingsTitle => "Configuración",
+            LocaleKey::ProviderAccountsTitle => "Cuentas",
+            LocaleKey::ProviderOptionsTitle => "Opciones",
+            LocaleKey::MenuBarMetric => "Métrica de barra de menú",
+            LocaleKey::MenuBarMetricHelper => "Elegir qué ventana controla el porcentaje de la barra de menú.",
+            LocaleKey::UsageSource => "Fuente de uso",
+            LocaleKey::ProviderNoCodexAccountsDetected => "Aún no se detectaron cuentas de Codex.",
+            LocaleKey::ProviderCodexAutoImportHelp => {
+                "Importa automáticamente cookies del navegador para extras del panel."
+            }
+            LocaleKey::ProviderCodexHistoryHelp => {
+                "Almacena el historial local de uso de Codex (8 semanas) para personalizar predicciones de ritmo."
+            }
+            LocaleKey::ProviderOpenAiCookies => "Cookies de OpenAI",
+            LocaleKey::ProviderHistoricalTracking => "Seguimiento histórico",
+            LocaleKey::ProviderOpenAiWebExtras => "Extras web de OpenAI",
+            LocaleKey::ProviderOpenAiWebExtrasHelp => {
+                "Mostrar desglose de uso, historial de créditos y revisión de código vía chatgpt.com."
+            }
+            LocaleKey::ProviderCodexCreditsUnavailable => {
+                "Créditos no disponibles; mantenga Codex en ejecución para actualizar."
+            }
+            LocaleKey::ProviderCodexLastFetchFailedTitle => "Última consulta de Codex fallida:",
+            LocaleKey::ProviderCodexNotRunningHelp => {
+                "Codex no está en ejecución. Intente ejecutar un comando de Codex primero."
+            }
+            LocaleKey::ProviderCookieSource => "Fuente de cookies",
+            LocaleKey::CookieSourceManual => "Manual",
+            LocaleKey::ProviderRegion => "Región",
+            LocaleKey::ProviderClaudeCookies => "Cookies de Claude",
+            LocaleKey::ProviderClaudeCookiesHelp => {
+                "Se prefieren cookies/sessionKey del navegador porque coinciden con la página de uso de configuración de Claude."
+            }
+            LocaleKey::ProviderClaudeAvoidKeychainPrompts => "Evitar avisos de llavero",
+            LocaleKey::ProviderClaudeAvoidKeychainPromptsHelp => {
+                "Usar /usr/bin/security para leer credenciales de Claude y evitar avisos de llavero de CodexBar."
+            }
+            LocaleKey::ProviderCursorCookieSourceHelp => {
+                "Importa automáticamente cookies del navegador o sesiones almacenadas."
+            }
+            LocaleKey::ProviderCursorCreditsHelp => "Uso bajo demanda más allá de los límites del plan incluido.",
+            LocaleKey::AutoFallbackHelp => {
+                "Auto recurre a la siguiente fuente si la preferida falla."
+            }
+            LocaleKey::ProviderSourceOauthWeb => "OAuth + Web",
+            LocaleKey::Automatic => "Automático",
+            LocaleKey::Average => "Promedio",
+            LocaleKey::ExtraUsage => "Uso extra",
+            LocaleKey::OAuth => "OAuth",
+            LocaleKey::Api => "API",
+            LocaleKey::Web => "Web",
+
+            // General tab sections
+            LocaleKey::PrivacyTitle => "Privacidad",
+            LocaleKey::HidePersonalInfo => "Ocultar información personal",
+            LocaleKey::HidePersonalInfoHelper => {
+                "Ocultar correos y nombres de cuenta (útil para transmisiones)"
+            }
+            LocaleKey::UpdatesTitle => "Actualizaciones",
+            LocaleKey::UpdateChannelChoice => "Canal de actualización",
+            LocaleKey::UpdateChannelChoiceHelper => {
+                "Elegir entre versiones estables y versiones beta de prueba"
+            }
+            LocaleKey::AutoDownloadUpdates => "Buscar actualizaciones automáticamente",
+            LocaleKey::AutoDownloadUpdatesHelper => {
+                "Descargar actualizaciones del instalador en segundo plano cuando se encuentre una nueva versión"
+            }
+            LocaleKey::InstallUpdatesOnQuit => "Instalar actualizaciones al salir",
+            LocaleKey::InstallUpdatesOnQuitHelper => {
+                "Iniciar automáticamente un instalador listo al salir de CodexBar"
+            }
+
+            // Keyboard shortcuts
+            LocaleKey::KeyboardShortcutsTitle => "Atajos de teclado",
+            LocaleKey::GlobalShortcutLabel => "Atajo global",
+            LocaleKey::GlobalShortcutHelper => "Presione este atajo para abrir CodexBar desde cualquier lugar",
+            LocaleKey::ShortcutFormatHint => {
+                "Formato: Ctrl+Shift+Tecla, Alt+Ctrl+Tecla, etc. Se requiere reiniciar para aplicar cambios."
+            }
+            LocaleKey::Saved => "Guardado (reiniciar para aplicar)",
+            LocaleKey::InvalidFormat => "Formato de atajo no válido",
+            LocaleKey::ShortcutHintPlaceholder => "p. ej., Ctrl+Shift+U",
+
+            // Display/Preferences helpers
+            LocaleKey::SelectProvider => "Seleccionar un proveedor",
+
+            // Refresh interval labels
+            LocaleKey::RefreshInterval30Sec => "30 seg",
+            LocaleKey::RefreshInterval1Min => "1 min",
+            LocaleKey::RefreshInterval5Min => "5 min",
+            LocaleKey::RefreshInterval10Min => "10 min",
+
+            // Cookies tab
+            LocaleKey::BrowserCookiesTitle => "Cookies del navegador",
+            LocaleKey::CookieImport => "Importación de cookies",
+            LocaleKey::Provider => "Proveedor",
+            LocaleKey::SelectPlaceholder => "Seleccionar...",
+            LocaleKey::AutoRefreshInterval => "Intervalo de actualización automática",
+
+            // About tab
+            LocaleKey::AboutDescription => "Una adaptación para Windows de la versión original de macOS.",
+            LocaleKey::AboutDescriptionLine2 => "Rastree el uso de proveedores de IA en su bandeja del sistema.",
+            LocaleKey::ViewOnGitHub => "→ Ver en GitHub",
+            LocaleKey::SubmitIssue => "→ Reportar un problema",
+            LocaleKey::MaintainedBy => "Mantenido por colaboradores de CodexBar",
+            LocaleKey::CommitLabel => "Commit",
+            LocaleKey::BuildDateLabel => "Compilado",
+
+            // Shared form controls
+            LocaleKey::Save => "Guardar",
+            LocaleKey::Cancel => "Cancelar",
+            LocaleKey::Label => "Etiqueta",
+            LocaleKey::Token => "Token",
+            LocaleKey::AddAccount => "Agregar cuenta",
+            LocaleKey::AccountAdded => "Cuenta agregada",
+            LocaleKey::AccountRemoved => "Cuenta eliminada",
+            LocaleKey::AccountSwitched => "Cuenta cambiada",
+            LocaleKey::AccountLabelHint => "p. ej., Cuenta de trabajo, Personal...",
+            LocaleKey::EnterApiKeyFor => "Ingresar clave API para {}",
+            LocaleKey::PasteApiKeyHere => "Pegue su clave API aquí...",
+            LocaleKey::ApiKeySaved => "Clave API guardada para {}",
+            LocaleKey::ApiKeyRemoved => "Clave API eliminada para {}",
+            LocaleKey::EnvironmentVariable => "Variable de entorno",
+            LocaleKey::CookieSavedForProvider => "Cookies guardadas para {}",
+            LocaleKey::CookieRemovedForProvider => "Cookies eliminadas para {}",
+
+            // Usage helper functions
+            LocaleKey::ShowUsedPercent => "{:.0}% usado",
+            LocaleKey::ShowRemainingPercent => "{:.0}% restante",
+
+            // Tauri desktop shell — Settings section headings
+            LocaleKey::TabTokenAccounts => "Tokens",
+            LocaleKey::SectionRefresh => "Automatización",
+            LocaleKey::SectionNotifications => "Notificaciones",
+            LocaleKey::SectionUsageThresholds => "Umbrales de uso",
+            LocaleKey::SectionKeyboard => "Teclado",
+            LocaleKey::SectionUsageRendering => "Representación de uso",
+            LocaleKey::SectionTime => "Tiempo",
+            LocaleKey::SectionLanguage => "Idioma",
+            LocaleKey::SectionCredentialsSecurity => "Credenciales y seguridad",
+            LocaleKey::SectionDebug => "Depuración",
+            LocaleKey::SectionApiKeys => "Claves API",
+            LocaleKey::SectionSavedCookies => "Cookies guardadas",
+            LocaleKey::SectionImportFromBrowser => "Importar del navegador",
+            LocaleKey::SectionAddCookieManually => "Agregar cookie manualmente",
+            LocaleKey::SectionTokenAccounts => "Cuentas de token",
+            LocaleKey::SectionSavedAccounts => "Cuentas guardadas",
+            LocaleKey::SectionAddAccount => "Agregar cuenta",
+
+            // Tauri desktop shell — General tab fields
+            LocaleKey::RefreshIntervalLabel => "Intervalo de actualización",
+            LocaleKey::RefreshIntervalHelper => {
+                "Segundos entre actualizaciones automáticas de proveedores (0 = manual)."
+            }
+            LocaleKey::SoundVolumeHelper => "Volumen para sonidos de alerta de umbral (0–100).",
+            LocaleKey::HighUsageWarningHelper => {
+                "Mostrar una advertencia cuando el uso exceda este porcentaje."
+            }
+            LocaleKey::CriticalUsageWarningHelper => {
+                "Mostrar una alerta crítica cuando el uso exceda este porcentaje."
+            }
+            LocaleKey::GlobalShortcutFieldLabel => "Atajo global",
+            LocaleKey::GlobalShortcutToggleHelper => "Combinación de teclas para alternar el panel de bandeja.",
+            LocaleKey::ShortcutRecordButton => "Grabar",
+            LocaleKey::ShortcutRecordingLabel => "Grabando…",
+            LocaleKey::ShortcutRecordingHint => {
+                "Presione modificadores + una tecla. Esc cancela, Retroceso borra."
+            }
+            LocaleKey::ShortcutClearButton => "Limpiar",
+            LocaleKey::ShortcutEmptyPlaceholder => "No configurado",
+            LocaleKey::NotificationTestSound => "Probar sonido",
+            LocaleKey::NotificationTestSoundPlaying => "Reproduciendo…",
+
+            // Tauri desktop shell — Display tab fields
+            LocaleKey::TrayIconModeLabel => "Modo de ícono de bandeja",
+            LocaleKey::TrayIconModeHelper => {
+                "Ícono único combinado o un ícono por cada proveedor habilitado."
+            }
+            LocaleKey::TrayIconModeSingle => "Único",
+            LocaleKey::TrayIconModePerProvider => "Por proveedor",
+            LocaleKey::ShowProviderIcons => "Mostrar íconos de proveedores",
+            LocaleKey::ShowProviderIconsHelper => "Mostrar íconos de proveedores en el selector de bandeja.",
+            LocaleKey::PreferHighestUsage => "Preferir uso más alto",
+            LocaleKey::PreferHighestUsageHelper => {
+                "Mostrar el proveedor más cercano a su límite en la pantalla de bandeja combinada."
+            }
+            LocaleKey::ShowPercentInTray => "Mostrar porcentaje en bandeja",
+            LocaleKey::ShowPercentInTrayHelper => {
+                "Reemplazar barra de uso con marca de proveedor + texto de porcentaje."
+            }
+            LocaleKey::DisplayModeLabel => "Modo de visualización",
+            LocaleKey::DisplayModeHelper => "Nivel de detalle mostrado en la etiqueta de barra de menú.",
+            LocaleKey::DisplayModeDetailed => "Detallado",
+            LocaleKey::DisplayModeCompact => "Compacto",
+            LocaleKey::DisplayModeMinimal => "Mínimo",
+            LocaleKey::ShowAsUsedLabel => "Mostrar como usado",
+            LocaleKey::ShowAsUsedHelper => "Mostrar barras de uso como consumido en lugar de restante.",
+            LocaleKey::ShowAllTokenAccountsLabel => "Mostrar todas las cuentas de token",
+            LocaleKey::ShowAllTokenAccountsHelper => {
+                "Listar todas las cuentas de token en los menús de proveedores en lugar de colapsarlas."
+            }
+            LocaleKey::EnableAnimationsLabel => "Habilitar animaciones",
+            LocaleKey::EnableAnimationsHelper => "Transiciones suaves y barras de progreso animadas.",
+            // Tauri desktop shell — Advanced tab fields
+            LocaleKey::UpdateChannelStableOption => "Estable",
+            LocaleKey::UpdateChannelBetaOption => "Beta",
+            LocaleKey::AvoidKeychainPromptsLabel => "Evitar avisos de llavero (Claude)",
+            LocaleKey::AvoidKeychainPromptsHelper => {
+                "Omitir lecturas de credenciales de llavero para Claude para evitar diálogos de permiso del SO."
+            }
+            LocaleKey::DisableAllKeychainLabel => "Deshabilitar todo acceso al llavero",
+            LocaleKey::DisableAllKeychainHelper => {
+                "Desactivar lecturas de credenciales/llavero para todos los proveedores. También habilita la opción de Claude anterior."
+            }
+            LocaleKey::LanguageEnglishOption => "English",
+            LocaleKey::LanguageChineseOption => "中文",
+            LocaleKey::LanguageJapaneseOption => "日本語",
+            LocaleKey::LanguageSpanishOption => "Español",
+
+            // Tauri desktop shell — Theme (Phase 12)
+            LocaleKey::SectionTheme => "Apariencia",
+            LocaleKey::ThemeLabel => "Tema",
+            LocaleKey::ThemeHelper => {
+                "Auto sigue el esquema de color de su sistema. Claro y oscuro lo anulan."
+            }
+            LocaleKey::ThemeAutoOption => "Auto (sistema)",
+            LocaleKey::ThemeLightOption => "Claro",
+            LocaleKey::ThemeDarkOption => "Oscuro",
+
+            // Tauri desktop shell — settings status / common
+            LocaleKey::SettingsStatusSaving => "Guardando…",
+            LocaleKey::ApiKeysTabHint => {
+                "Configurar claves API para proveedores que usan autenticación basada en tokens. Las claves se almacenan localmente y nunca se transmiten."
+            }
+
+            // Tauri desktop shell — tray / popout
+            LocaleKey::FetchingProviderData => "Obteniendo datos del proveedor…",
+            LocaleKey::NoProvidersConfigured => "No hay proveedores configurados.",
+            LocaleKey::EnableProvidersHint => "Habilite proveedores en Configuración para ver datos de uso.",
+            LocaleKey::OpenSettingsButton => "Abrir configuración",
+            LocaleKey::TooltipRefresh => "Actualizar",
+            LocaleKey::TooltipSettings => "Configuración",
+            LocaleKey::TooltipPopOut => "Abrir panel",
+            LocaleKey::TooltipBackToTray => "Volver a bandeja",
+            LocaleKey::TrayCardErrorBadge => "Error",
+            LocaleKey::SummaryProvidersLabel => "proveedores",
+            LocaleKey::SummaryRefreshing => "actualizando…",
+            LocaleKey::SummaryFailed => "fallido",
+            LocaleKey::SummaryWithErrors => "con errores",
+
+            // Tauri desktop shell — provider detail
+            LocaleKey::DetailBackButton => "Volver",
+            LocaleKey::DetailWindowPrimary => "Principal",
+            LocaleKey::DetailWindowSecondary => "Secundario",
+            LocaleKey::DetailWindowModelSpecific => "Específico del modelo",
+            LocaleKey::DetailWindowTertiary => "Terciario",
+            LocaleKey::DetailWindowMinutesSuffix => "ventana de m",
+            LocaleKey::DetailWindowExhausted => "Agotado",
+            LocaleKey::DetailPaceTitle => "Ritmo",
+            LocaleKey::DetailPaceOnTrack => "En ritmo",
+            LocaleKey::DetailPaceSlightlyAhead => "Ligeramente adelantado",
+            LocaleKey::DetailPaceAhead => "Adelantado",
+            LocaleKey::DetailPaceFarAhead => "Muy adelantado",
+            LocaleKey::DetailPaceSlightlyBehind => "Ligeramente atrasado",
+            LocaleKey::DetailPaceBehind => "Atrasado",
+            LocaleKey::DetailPaceFarBehind => "Muy atrasado",
+            LocaleKey::DetailPaceRunsOutIn => "Se agota en",
+            LocaleKey::DetailPaceWillLastToReset => "Durará hasta el reinicio",
+            LocaleKey::DetailCostTitle => "Costo",
+            LocaleKey::DetailCostUsed => "Usado",
+            LocaleKey::DetailCostLimit => "Límite",
+            LocaleKey::DetailCostRemaining => "Restante",
+            LocaleKey::DetailCostResets => "Reinicia",
+            LocaleKey::DetailChartCost => "Costo (30 días)",
+            LocaleKey::DetailChartCredits => "Créditos usados (30 días)",
+            LocaleKey::DetailChartUsageBreakdown => "Uso por servicio (30 días)",
+            LocaleKey::DetailChartEmpty => "Sin datos de gráfico aún.",
+            LocaleKey::DetailUpdatedPrefix => "Actualizado",
+
+            // Tauri desktop shell — update banner
+            LocaleKey::BannerCheckingForUpdates => "Buscando actualizaciones…",
+            LocaleKey::BannerUpdateAvailablePrefix => "Actualización",
+            LocaleKey::BannerDownloadButton => "Descargar",
+            LocaleKey::BannerViewRelease => "Ver versión",
+            LocaleKey::BannerDismiss => "Descartar",
+            LocaleKey::BannerDownloadingPrefix => "Descargando actualización",
+            LocaleKey::BannerReadyToInstallSuffix => "lista para instalar",
+            LocaleKey::BannerInstallRestart => "Instalar y reiniciar",
+            LocaleKey::BannerUpdateFailedPrefix => "Actualización fallida",
+            LocaleKey::BannerRetry => "Reintentar",
+
+            // Tauri desktop shell — providers sidebar (Phase 6a)
+            LocaleKey::ProviderSidebarSearch => "Buscar",
+            LocaleKey::ProviderSidebarClearSearch => "Limpiar búsqueda de proveedores",
+            LocaleKey::ProviderSidebarNoMatches => "Sin proveedores coincidentes",
+            LocaleKey::ProviderSidebarReorderHint => "Arrastrar para reordenar",
+            LocaleKey::ProviderSidebarMoveUp => "Subir",
+            LocaleKey::ProviderSidebarMoveDown => "Bajar",
+            LocaleKey::ProviderStatusOk => "Actualizado",
+            LocaleKey::ProviderStatusStale => "Desactualizado",
+            LocaleKey::ProviderStatusError => "Error",
+            LocaleKey::ProviderStatusLoading => "Cargando",
+            LocaleKey::ProviderStatusDisabled => "Deshabilitado",
+            LocaleKey::ProviderDetailPlaceholder => "Panel de detalle llegando en Fase 6b",
+
+            // Phase 6d — credential detection
+            LocaleKey::CredentialsSectionTitle => "Credenciales",
+            LocaleKey::CredsStatusAuthenticated => "Autenticado",
+            LocaleKey::CredsStatusNotSignedIn => "Sin iniciar sesión",
+            LocaleKey::CredsStatusDetected => "Detectado",
+            LocaleKey::CredsStatusNotDetected => "No detectado",
+            LocaleKey::CredsStatusAvailable => "Disponible",
+            LocaleKey::CredsStatusUnavailable => "No disponible",
+            LocaleKey::CredsOpenFolderAction => "Abrir carpeta de credenciales",
+            LocaleKey::CredsRefreshDetectionAction => "Actualizar detección",
+            LocaleKey::CredsSavePathAction => "Guardar ruta",
+            LocaleKey::CredsBrowseAction => "Explorar…",
+            LocaleKey::CredsGeminiCliLabel => "Gemini CLI",
+            LocaleKey::CredsGeminiCliHelperPrefix => "Usa credenciales OAuth de",
+            LocaleKey::CredsGeminiCliSetupAction => "Configurar Gemini CLI",
+            LocaleKey::CredsGeminiCliSetupHelp => {
+                "Instale Gemini CLI y ejecute `gemini auth login` para iniciar sesión."
+            }
+            LocaleKey::CredsVertexAiLabel => "Google Cloud",
+            LocaleKey::CredsVertexAiHelperPrefix => "Usa credenciales de Google Cloud de",
+            LocaleKey::CredsVertexAiSetupAction => "Configurar autenticación de Google Cloud",
+            LocaleKey::CredsVertexAiSetupHelp => {
+                "Ejecute `gcloud auth application-default login` para crear credenciales."
+            }
+            LocaleKey::CredsJetBrainsLabel => "JetBrains IDE",
+            LocaleKey::CredsJetBrainsHelperDetectedPrefix => "Usando configuración de IDE detectada en",
+            LocaleKey::CredsJetBrainsHelperCustomPrefix => "Usando ruta base de IDE personalizada",
+            LocaleKey::CredsJetBrainsHelperMissing => {
+                "Instale un IDE de JetBrains con AI Assistant habilitado, luego actualice CodexBar."
+            }
+            LocaleKey::CredsJetBrainsCustomPathLabel => "Ruta personalizada",
+            LocaleKey::CredsJetBrainsCustomPathPlaceholder => "%APPDATA%/JetBrains/IntelliJIdea...",
+            LocaleKey::CredsJetBrainsSelectLabel => "Seleccione el IDE de JetBrains a monitorear.",
+            LocaleKey::CredsJetBrainsAutoDetectOption => "Detectar automáticamente",
+            LocaleKey::CredsKiroLabel => "Kiro CLI",
+            LocaleKey::CredsKiroHelperAvailablePrefix => "Detectado en",
+            LocaleKey::CredsKiroHelperMissing => {
+                "kiro-cli: no se encontró en PATH ni en ubicaciones de instalación conocidas."
+            }
+            LocaleKey::CredsOpenAiHistoryHelp => {
+                "Habilitar seguimiento histórico para ver el uso a lo largo del tiempo."
+            }
+
+            // Tauri desktop shell — Token accounts (Phase 6e, review)
+            LocaleKey::TokenAccountActive => "Activo",
+            LocaleKey::TokenAccountSetActive => "Establecer activo",
+            LocaleKey::TokenAccountRemove => "Eliminar",
+            LocaleKey::TokenAccountAddButton => "Agregar cuenta",
+            LocaleKey::TokenAccountGithubLoginButton => "Iniciar sesión con GitHub",
+            LocaleKey::TokenAccountEmpty => "No hay cuentas guardadas para este proveedor.",
+            LocaleKey::TokenAccountLabelPlaceholder => "Etiqueta (p. ej. Trabajo, Personal)…",
+            LocaleKey::TokenAccountProviderLabel => "Proveedor",
+            LocaleKey::TokenAccountProviderPlaceholder => "Seleccionar proveedor…",
+            LocaleKey::TokenAccountAddedPrefix => "Agregada",
+            LocaleKey::TokenAccountUsedPrefix => "Usada",
+            LocaleKey::TokenAccountTabHint => {
+                "Administrar múltiples tokens de sesión o tokens API por proveedor. La cuenta activa se usa para todas las consultas. Solo los proveedores que requieren tokens manuales aparecen aquí."
+            }
+            LocaleKey::TokenAccountNoSupported => "Actualmente ningún proveedor admite cuentas de token.",
+            LocaleKey::TokenAccountInlineSummary => "Cuentas de token",
+
+            // Phase 9 - Tray / pop-out pace badges + countdowns
+            LocaleKey::TrayPaceBadgeSlow => "Lento",
+            LocaleKey::TrayPaceBadgeSteady => "Constante",
+            LocaleKey::TrayPaceBadgeRacing => "Acelerado",
+            LocaleKey::TrayPaceBadgeBurning => "Crítico",
+            LocaleKey::TrayResetsInLabel => "Reinicia en {}",
+            LocaleKey::TrayResetsDueNow => "Reiniciando…",
+        }
+    }
+}

--- a/rust/src/locale/tests.rs
+++ b/rust/src/locale/tests.rs
@@ -44,6 +44,21 @@ fn test_locale_key_japanese() {
 }
 
 #[test]
+fn test_locale_key_spanish() {
+    assert_eq!(
+        get_text(Language::Spanish, LocaleKey::TabGeneral),
+        "General"
+    );
+    assert_eq!(
+        get_text(Language::Spanish, LocaleKey::InterfaceLanguage),
+        "Idioma de la interfaz"
+    );
+    assert_eq!(
+        get_text(Language::Spanish, LocaleKey::StartAtLogin),
+        "Iniciar al arrancar"
+    );
+}
+
 fn test_locale_respects_language_setting() {
     // Test that English language returns English strings
     let lang = Language::English;
@@ -56,11 +71,15 @@ fn test_locale_respects_language_setting() {
     // Test that Japanese language returns Japanese strings
     let lang = Language::Japanese;
     assert_eq!(get_text(lang, LocaleKey::TabAbout), "情報");
+
+    // Test that Spanish language returns Spanish strings
+    let lang = Language::Spanish;
+    assert_eq!(get_text(lang, LocaleKey::TabAbout), "Acerca de");
 }
 
 #[test]
-fn test_all_locale_keys_have_both_languages() {
-    // Verify all sampled variants have English, Chinese, and Japanese coverage.
+fn test_all_locale_keys_have_all_languages() {
+    // Verify all sampled variants have English, Chinese, Japanese, and Spanish coverage.
     let keys = [
         // Tab names
         LocaleKey::TabGeneral,
@@ -171,6 +190,14 @@ fn test_all_locale_keys_have_both_languages() {
         assert!(
             !japanese.is_empty(),
             "Japanese string for {:?} is empty",
+            key
+        );
+
+        // Spanish should not be empty
+        let spanish = key.spanish();
+        assert!(
+            !spanish.is_empty(),
+            "Spanish string for {:?} is empty",
             key
         );
     }

--- a/rust/src/locale/tests.rs
+++ b/rust/src/locale/tests.rs
@@ -59,6 +59,7 @@ fn test_locale_key_spanish() {
     );
 }
 
+#[test]
 fn test_locale_respects_language_setting() {
     // Test that English language returns English strings
     let lang = Language::English;

--- a/rust/src/providers/claude/oauth.rs
+++ b/rust/src/providers/claude/oauth.rs
@@ -378,16 +378,16 @@ impl ClaudeOAuthFetcher {
 
         #[cfg(not(windows))]
         {
-            if let Ok(output) = std::process::Command::new("whoami").output() {
-                if output.status.success() {
-                    let value = String::from_utf8_lossy(&output.stdout).trim().to_string();
-                    Self::push_keyring_candidate(&mut candidates, value.clone());
-                    if let Some((_, username)) = value.rsplit_once('\\') {
-                        Self::push_keyring_candidate(&mut candidates, username.to_string());
-                    }
-                    if let Some((_, username)) = value.rsplit_once('/') {
-                        Self::push_keyring_candidate(&mut candidates, username.to_string());
-                    }
+            if let Ok(output) = std::process::Command::new("whoami").output()
+                && output.status.success()
+            {
+                let value = String::from_utf8_lossy(&output.stdout).trim().to_string();
+                Self::push_keyring_candidate(&mut candidates, value.clone());
+                if let Some((_, username)) = value.rsplit_once('\\') {
+                    Self::push_keyring_candidate(&mut candidates, username.to_string());
+                }
+                if let Some((_, username)) = value.rsplit_once('/') {
+                    Self::push_keyring_candidate(&mut candidates, username.to_string());
                 }
             }
         }

--- a/rust/src/settings/tests.rs
+++ b/rust/src/settings/tests.rs
@@ -293,7 +293,7 @@ fn test_language_defaults_to_english() {
 #[test]
 fn test_language_all_variants_available() {
     let languages = Language::all();
-    assert_eq!(languages.len(), 3);
+    assert_eq!(languages.len(), 4);
     assert!(languages.contains(&Language::English));
     assert!(languages.contains(&Language::Chinese));
     assert!(languages.contains(&Language::Japanese));

--- a/rust/src/settings/types.rs
+++ b/rust/src/settings/types.rs
@@ -30,6 +30,46 @@ impl Language {
     pub fn all() -> &'static [Language] {
         &[Language::English, Language::Chinese, Language::Japanese, Language::Spanish]
     }
+
+    /// Stable label used in bridge JSON and persisted settings
+    /// (e.g. "english", "spanish").
+    pub fn label(&self) -> &'static str {
+        match self {
+            Language::English => "english",
+            Language::Chinese => "chinese",
+            Language::Japanese => "japanese",
+            Language::Spanish => "spanish",
+        }
+    }
+
+    /// Accepted input aliases — short codes and native names (all lowercase).
+    /// Used by resolve() for flexible language parsing.
+    pub fn accepted_aliases(&self) -> &'static [&'static str] {
+        match self {
+            Language::English => &["en", "en-us"],
+            Language::Chinese => &["zh", "zh-cn", "zh-hans", "中文"],
+            Language::Japanese => &["ja", "ja-jp", "日本語"],
+            Language::Spanish => &["es", "es-mx", "español"],
+        }
+    }
+
+    /// Resolve a language from any recognized input string.
+    /// Matches against label() and all accepted_aliases().
+    /// Case-insensitive via Unicode-aware to_lowercase().
+    pub fn resolve(raw: &str) -> Option<Language> {
+        let normalized = raw.trim().to_lowercase();
+        for lang in Self::all() {
+            if normalized == lang.label() {
+                return Some(*lang);
+            }
+            for alias in lang.accepted_aliases() {
+                if normalized == *alias {
+                    return Some(*lang);
+                }
+            }
+        }
+        None
+    }
 }
 
 /// UI theme preference (Phase 12).

--- a/rust/src/settings/types.rs
+++ b/rust/src/settings/types.rs
@@ -11,6 +11,8 @@ pub enum Language {
     Chinese,
     /// Japanese
     Japanese,
+    /// Spanish (Mexican)
+    Spanish,
 }
 
 impl Language {
@@ -20,12 +22,13 @@ impl Language {
             Language::English => "English",
             Language::Chinese => "中文",
             Language::Japanese => "日本語",
+            Language::Spanish => "Español",
         }
     }
 
     /// Get all available languages
     pub fn all() -> &'static [Language] {
-        &[Language::English, Language::Chinese, Language::Japanese]
+        &[Language::English, Language::Chinese, Language::Japanese, Language::Spanish]
     }
 }
 


### PR DESCRIPTION
## What

Adds full Mexican Spanish (es-MX) locale support (~300 UI strings) and refactors the language contract into a centralized catalog to eliminate scattered match/lists across the codebase.

## Changes

### es-MX Locale
- `rust/src/locale/spanish.rs` — ~300 translated UI strings
- `rust/src/locale/keys.rs` — `spanish()` method for each LocaleKey
- `rust/src/locale/tests.rs` — Spanish coverage tests
- `README.es-MX.md` — Spanish localized README (version updated to v0.37.5)

### Centralized Language Catalog
- `Language::label()` — canonical bridge/settings value (replaces scattered `language_label`)
- `Language::accepted_aliases()` — short codes and native name aliases (replaces scattered `parse_locale_language`)
- `Language::resolve()` — unified parsing from any input (replaces 2 separate parse functions)
- All 3 scattered functions now delegate to the catalog (1 line each)

### Frontend
- `get_available_languages` Tauri command exposes the catalog to the frontend
- `GeneralTab` loads language picker dynamically from the backend with static fallback
- Native display names replace i18n-key labels for consistent UX across all UI languages

### Why
Replaces #103 and #104 (closed). Addresses all review feedback: single PR, centralized language contract, dynamic frontend picker.

## Validation
- `cargo test -p codexbar -- language` — 10/10 ✅
- `cargo test -- locale language` (Tauri commands) — 5/5 ✅ (includes new Spanish alias tests)
- `cargo fmt --all` ✅
- `cargo clippy --all-targets -- -D warnings` ✅ (both crates)
- Frontend tests: 109 passed ✅