### PR TITLE
Fix stale flyout reveal after refresh

### DIFF
--- a/apps/desktop-tauri/src-tauri/src/commands/surface.rs
+++ b/apps/desktop-tauri/src-tauri/src/commands/surface.rs
@@ -76,10 +76,7 @@ pub async fn open_flyout_window(app: tauri::AppHandle) -> Result<(), String> {
 /// remembered fixed size re-applied), so Windows never shows a pre-measure
 /// blank/backing frame.
 ///
-/// No-ops when the flyout window doesn't exist — the `== TrayPanel` gate this
-/// replaced was checking "is the flyout the thing we're currently showing?";
-/// now that the flyout is its own window (not a state of `main`'s surface
-/// machine), window-existence is the equivalent check.
+/// No-ops when the flyout window doesn't exist or no one-shot reveal is pending.
 #[tauri::command]
 pub fn reveal_tray_panel_window(
     app: tauri::AppHandle,
@@ -90,6 +87,11 @@ pub fn reveal_tray_panel_window(
     let Some(window) = app.get_webview_window(crate::shell::flyout_window::FLYOUT_LABEL) else {
         return Ok(());
     };
+    let mut guard = state.lock().map_err(|e| e.to_string())?;
+    if !guard.take_pending_flyout_reveal() {
+        return Ok(());
+    }
+    drop(guard);
     window.show().map_err(|e| e.to_string())?;
     state
         .lock()

--- a/apps/desktop-tauri/src-tauri/src/shell/flyout_window.rs
+++ b/apps/desktop-tauri/src-tauri/src/shell/flyout_window.rs
@@ -131,11 +131,20 @@ pub fn open_or_focus(app: &AppHandle, position: Option<(i32, i32)>) -> Result<()
     if show_grace_starts_now(true) {
         mark_shown(app);
     }
+    arm_reveal(app)?;
     Ok(())
 }
 
 fn show_grace_starts_now(first_build_hidden: bool) -> bool {
     !first_build_hidden
+}
+
+fn arm_reveal(app: &AppHandle) -> Result<(), String> {
+    let state = app
+        .try_state::<Mutex<AppState>>()
+        .ok_or_else(|| "app state unavailable".to_string())?;
+    state.lock().map_err(|e| e.to_string())?.arm_flyout_reveal();
+    Ok(())
 }
 
 /// Toggle the flyout: hide if open, open (or focus) otherwise. Consumes a
@@ -169,6 +178,13 @@ pub fn toggle_with_blur_consume(app: &AppHandle, position: Option<(i32, i32)>) {
 /// process/window lifecycle treating it as an app-relevant close.
 pub fn hide(app: &AppHandle) -> Result<(), String> {
     if let Some(window) = app.get_webview_window(FLYOUT_LABEL) {
+        let state = app
+            .try_state::<Mutex<AppState>>()
+            .ok_or_else(|| "app state unavailable".to_string())?;
+        state
+            .lock()
+            .map_err(|e| e.to_string())?
+            .clear_flyout_reveal();
         window.hide().map_err(|e| e.to_string())?;
     }
     Ok(())

--- a/apps/desktop-tauri/src-tauri/src/state.rs
+++ b/apps/desktop-tauri/src-tauri/src/state.rs
@@ -146,6 +146,8 @@ pub struct AppState {
     pub startup_tray_blur_grace_until: Option<std::time::Instant>,
     /// Whether the explicit startup path may use its delayed shell fallback.
     pub startup_tray_reveal_pending: bool,
+    /// One-shot permission for frontend layout code to reveal a newly opened flyout.
+    pub flyout_reveal_pending: bool,
     /// Active while a user gesture (resize drag, HTML5 drag-reorder) is
     /// running a Win32 modal loop that transiently steals focus from the
     /// WebView2 child. `(began, until)` — `until` is the hard expiry;
@@ -194,6 +196,7 @@ impl AppState {
             last_blur_dismissed_at: None,
             startup_tray_blur_grace_until: None,
             startup_tray_reveal_pending: false,
+            flyout_reveal_pending: false,
             gesture_blur_guard: None,
         }
     }
@@ -240,6 +243,18 @@ impl AppState {
 
     pub fn take_startup_tray_reveal_fallback(&mut self) -> bool {
         std::mem::take(&mut self.startup_tray_reveal_pending)
+    }
+
+    pub fn arm_flyout_reveal(&mut self) {
+        self.flyout_reveal_pending = true;
+    }
+
+    pub fn clear_flyout_reveal(&mut self) {
+        self.flyout_reveal_pending = false;
+    }
+
+    pub fn take_pending_flyout_reveal(&mut self) -> bool {
+        std::mem::take(&mut self.flyout_reveal_pending)
     }
 
     /// Arm the gesture blur guard for 15s. Called when the frontend reports
@@ -459,6 +474,33 @@ mod tests {
 
         assert!(state.take_startup_tray_reveal_fallback());
         assert!(!state.take_startup_tray_reveal_fallback());
+    }
+
+    #[test]
+    fn hidden_flyout_cannot_be_revealed_by_stale_layout_work() {
+        let mut state = AppState::new();
+
+        assert!(!state.take_pending_flyout_reveal());
+    }
+
+    #[test]
+    fn pending_flyout_reveal_is_consumed_once() {
+        let mut state = AppState::new();
+
+        state.arm_flyout_reveal();
+
+        assert!(state.take_pending_flyout_reveal());
+        assert!(!state.take_pending_flyout_reveal());
+    }
+
+    #[test]
+    fn pending_flyout_reveal_can_be_cleared_without_revealing() {
+        let mut state = AppState::new();
+
+        state.arm_flyout_reveal();
+        state.clear_flyout_reveal();
+
+        assert!(!state.take_pending_flyout_reveal());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Gate `reveal_tray_panel_window` behind a one-shot pending reveal flag.
- Arm the flag only when the detached flyout is newly created hidden for first layout.
- Clear the flag when the flyout is hidden so stale layout/refresh work cannot pop it back open.
- Add focused AppState tests for hidden, consumed, and cleared reveal permission.

Fixes #129.

## Validation
- CUA driver against final debug Tauri build:
  - first-build flyout starts hidden, then frontend layout reveal makes it visible
  - stale `reveal_tray_panel_window` keeps hidden flyout hidden
  - `refresh_providers_if_stale` + stale reveal keeps hidden flyout hidden
  - explicit `open_flyout_window` still shows the flyout
- `cargo fmt --all -- --check`
- `cargo test --manifest-path apps\desktop-tauri\src-tauri\Cargo.toml`
- `cargo clippy --manifest-path apps\desktop-tauri\src-tauri\Cargo.toml --all-targets -- -D warnings`
- `git diff --check`
- `cargo clippy --manifest-path rust\Cargo.toml --all-targets -- -D warnings`
- `cargo test --manifest-path rust\Cargo.toml` (first run hit a transient Windows PTY flake; focused rerun and full rerun passed)

## Reviewer notes
The risky area is the first-build hidden flyout reveal: it still relies on frontend layout calling `reveal_tray_panel_window`, but now that command is a one-shot permission instead of “window exists, show it.”