### PR TITLE
Fix NanoGPT daily-only usage parsing

### DIFF
--- a/apps/desktop-tauri/src-tauri/src/shell/tests.rs
+++ b/apps/desktop-tauri/src-tauri/src/shell/tests.rs
@@ -470,9 +470,9 @@ fn visible_surface_position_without_anchor_prefers_primary_over_offview_current_
     let position = visible_surface_position_for_mode_with_fallbacks(
         SurfaceMode::PopOut,
         Some(&[offview_current, primary]),
-        None,                              // no tray anchor
-        Some(offview_current),             // hidden main window parked off-view
-        Some(((-1288, 8), (1024, 1088))),  // last bounds also off-view
+        None,                             // no tray anchor
+        Some(offview_current),            // hidden main window parked off-view
+        Some(((-1288, 8), (1024, 1088))), // last bounds also off-view
         Some(primary),
     )
     .expect("should resolve a position");

--- a/apps/desktop-tauri/src-tauri/src/state.rs
+++ b/apps/desktop-tauri/src-tauri/src/state.rs
@@ -489,12 +489,8 @@ mod tests {
 
         state.begin_gesture_blur_guard(now);
 
-        assert!(!state.is_gesture_blur_guard_active(
-            now + std::time::Duration::from_secs(15)
-        ));
-        assert!(!state.is_gesture_blur_guard_active(
-            now + std::time::Duration::from_secs(16)
-        ));
+        assert!(!state.is_gesture_blur_guard_active(now + std::time::Duration::from_secs(15)));
+        assert!(!state.is_gesture_blur_guard_active(now + std::time::Duration::from_secs(16)));
     }
 
     #[test]

--- a/rust/src/providers/nanogpt/mod.rs
+++ b/rust/src/providers/nanogpt/mod.rs
@@ -29,7 +29,8 @@ struct UsageResponse {
     period: BillingPeriod,
     #[serde(default)]
     daily: Option<UsageMetric>,
-    monthly: UsageMetric,
+    #[serde(default)]
+    monthly: Option<UsageMetric>,
     state: String,
     grace_until: Option<String>,
 }
@@ -39,6 +40,7 @@ struct UsageResponse {
 struct UsageLimits {
     #[serde(default)]
     daily: Option<f64>,
+    #[serde(default)]
     monthly: f64,
 }
 
@@ -111,10 +113,12 @@ impl NanoGPTProvider {
             return Err(ProviderError::AuthRequired);
         }
 
-        // NanoGPT documents these as usage units, not tokens or dollars. Some
-        // live responses omit the daily block entirely, so monthly usage must
-        // be able to stand alone instead of failing deserialization.
-        let monthly_window = Self::window_from_metric(&usage.monthly, usage.limits.monthly);
+        // NanoGPT documents these as usage units, not tokens or dollars. Live
+        // responses may omit either usage block, so use whichever one exists.
+        let monthly_window = usage
+            .monthly
+            .as_ref()
+            .map(|monthly| Self::window_from_metric(monthly, usage.limits.monthly));
         let daily_window = usage
             .daily
             .as_ref()
@@ -130,10 +134,17 @@ impl NanoGPTProvider {
             usage.state
         };
 
-        let usage = if let Some(daily_window) = daily_window {
-            UsageSnapshot::new(daily_window).with_secondary(monthly_window)
-        } else {
-            UsageSnapshot::new(monthly_window)
+        let usage = match (daily_window, monthly_window) {
+            (Some(daily_window), Some(monthly_window)) => {
+                UsageSnapshot::new(daily_window).with_secondary(monthly_window)
+            }
+            (Some(daily_window), None) => UsageSnapshot::new(daily_window),
+            (None, Some(monthly_window)) => UsageSnapshot::new(monthly_window),
+            (None, None) => {
+                return Err(ProviderError::Parse(
+                    "NanoGPT response did not include daily or monthly usage".to_string(),
+                ));
+            }
         };
 
         Ok(usage.with_login_method(period_note))
@@ -333,6 +344,42 @@ mod tests {
         assert_eq!(
             usage.login_method.as_deref(),
             Some("active until 2025-02-13T23:59:59.000Z")
+        );
+    }
+
+    #[test]
+    fn parses_daily_usage_when_monthly_is_missing() {
+        let response: UsageResponse = serde_json::from_value(serde_json::json!({
+            "active": true,
+            "limits": {
+                "daily": 5000.0
+            },
+            "enforceDailyLimit": true,
+            "daily": {
+                "used": 125.0,
+                "remaining": 4875.0,
+                "percentUsed": 0.025,
+                "resetAt": 1738540800000_i64
+            },
+            "period": {
+                "currentPeriodEnd": "2025-02-13T23:59:59.000Z"
+            },
+            "state": "active",
+            "graceUntil": null
+        }))
+        .expect("daily-only response should deserialize");
+
+        let usage = NanoGPTProvider::usage_snapshot_from_response(response)
+            .expect("daily-only response should parse");
+
+        assert!((usage.primary.used_percent - 2.5).abs() < 0.0001);
+        assert_eq!(
+            usage.primary.reset_description.as_deref(),
+            Some("125/5000 units")
+        );
+        assert!(
+            usage.secondary.is_none(),
+            "monthly usage should not be synthesized when the API omits it"
         );
     }
 


### PR DESCRIPTION
## Summary
- Fix NanoGPT usage parsing when the API omits the top-level `monthly` usage block
- Accept daily-only or monthly-only responses, and return a parse error only when both usage windows are missing
- Add a regression test for the daily-only response from #127
- Apply rustfmt-only cleanup in two existing Tauri test files

Closes #127

## Local checks
```powershell
cargo fmt --all -- --check
cargo test --manifest-path rust\Cargo.toml
cargo clippy --manifest-path rust\Cargo.toml --all-targets -- -D warnings
cargo test --manifest-path apps\desktop-tauri\src-tauri\Cargo.toml
cargo clippy --manifest-path apps\desktop-tauri\src-tauri\Cargo.toml --all-targets -- -D warnings
git diff --check
```

All completed with exit code 0.