### PR TITLE
Fix Command Code cookie normalization

### DIFF
--- a/rust/src/core/token_accounts.rs
+++ b/rust/src/core/token_accounts.rs
@@ -167,8 +167,8 @@ impl TokenAccountSupport {
             }),
             ProviderId::CommandCode => Some(TokenAccountSupport {
                 title: "Session tokens",
-                subtitle: "Store multiple Command Code better-auth session tokens.",
-                placeholder: "better-auth.session_token value or Cookie: ...",
+                subtitle: "Store multiple Command Code Cookie headers or Better Auth values.",
+                placeholder: "Cookie: __Secure-commandcode_prod_.session_token=... or better-auth value",
                 injection: TokenInjection::CookieHeader,
                 requires_manual_cookie_source: true,
                 cookie_name: Some("__Secure-better-auth.session_token"),

--- a/rust/src/providers/commandcode/mod.rs
+++ b/rust/src/providers/commandcode/mod.rs
@@ -4,6 +4,7 @@
 
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
+use regex_lite::Regex;
 use reqwest::Client;
 use serde_json::Value;
 
@@ -91,30 +92,86 @@ impl CommandCodeProvider {
 }
 
 fn normalize_cookie_header(raw: &str) -> Option<String> {
-    let trimmed = raw.trim();
-    if trimmed.is_empty() {
+    let extracted;
+    let mut header = raw.trim();
+    if let Some(cookie_header) = cookie_header_from_curl(raw) {
+        extracted = cookie_header;
+        header = extracted.trim();
+    } else if looks_like_curl_capture(header) {
         return None;
     }
-    if !trimmed.contains('=') && !trimmed.contains(';') {
-        return Some(format!("__Secure-better-auth.session_token={trimmed}"));
+    if header
+        .get(.."cookie:".len())
+        .is_some_and(|prefix| prefix.eq_ignore_ascii_case("cookie:"))
+    {
+        header = header["cookie:".len()..].trim();
+    }
+    if header.is_empty() {
+        return None;
+    }
+    if !header.contains('=') && !header.contains(';') {
+        return Some(format!("__Secure-better-auth.session_token={header}"));
     }
 
-    let supported = [
-        "__Host-better-auth.session_token",
-        "__Secure-better-auth.session_token",
-        "better-auth.session_token",
-    ];
-    for chunk in trimmed.split(';') {
-        let (name, value) = chunk.trim().split_once('=')?;
-        if supported
-            .iter()
-            .any(|expected| expected.eq_ignore_ascii_case(name.trim()))
-            && !value.trim().is_empty()
-        {
-            return Some(format!("{}={}", name.trim(), value.trim()));
+    let mut cookies = Vec::new();
+    for chunk in header.split(';') {
+        let Some((name, value)) = chunk.trim().split_once('=') else {
+            continue;
+        };
+        let name = name.trim();
+        let value = value.trim();
+        if name.is_empty() || value.is_empty() {
+            continue;
+        }
+        cookies.push(format!("{name}={value}"));
+    }
+    if !cookies.is_empty() {
+        Some(cookies.join("; "))
+    } else {
+        None
+    }
+}
+
+fn cookie_header_from_curl(raw: &str) -> Option<String> {
+    let re =
+        Regex::new(r#"(?s)(?:^|\s)(?:-H|--header)(?:\s+|=)(?:'([^']*)'|"([^"]*)"|(\S+))"#).ok()?;
+    re.captures_iter(raw).find_map(|caps| {
+        let field = caps
+            .get(1)
+            .or_else(|| caps.get(2))
+            .or_else(|| caps.get(3))?
+            .as_str();
+        let field = unescape_shell_segment(field);
+        let (name, value) = split_header(&field)?;
+        name.eq_ignore_ascii_case("cookie")
+            .then(|| value.trim().to_string())
+            .filter(|value| !value.is_empty())
+    })
+}
+
+fn looks_like_curl_capture(raw: &str) -> bool {
+    let lower = raw.trim_start().to_ascii_lowercase();
+    lower.starts_with("curl ") || lower.starts_with("curl.exe ")
+}
+
+fn split_header(field: &str) -> Option<(&str, &str)> {
+    let colon = field.find(':')?;
+    Some((field[..colon].trim(), field[colon + 1..].trim()))
+}
+
+fn unescape_shell_segment(raw: &str) -> String {
+    let mut output = String::with_capacity(raw.len());
+    let mut chars = raw.chars();
+    while let Some(ch) = chars.next() {
+        if ch == '\\' {
+            if let Some(next) = chars.next() {
+                output.push(next);
+            }
+        } else {
+            output.push(ch);
         }
     }
-    None
+    output
 }
 
 fn result_from_payloads(
@@ -232,6 +289,48 @@ mod tests {
             normalize_cookie_header("abc123").as_deref(),
             Some("__Secure-better-auth.session_token=abc123")
         );
+    }
+
+    #[test]
+    fn command_code_accepts_production_session_cookies() {
+        assert_eq!(
+            normalize_cookie_header(
+                "__Secure-commandcode_prod_.session_token=token; __Secure-commandcode_prod_.session_data=data; stripe=ignored"
+            )
+            .as_deref(),
+            Some("__Secure-commandcode_prod_.session_token=token; __Secure-commandcode_prod_.session_data=data; stripe=ignored")
+        );
+    }
+
+    #[test]
+    fn command_code_preserves_unknown_full_cookie_header() {
+        assert_eq!(
+            normalize_cookie_header("Cookie: sidebar=value; stripe_mid=mid").as_deref(),
+            Some("sidebar=value; stripe_mid=mid")
+        );
+    }
+
+    #[test]
+    fn command_code_extracts_cookie_header_from_curl() {
+        let curl = r#"curl 'https://commandcode.ai' -H 'User-Agent: Browser' -H 'Cookie: __Secure-commandcode_prod_.session_token=token; __Secure-commandcode_prod_.session_data=data' "#;
+        assert_eq!(
+            normalize_cookie_header(curl).as_deref(),
+            Some(
+                "__Secure-commandcode_prod_.session_token=token; __Secure-commandcode_prod_.session_data=data"
+            )
+        );
+    }
+
+    #[test]
+    fn command_code_rejects_curl_without_cookie_header() {
+        let curl = r#"curl 'https://commandcode.ai' -H 'User-Agent: Browser'"#;
+        assert_eq!(normalize_cookie_header(curl), None);
+    }
+
+    #[test]
+    fn command_code_rejects_empty_or_malformed_cookie_header() {
+        assert_eq!(normalize_cookie_header("Cookie:   "), None);
+        assert_eq!(normalize_cookie_header("not-a-cookie; also-bad"), None);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Accept current Command Code production cookie names such as `__Secure-commandcode_prod_.session_token` and `.session_data`
- Pass through valid full `Cookie:` headers instead of reducing manual cookies to legacy Better Auth names
- Extract Cookie headers from one-line browser cURL captures and reject cURL captures without cookies
- Update Command Code token-account helper text to match the accepted input shapes

Fixes #116

## Validation
- `cargo fmt --manifest-path rust\\Cargo.toml --all`
- `git diff --check`
- `cargo test --manifest-path rust\\Cargo.toml providers::commandcode` could not complete locally because this Windows environment is missing MSVC/Windows SDK linker files (`link.exe` / `kernel32.lib`).