### PR TITLE
Route Claude cost estimates through the canonical pricing table (fixes Opus 4.8 / Haiku 4.5)

### DIFF
--- a/rust/src/core/cost_pricing.rs
+++ b/rust/src/core/cost_pricing.rs
@@ -272,6 +272,22 @@ static CODEX_PRICING: LazyLock<HashMap<&'static str, CodexPricing>> = LazyLock::
 static CLAUDE_PRICING: LazyLock<HashMap<&'static str, ClaudePricing>> = LazyLock::new(|| {
     let mut m = HashMap::new();
 
+    // Fable 5
+    m.insert(
+        "claude-fable-5",
+        ClaudePricing {
+            input_cost_per_token: 1e-5,
+            output_cost_per_token: 5e-5,
+            cache_creation_input_cost_per_token: 1.25e-5,
+            cache_read_input_cost_per_token: 1e-6,
+            threshold_tokens: None,
+            input_cost_per_token_above_threshold: None,
+            output_cost_per_token_above_threshold: None,
+            cache_creation_input_cost_per_token_above_threshold: None,
+            cache_read_input_cost_per_token_above_threshold: None,
+        },
+    );
+
     // Haiku 4.5
     m.insert(
         "claude-haiku-4-5",
@@ -335,6 +351,22 @@ static CLAUDE_PRICING: LazyLock<HashMap<&'static str, ClaudePricing>> = LazyLock
     // Opus 4.7 (same pricing as Opus 4.6)
     m.insert(
         "claude-opus-4-7",
+        ClaudePricing {
+            input_cost_per_token: 5e-6,
+            output_cost_per_token: 2.5e-5,
+            cache_creation_input_cost_per_token: 6.25e-6,
+            cache_read_input_cost_per_token: 5e-7,
+            threshold_tokens: None,
+            input_cost_per_token_above_threshold: None,
+            output_cost_per_token_above_threshold: None,
+            cache_creation_input_cost_per_token_above_threshold: None,
+            cache_read_input_cost_per_token_above_threshold: None,
+        },
+    );
+
+    // Opus 4.8 (same pricing as Opus 4.5/4.6/4.7)
+    m.insert(
+        "claude-opus-4-8",
         ClaudePricing {
             input_cost_per_token: 5e-6,
             output_cost_per_token: 2.5e-5,
@@ -617,6 +649,16 @@ impl CostUsagePricing {
         Some(cost)
     }
 
+    /// Base per-token input rate for a Claude model. Exposed for callers that
+    /// need a rate the standard cost function doesn't model — e.g. the usage
+    /// scanner's one-hour cache-write premium, billed at 2x the input rate.
+    pub fn claude_input_cost_per_token(model: &str) -> Option<f64> {
+        let key = Self::normalize_claude_model(model);
+        CLAUDE_PRICING
+            .get(key.as_str())
+            .map(|p| p.input_cost_per_token)
+    }
+
     /// Format model name for display (e.g., "claude-3.5-sonnet" → "Sonnet 3.5")
     pub fn format_model_name(model: &str) -> String {
         let lower = model.to_lowercase();
@@ -708,6 +750,38 @@ mod tests {
     fn test_claude_cost() {
         let cost = CostUsagePricing::claude_cost_usd("claude-haiku-4-5-20251001", 1000, 0, 0, 500);
         assert!(cost.is_some());
+    }
+
+    #[test]
+    fn test_opus_4_8_cost() {
+        // Opus 4.8 bills at $5/1M input + $25/1M output (same tier as 4.5/4.6/4.7).
+        let cost = CostUsagePricing::claude_cost_usd("claude-opus-4-8", 1_000, 0, 0, 500).unwrap();
+        // 1000 * 5e-6 + 500 * 2.5e-5 = 0.005 + 0.0125 = 0.0175
+        assert!((cost - 0.0175).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_fable_5_cost() {
+        // Fable 5 bills at $10/1M input + $50/1M output.
+        let cost = CostUsagePricing::claude_cost_usd("claude-fable-5", 1_000, 0, 0, 500).unwrap();
+        // 1000 * 1e-5 + 500 * 5e-5 = 0.01 + 0.025 = 0.035
+        assert!((cost - 0.035).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_claude_input_cost_per_token() {
+        assert_eq!(
+            CostUsagePricing::claude_input_cost_per_token("claude-opus-4-8"),
+            Some(5e-6)
+        );
+        assert_eq!(
+            CostUsagePricing::claude_input_cost_per_token("claude-fable-5"),
+            Some(1e-5)
+        );
+        assert_eq!(
+            CostUsagePricing::claude_input_cost_per_token("totally-unknown-model"),
+            None
+        );
     }
 
     #[test]

--- a/rust/src/cost_scanner.rs
+++ b/rust/src/cost_scanner.rs
@@ -122,9 +122,24 @@ impl ClaudePricing {
             .as_str()
         {
             m if m.contains("fable-5") => (10.00, 12.50, 1.00, 50.00),
-            m if m.contains("opus-4-6") || m.contains("opus_4_6") => (5.00, 6.25, 0.50, 25.00),
+            // Opus 4.5 and later (4.5/4.6/4.7/4.8) bill at $5/$25. Older Opus
+            // (3, 4.0, 4.1) stay at the legacy $15/$75 in the generic `opus`
+            // arm below. Current-gen IDs are consistently named `opus-4-N`, so
+            // match them explicitly; the generic fallback also correctly keeps
+            // Opus 3 (ID `claude-3-opus-...`) on legacy pricing.
+            m if m.contains("opus-4-5")
+                || m.contains("opus_4_5")
+                || m.contains("opus-4-6")
+                || m.contains("opus_4_6")
+                || m.contains("opus-4-7")
+                || m.contains("opus_4_7")
+                || m.contains("opus-4-8")
+                || m.contains("opus_4_8") =>
+            {
+                (5.00, 6.25, 0.50, 25.00)
+            }
             m if m.contains("sonnet-4-6") || m.contains("sonnet_4_6") => (3.00, 3.75, 0.30, 15.00),
-            m if m.contains("opus") => (15.00, 18.75, 1.50, 75.00),
+            m if m.contains("opus") => (15.00, 18.75, 1.50, 75.00), // legacy Opus 3 / 4.0 / 4.1
             m if m.contains("sonnet") => (3.00, 3.75, 0.30, 15.00),
             m if m.contains("haiku") => (0.25, 0.30, 0.03, 1.25),
             _ => (3.00, 3.75, 0.30, 15.00), // Default to Sonnet
@@ -679,6 +694,43 @@ mod tests {
     fn test_claude_sonnet_46_uses_standard_full_context_pricing() {
         let cost = ClaudePricing::cost_usd_with_cache_ttl("claude-sonnet-4-6", 240_000, 0, 0, 0, 0);
         assert!((cost - 0.72).abs() < 0.001);
+    }
+
+    #[test]
+    fn test_current_gen_opus_uses_5_25_pricing() {
+        // Opus 4.5/4.6/4.7/4.8 bill at $5/1M input + $25/1M output = $30 total,
+        // not the legacy $15/$75. Regression guard for opus-4-7/4-8 previously
+        // falling through to the generic (legacy) Opus arm.
+        for model in [
+            "claude-opus-4-5",
+            "claude-opus-4-6",
+            "claude-opus-4-7",
+            "claude-opus-4-8",
+        ] {
+            let cost = ClaudePricing::cost_usd_with_cache_ttl(model, 1_000_000, 0, 0, 0, 1_000_000);
+            assert!(
+                (cost - 30.00).abs() < 0.001,
+                "{model} should bill $30 ($5 in + $25 out), got {cost}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_legacy_opus_keeps_legacy_pricing() {
+        // Opus 3 / 4.0 / 4.1 remain at $15/1M input + $75/1M output = $90.
+        // Note Opus 3's ID is `claude-3-opus-...` (inverted), caught by the
+        // generic `opus` fallback rather than an `opus-4-N` arm.
+        for model in [
+            "claude-3-opus-20240229",
+            "claude-opus-4-1",
+            "claude-opus-4-0",
+        ] {
+            let cost = ClaudePricing::cost_usd_with_cache_ttl(model, 1_000_000, 0, 0, 0, 1_000_000);
+            assert!(
+                (cost - 90.00).abs() < 0.001,
+                "{model} should bill $90 ($15 in + $75 out), got {cost}"
+            );
+        }
     }
 
     #[test]

--- a/rust/src/cost_scanner.rs
+++ b/rust/src/cost_scanner.rs
@@ -105,7 +105,17 @@ impl CodexPricing {
     }
 }
 
-/// Claude token pricing (per 1M tokens, as of 2024)
+/// Fallback Claude model used when a scanned model isn't in the canonical
+/// pricing table (unknown or retired IDs). Prices as Sonnet 4.6.
+const FALLBACK_CLAUDE_MODEL: &str = "claude-sonnet-4-6";
+
+/// Claude cost calculation for the usage scanner.
+///
+/// Per-token rates come from the canonical `CostUsagePricing::claude_cost_usd`
+/// table (the single source of truth for Claude pricing). The only
+/// scanner-specific piece is the one-hour cache-write premium, which the
+/// canonical cost function doesn't model: one-hour cache writes bill at 2x the
+/// input rate.
 struct ClaudePricing;
 
 impl ClaudePricing {
@@ -117,47 +127,37 @@ impl ClaudePricing {
         cache_read: u64,
         output: u64,
     ) -> f64 {
-        let (input_price, cache_create_price, cache_read_price, output_price) = match model
-            .to_lowercase()
-            .as_str()
-        {
-            m if m.contains("fable-5") => (10.00, 12.50, 1.00, 50.00),
-            // Opus 4.5 and later (4.5/4.6/4.7/4.8) bill at $5/$25. Older Opus
-            // (3, 4.0, 4.1) stay at the legacy $15/$75 in the generic `opus`
-            // arm below. Current-gen IDs are consistently named `opus-4-N`, so
-            // match them explicitly; the generic fallback also correctly keeps
-            // Opus 3 (ID `claude-3-opus-...`) on legacy pricing.
-            m if m.contains("opus-4-5")
-                || m.contains("opus_4_5")
-                || m.contains("opus-4-6")
-                || m.contains("opus_4_6")
-                || m.contains("opus-4-7")
-                || m.contains("opus_4_7")
-                || m.contains("opus-4-8")
-                || m.contains("opus_4_8") =>
-            {
-                (5.00, 6.25, 0.50, 25.00)
-            }
-            m if m.contains("sonnet-4-6") || m.contains("sonnet_4_6") => (3.00, 3.75, 0.30, 15.00),
-            m if m.contains("opus") => (15.00, 18.75, 1.50, 75.00), // legacy Opus 3 / 4.0 / 4.1
-            m if m.contains("sonnet") => (3.00, 3.75, 0.30, 15.00),
-            // Haiku 4.5 bills at $1/$5. The generic `haiku` arm below is the
-            // legacy Haiku 3 rate ($0.25/$1.25); match 4.5 explicitly so it is
-            // not under-priced by falling through to it.
-            m if m.contains("haiku-4-5") || m.contains("haiku_4_5") => (1.00, 1.25, 0.10, 5.00),
-            m if m.contains("haiku") => (0.25, 0.30, 0.03, 1.25),
-            _ => (3.00, 3.75, 0.30, 15.00), // Default to Sonnet
-        };
-
         let cache_create_1h = cache_create_1h.min(cache_create);
         let cache_create_5m = cache_create.saturating_sub(cache_create_1h);
-        let input_cost = (input as f64 / 1_000_000.0) * input_price;
-        let cache_create_cost = (cache_create_5m as f64 / 1_000_000.0) * cache_create_price;
-        let cache_create_1h_cost = (cache_create_1h as f64 / 1_000_000.0) * input_price * 2.0;
-        let cache_read_cost = (cache_read as f64 / 1_000_000.0) * cache_read_price;
-        let output_cost = (output as f64 / 1_000_000.0) * output_price;
 
-        input_cost + cache_create_cost + cache_create_1h_cost + cache_read_cost + output_cost
+        // Standard buckets (input, cache-read, 5-minute cache-write, output),
+        // including any long-context tiering, come from the canonical table.
+        // Unknown/retired models fall back to Sonnet pricing.
+        let clamp = |v: u64| v.min(i32::MAX as u64) as i32;
+        let base = CostUsagePricing::claude_cost_usd(
+            model,
+            clamp(input),
+            clamp(cache_read),
+            clamp(cache_create_5m),
+            clamp(output),
+        )
+        .or_else(|| {
+            CostUsagePricing::claude_cost_usd(
+                FALLBACK_CLAUDE_MODEL,
+                clamp(input),
+                clamp(cache_read),
+                clamp(cache_create_5m),
+                clamp(output),
+            )
+        })
+        .unwrap_or(0.0);
+
+        // Scanner-specific: one-hour cache writes bill at 2x the input rate.
+        let input_rate = CostUsagePricing::claude_input_cost_per_token(model)
+            .or_else(|| CostUsagePricing::claude_input_cost_per_token(FALLBACK_CLAUDE_MODEL))
+            .unwrap_or(0.0);
+
+        base + (cache_create_1h as f64) * input_rate * 2.0
     }
 }
 
@@ -660,17 +660,13 @@ mod tests {
     }
 
     #[test]
-    fn test_claude_pricing() {
-        // Test Sonnet pricing: $3/1M input, $15/1M output
-        let cost = ClaudePricing::cost_usd_with_cache_ttl(
-            "claude-3-5-sonnet",
-            1_000_000,
-            0,
-            0,
-            0,
-            1_000_000,
-        );
-        assert!((cost - 18.0).abs() < 0.01);
+    fn test_unknown_model_falls_back_to_sonnet() {
+        // Unknown/retired Claude IDs fall back to Sonnet 4.6 base pricing
+        // ($3/1M input, $15/1M output). 100k tokens stay under the 200k tier.
+        let cost =
+            ClaudePricing::cost_usd_with_cache_ttl("claude-3-5-sonnet", 100_000, 0, 0, 0, 100_000);
+        // 100k * $3/M + 100k * $15/M = 0.30 + 1.50 = 1.80
+        assert!((cost - 1.80).abs() < 0.001);
     }
 
     #[test]
@@ -695,16 +691,19 @@ mod tests {
     }
 
     #[test]
-    fn test_claude_sonnet_46_uses_standard_full_context_pricing() {
+    fn test_claude_sonnet_46_honors_200k_tier() {
+        // Delegating to the canonical table means the scanner now honors the
+        // 200k long-context tier: 200k @ $3/M + 40k @ $6/M = 0.60 + 0.24 = 0.84
+        // (the scanner's old inline table applied a flat $3/M = 0.72).
         let cost = ClaudePricing::cost_usd_with_cache_ttl("claude-sonnet-4-6", 240_000, 0, 0, 0, 0);
-        assert!((cost - 0.72).abs() < 0.001);
+        assert!((cost - 0.84).abs() < 0.001);
     }
 
     #[test]
     fn test_current_gen_opus_uses_5_25_pricing() {
-        // Opus 4.5/4.6/4.7/4.8 bill at $5/1M input + $25/1M output = $30 total,
-        // not the legacy $15/$75. Regression guard for opus-4-7/4-8 previously
-        // falling through to the generic (legacy) Opus arm.
+        // Opus 4.5/4.6/4.7/4.8 bill at $5/1M input + $25/1M output = $30 total.
+        // Delegation regression guard: opus-4-8 in particular must resolve
+        // through the canonical table (it was missing there before this fix).
         for model in [
             "claude-opus-4-5",
             "claude-opus-4-6",
@@ -721,14 +720,11 @@ mod tests {
 
     #[test]
     fn test_legacy_opus_keeps_legacy_pricing() {
-        // Opus 3 / 4.0 / 4.1 remain at $15/1M input + $75/1M output = $90.
-        // Note Opus 3's ID is `claude-3-opus-...` (inverted), caught by the
-        // generic `opus` fallback rather than an `opus-4-N` arm.
-        for model in [
-            "claude-3-opus-20240229",
-            "claude-opus-4-1",
-            "claude-opus-4-0",
-        ] {
+        // Legacy Opus 4.0 / 4.1 remain at $15/1M input + $75/1M output = $90 in
+        // the canonical table. (Retired IDs absent from the table — e.g. Opus 3
+        // `claude-3-opus-...` — fall back to Sonnet instead; they are outside
+        // any realistic 30-day scan window.)
+        for model in ["claude-opus-4-20250514", "claude-opus-4-1"] {
             let cost = ClaudePricing::cost_usd_with_cache_ttl(model, 1_000_000, 0, 0, 0, 1_000_000);
             assert!(
                 (cost - 90.00).abs() < 0.001,
@@ -739,8 +735,8 @@ mod tests {
 
     #[test]
     fn test_haiku_45_uses_current_pricing() {
-        // Haiku 4.5 bills at $1/1M input + $5/1M output = $6, not the legacy
-        // Haiku 3 rate of $0.25/$1.25 that the generic `haiku` arm applies.
+        // Haiku 4.5 bills at $1/1M input + $5/1M output = $6 via the canonical
+        // table (previously the scanner under-priced it at the Haiku 3 rate).
         let cost = ClaudePricing::cost_usd_with_cache_ttl(
             "claude-haiku-4-5",
             1_000_000,
@@ -752,23 +748,6 @@ mod tests {
         assert!(
             (cost - 6.00).abs() < 0.001,
             "haiku-4-5 should bill $6 ($1 in + $5 out), got {cost}"
-        );
-    }
-
-    #[test]
-    fn test_legacy_haiku_keeps_legacy_pricing() {
-        // Haiku 3 remains at $0.25/1M input + $1.25/1M output = $1.50.
-        let cost = ClaudePricing::cost_usd_with_cache_ttl(
-            "claude-3-haiku-20240307",
-            1_000_000,
-            0,
-            0,
-            0,
-            1_000_000,
-        );
-        assert!(
-            (cost - 1.50).abs() < 0.001,
-            "haiku 3 should bill $1.50, got {cost}"
         );
     }
 

--- a/rust/src/cost_scanner.rs
+++ b/rust/src/cost_scanner.rs
@@ -141,6 +141,10 @@ impl ClaudePricing {
             m if m.contains("sonnet-4-6") || m.contains("sonnet_4_6") => (3.00, 3.75, 0.30, 15.00),
             m if m.contains("opus") => (15.00, 18.75, 1.50, 75.00), // legacy Opus 3 / 4.0 / 4.1
             m if m.contains("sonnet") => (3.00, 3.75, 0.30, 15.00),
+            // Haiku 4.5 bills at $1/$5. The generic `haiku` arm below is the
+            // legacy Haiku 3 rate ($0.25/$1.25); match 4.5 explicitly so it is
+            // not under-priced by falling through to it.
+            m if m.contains("haiku-4-5") || m.contains("haiku_4_5") => (1.00, 1.25, 0.10, 5.00),
             m if m.contains("haiku") => (0.25, 0.30, 0.03, 1.25),
             _ => (3.00, 3.75, 0.30, 15.00), // Default to Sonnet
         };
@@ -731,6 +735,41 @@ mod tests {
                 "{model} should bill $90 ($15 in + $75 out), got {cost}"
             );
         }
+    }
+
+    #[test]
+    fn test_haiku_45_uses_current_pricing() {
+        // Haiku 4.5 bills at $1/1M input + $5/1M output = $6, not the legacy
+        // Haiku 3 rate of $0.25/$1.25 that the generic `haiku` arm applies.
+        let cost = ClaudePricing::cost_usd_with_cache_ttl(
+            "claude-haiku-4-5",
+            1_000_000,
+            0,
+            0,
+            0,
+            1_000_000,
+        );
+        assert!(
+            (cost - 6.00).abs() < 0.001,
+            "haiku-4-5 should bill $6 ($1 in + $5 out), got {cost}"
+        );
+    }
+
+    #[test]
+    fn test_legacy_haiku_keeps_legacy_pricing() {
+        // Haiku 3 remains at $0.25/1M input + $1.25/1M output = $1.50.
+        let cost = ClaudePricing::cost_usd_with_cache_ttl(
+            "claude-3-haiku-20240307",
+            1_000_000,
+            0,
+            0,
+            0,
+            1_000_000,
+        );
+        assert!(
+            (cost - 1.50).abs() < 0.001,
+            "haiku 3 should bill $1.50, got {cost}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Problem

The usage scanner (`rust/src/cost_scanner.rs`) carried its own inline Claude pricing table, separate from the canonical `CostUsagePricing::claude_cost_usd` in `rust/src/core/cost_pricing.rs`. That second source had drifted — current-gen models fell through to stale generic rates:

- `claude-opus-4-8` / `-4-7` / `-4-5` → legacy Opus $15/$75 (should be $5/$25) — **3× over**
- `claude-haiku-4-5` → legacy Haiku 3 $0.25/$1.25 (should be $1/$5) — **4× under**

And `claude-opus-4-8` was missing from the canonical table entirely.

## Fix (per review)

Rather than grow the scanner's parallel table, route Claude pricing through the canonical one:

- **`core/cost_pricing.rs`**: add `claude-opus-4-8` ($5/$25) and `claude-fable-5` ($10/$50) to `CLAUDE_PRICING`; expose `CostUsagePricing::claude_input_cost_per_token`.
- **`cost_scanner.rs`**: delete the inline rate table. `ClaudePricing::cost_usd_with_cache_ttl` now delegates the standard buckets (input, cache-read, 5-minute cache-write, output) to `claude_cost_usd`, keeping only the scanner-specific one-hour cache-write premium (2× the input rate). Unknown/retired IDs fall back to Sonnet 4.6.

### Behavior notes

- Opus 4.5–4.8 and Haiku 4.5 are now priced correctly from the single canonical source.
- The scanner now honors the canonical **Sonnet 200k long-context tier** (it previously applied a flat rate). Opus 4.8 has no tier, so those estimates are unchanged.
- Retired IDs absent from the canonical table (Opus 3, Haiku 3/3.5) now fall back to Sonnet rather than a hardcoded legacy rate — they're outside any realistic 30-day scan window.

## Tests

- Canonical (`cost_pricing.rs`): `test_opus_4_8_cost`, `test_fable_5_cost`, `test_claude_input_cost_per_token`.
- Scanner (`cost_scanner.rs`): current-gen Opus / Haiku 4.5 delegation, one-hour cache-write, 200k-tier, unknown-model fallback, canonical-covered legacy Opus.

Full lib suite: **458 passed, 0 failed**; `cargo clippy --lib -- -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
