### PR TITLE
Fix cost_scanner token-count test that ages out of the 30-day window

### DIFF
--- a/rust/src/cost_scanner.rs
+++ b/rust/src/cost_scanner.rs
@@ -694,10 +694,18 @@ mod tests {
             "codexbar-current-codex-token-count-{}.jsonl",
             std::process::id()
         ));
+        // Use a recent timestamp so the event stays inside the scanner's
+        // 30-day window no matter when the test runs. A hardcoded date
+        // silently ages out of the window and makes this test fail with 0
+        // sessions once it is more than 30 days in the past.
+        let recent = (Utc::now() - Duration::hours(1))
+            .format("%Y-%m-%dT%H:%M:%S%.3fZ")
+            .to_string();
         let mut file = File::create(&path).unwrap();
         writeln!(
             file,
-            r#"{{"timestamp":"2026-05-27T17:12:48.000Z","type":"event_msg","payload":{{"type":"token_count","info":{{"model":"gpt-5","total_token_usage":{{"input_tokens":125,"cached_input_tokens":30,"output_tokens":15}}}}}}}}"#
+            r#"{{"timestamp":"{ts}","type":"event_msg","payload":{{"type":"token_count","info":{{"model":"gpt-5","total_token_usage":{{"input_tokens":125,"cached_input_tokens":30,"output_tokens":15}}}}}}}}"#,
+            ts = recent
         )
         .unwrap();
         drop(file);


### PR DESCRIPTION
Standalone fix split out of #108 per review.

`cost_scanner::tests::parses_current_codex_payload_token_count_events` writes a fixture event dated 2026-05-27 and scans with a 30-day window, so it fails with 0 sessions once that date is more than 30 days old (it fails on `main` today). The fixture timestamp is now computed relative to now, so the event always lands inside the window.