### PR TITLE
Port scoped upstream 0.41 fixes

### DIFF
--- a/rust/src/cli/mod.rs
+++ b/rust/src/cli/mod.rs
@@ -100,6 +100,10 @@ pub struct Cli {
     /// Send Antigravity planInfo fields to stderr (debug)
     #[arg(long = "antigravity-plan-debug")]
     pub antigravity_plan_debug: bool,
+
+    /// Print one compact usage line per provider
+    #[arg(long)]
+    pub brief: bool,
 }
 
 #[derive(Subcommand, Debug)]
@@ -148,6 +152,7 @@ impl Cli {
             web_timeout: self.web_timeout,
             web_debug_dump_html: self.web_debug_dump_html,
             antigravity_plan_debug: self.antigravity_plan_debug,
+            brief: self.brief,
         }
     }
 }

--- a/rust/src/cli/usage.rs
+++ b/rust/src/cli/usage.rs
@@ -60,6 +60,10 @@ pub struct UsageArgs {
     /// Send Antigravity planInfo fields to stderr (debug)
     #[arg(long = "antigravity-plan-debug")]
     pub antigravity_plan_debug: bool,
+
+    /// Print one compact line per provider
+    #[arg(long)]
+    pub brief: bool,
 }
 
 /// Output format enum
@@ -148,6 +152,7 @@ struct UsageCommand {
     format: OutputFormat,
     providers: Vec<ProviderId>,
     use_color: bool,
+    brief: bool,
     fetch_status: bool,
     pretty: bool,
     ctx: FetchContext,
@@ -163,6 +168,7 @@ impl UsageCommand {
             format,
             providers,
             use_color: !args.no_color && is_terminal(),
+            brief: args.brief,
             fetch_status: args.status,
             pretty: args.pretty,
             ctx: build_usage_fetch_context(&args, source_mode),
@@ -234,7 +240,11 @@ async fn collect_usage_output(command: &UsageCommand) -> UsageOutput {
 async fn fetch_provider_text_output(provider_id: ProviderId, command: &UsageCommand) -> String {
     match fetch_provider_result(provider_id, command).await {
         Ok((result, status)) => {
-            render_text_with_status(provider_id, &result, status.as_ref(), command.use_color)
+            if command.brief {
+                render_brief_text(provider_id, &result)
+            } else {
+                render_text_with_status(provider_id, &result, status.as_ref(), command.use_color)
+            }
         }
         Err(e) => render_text_error(provider_id, &e.to_string(), command.use_color),
     }
@@ -429,10 +439,10 @@ fn append_window_line(lines: &mut Vec<String>, label: &str, window: &RateWindow,
         .map(|c| format!(" (resets in {})", c))
         .unwrap_or_default();
     lines.push(format!(
-        "  {:<8} {} {:.0}% used{}",
+        "  {:<8} {} {} used{}",
         format!("{}:", label),
         bar,
-        window.used_percent,
+        format_percent(window.used_percent),
         reset
     ));
 }
@@ -464,9 +474,46 @@ fn append_model_specific_line(
     if let Some(opus) = model_specific {
         let opus_bar = render_progress_bar(opus.used_percent, 20, use_color);
         lines.push(format!(
-            "  Opus:    {} {:.0}% used",
-            opus_bar, opus.used_percent
+            "  Opus:    {} {} used",
+            opus_bar,
+            format_percent(opus.used_percent)
         ));
+    }
+}
+
+pub fn render_brief_text(provider: ProviderId, result: &ProviderFetchResult) -> String {
+    let metadata = instantiate_provider(provider).metadata().clone();
+    let usage = &result.usage;
+    let reset = usage
+        .primary
+        .format_countdown()
+        .unwrap_or_else(|| "n/a".to_string());
+    let mut parts = vec![format!(
+        "{} {}",
+        metadata.session_label,
+        format_percent(usage.primary.used_percent)
+    )];
+    if let Some(secondary) = &usage.secondary {
+        parts.push(format!(
+            "{} {}",
+            metadata.weekly_label,
+            format_percent(secondary.used_percent)
+        ));
+    }
+    parts.push(format!("resets {reset}"));
+    if let Some(plan) = &usage.login_method {
+        parts.push(plan.clone());
+    }
+    format!("{}: {}", provider.display_name(), parts.join(", "))
+}
+
+fn format_percent(percent: f64) -> String {
+    if !percent.is_finite() {
+        "0%".to_string()
+    } else if percent > 0.0 && percent < 1.0 {
+        "<1%".to_string()
+    } else {
+        format!("{:.0}%", percent.clamp(0.0, 100.0))
     }
 }
 
@@ -498,6 +545,11 @@ pub fn render_text(provider: ProviderId, result: &ProviderFetchResult, use_color
 
 /// Render a text-based progress bar
 fn render_progress_bar(percent: f64, width: usize, use_color: bool) -> String {
+    let percent = if percent.is_finite() {
+        percent.clamp(0.0, 100.0)
+    } else {
+        0.0
+    };
     let filled = ((percent / 100.0) * width as f64).round() as usize;
     let empty = width.saturating_sub(filled);
 
@@ -514,5 +566,39 @@ fn render_progress_bar(percent: f64, width: usize, use_color: bool) -> String {
         format!("{}{}\x1b[0m", color, bar)
     } else {
         bar
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fetch_result(usage: UsageSnapshot) -> ProviderFetchResult {
+        ProviderFetchResult::new(usage, "test")
+    }
+
+    #[test]
+    fn text_rendering_shows_sub_one_percent_usage() {
+        let result = fetch_result(UsageSnapshot::new(RateWindow::new(0.4)));
+
+        let output = render_text_with_status(ProviderId::Codex, &result, None, false);
+
+        assert!(output.contains("<1% used"));
+    }
+
+    #[test]
+    fn brief_rendering_keeps_one_line_per_provider() {
+        let result = fetch_result(
+            UsageSnapshot::new(RateWindow::new(0.4))
+                .with_secondary(RateWindow::new(100.0))
+                .with_login_method("Pro"),
+        );
+
+        let output = render_brief_text(ProviderId::Claude, &result);
+
+        assert_eq!(
+            output,
+            "Claude: Session (5h) <1%, Weekly 100%, resets n/a, Pro"
+        );
     }
 }

--- a/rust/src/core/rate_window.rs
+++ b/rust/src/core/rate_window.rs
@@ -26,7 +26,7 @@ impl RateWindow {
     /// Create a new rate window
     pub fn new(used_percent: f64) -> Self {
         Self {
-            used_percent: used_percent.clamp(0.0, 100.0),
+            used_percent: Self::finite_percent(used_percent),
             window_minutes: None,
             resets_at: None,
             reset_description: None,
@@ -41,7 +41,7 @@ impl RateWindow {
         reset_description: Option<String>,
     ) -> Self {
         Self {
-            used_percent: used_percent.clamp(0.0, 100.0),
+            used_percent: Self::finite_percent(used_percent),
             window_minutes,
             resets_at,
             reset_description,
@@ -74,7 +74,8 @@ impl RateWindow {
 
         let duration = resets_at - now;
         let hours = duration.num_hours();
-        let minutes = duration.num_minutes() % 60;
+        let total_minutes = ((duration.num_seconds() + 59) / 60).max(1);
+        let minutes = total_minutes % 60;
 
         if hours > 24 {
             let days = hours / 24;
@@ -83,6 +84,14 @@ impl RateWindow {
             Some(format!("{}h {}m", hours, minutes))
         } else {
             Some(format!("{}m", minutes))
+        }
+    }
+
+    fn finite_percent(value: f64) -> f64 {
+        if value.is_finite() {
+            value.clamp(0.0, 100.0)
+        } else {
+            0.0
         }
     }
 }
@@ -116,5 +125,17 @@ mod tests {
     fn test_exhausted() {
         assert!(RateWindow::new(100.0).is_exhausted());
         assert!(!RateWindow::new(99.0).is_exhausted());
+    }
+
+    #[test]
+    fn countdown_uses_one_minute_for_sub_minute_future_reset() {
+        let window = RateWindow::with_details(
+            10.0,
+            None,
+            Some(Utc::now() + chrono::Duration::seconds(30)),
+            None,
+        );
+
+        assert_eq!(window.format_countdown().as_deref(), Some("1m"));
     }
 }

--- a/rust/src/core/usage_snapshot.rs
+++ b/rust/src/core/usage_snapshot.rs
@@ -200,7 +200,7 @@ impl CostSnapshot {
     /// Create a new cost snapshot
     pub fn new(used: f64, currency_code: impl Into<String>, period: impl Into<String>) -> Self {
         Self {
-            used,
+            used: finite_amount(used).unwrap_or(0.0),
             limit: None,
             currency_code: currency_code.into(),
             period: period.into(),
@@ -211,7 +211,7 @@ impl CostSnapshot {
 
     /// Builder pattern: set limit
     pub fn with_limit(mut self, limit: f64) -> Self {
-        self.limit = Some(limit);
+        self.limit = finite_amount(limit);
         self
     }
 
@@ -250,12 +250,17 @@ impl CostSnapshot {
 
 /// Format a value as currency
 fn format_currency(value: f64, currency_code: &str) -> String {
+    let value = finite_amount(value).unwrap_or(0.0);
     match currency_code.to_uppercase().as_str() {
         "USD" => format!("${:.2}", value),
         "EUR" => format!("€{:.2}", value),
         "GBP" => format!("£{:.2}", value),
         _ => format!("{:.2} {}", value, currency_code),
     }
+}
+
+fn finite_amount(value: f64) -> Option<f64> {
+    value.is_finite().then_some(value.max(0.0))
 }
 
 /// Combined fetch result containing usage and optional cost data
@@ -286,5 +291,20 @@ impl ProviderFetchResult {
     pub fn with_cost(mut self, cost: CostSnapshot) -> Self {
         self.cost = Some(cost);
         self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cost_snapshot_ignores_non_finite_values() {
+        let cost = CostSnapshot::new(f64::NAN, "USD", "Monthly").with_limit(f64::INFINITY);
+
+        assert_eq!(cost.used, 0.0);
+        assert_eq!(cost.limit, None);
+        assert_eq!(cost.used_percent(), None);
+        assert_eq!(cost.format_used(), "$0.00");
     }
 }

--- a/rust/src/providers/amp/mod.rs
+++ b/rust/src/providers/amp/mod.rs
@@ -28,7 +28,7 @@ impl AmpProvider {
                 supports_credits: true,
                 default_enabled: false,
                 is_primary: false,
-                dashboard_url: Some("https://sourcegraph.com/cody/manage"),
+                dashboard_url: Some("https://ampcode.com/settings/usage"),
                 status_page_url: Some("https://sourcegraphstatus.com"),
             },
         }
@@ -257,5 +257,18 @@ impl Provider for AmpProvider {
 
     fn supports_cli(&self) -> bool {
         true
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn dashboard_points_to_current_usage_page() {
+        assert_eq!(
+            AmpProvider::new().metadata().dashboard_url,
+            Some("https://ampcode.com/settings/usage")
+        );
     }
 }

--- a/rust/src/providers/claude/mod.rs
+++ b/rust/src/providers/claude/mod.rs
@@ -57,6 +57,24 @@ impl Default for ClaudeProvider {
     }
 }
 
+fn claude_plan_label(tier: &str) -> String {
+    let normalized = tier.to_lowercase();
+    if normalized.contains("claude_max_5x") || normalized.contains("claude_max_5") {
+        "Claude Max 5x".to_string()
+    } else if normalized.contains("claude_max_20x") || normalized.contains("claude_max_20") {
+        "Claude Max 20x".to_string()
+    } else {
+        match normalized.as_str() {
+            "free" => "Claude Free".to_string(),
+            "pro" | "claude_pro" => "Claude Pro".to_string(),
+            "max" => "Claude Max".to_string(),
+            "team" => "Claude Team".to_string(),
+            "enterprise" => "Claude Enterprise".to_string(),
+            _ => format!("Claude ({})", tier),
+        }
+    }
+}
+
 fn claude_usage_probe_dir() -> Result<std::path::PathBuf, ProviderError> {
     let base = dirs::data_local_dir()
         .or_else(dirs::home_dir)

--- a/rust/src/providers/claude/oauth/mod.rs
+++ b/rust/src/providers/claude/oauth/mod.rs
@@ -401,7 +401,7 @@ impl ClaudeOAuthFetcher {
 
         // Login method from rate limit tier or default
         if let Some(ref tier) = credentials.rate_limit_tier {
-            usage = usage.with_login_method(tier);
+            usage = usage.with_login_method(super::claude_plan_label(tier));
         } else {
             usage = usage.with_login_method("Claude (OAuth)");
         }

--- a/rust/src/providers/claude/web_api.rs
+++ b/rust/src/providers/claude/web_api.rs
@@ -358,7 +358,7 @@ impl ClaudeWebApiFetcher {
                 snapshot = snapshot.with_email(email.clone());
             }
             if let Some(ref tier) = acc.rate_limit_tier {
-                snapshot = snapshot.with_login_method(Self::tier_to_plan_name(tier));
+                snapshot = snapshot.with_login_method(super::claude_plan_label(tier));
             }
         }
 
@@ -594,14 +594,7 @@ impl ClaudeWebApiFetcher {
 
     /// Convert rate limit tier to plan name
     fn tier_to_plan_name(tier: &str) -> String {
-        match tier.to_lowercase().as_str() {
-            "free" => "Claude Free".to_string(),
-            "pro" | "claude_pro" => "Claude Pro".to_string(),
-            "max" | "claude_max_5" | "claude_max_20" => "Claude Max".to_string(),
-            "team" => "Claude Team".to_string(),
-            "enterprise" => "Claude Enterprise".to_string(),
-            _ => format!("Claude ({})", tier),
-        }
+        super::claude_plan_label(tier)
     }
 }
 
@@ -667,6 +660,18 @@ mod tests {
         let rate = ClaudeWebApiFetcher::new().to_rate_window(&window, Some(300));
 
         assert!((rate.used_percent - 23.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn labels_max_5x_and_20x_plans() {
+        assert_eq!(
+            ClaudeWebApiFetcher::tier_to_plan_name("default_claude_max_5x"),
+            "Claude Max 5x"
+        );
+        assert_eq!(
+            ClaudeWebApiFetcher::tier_to_plan_name("v2_default_claude_max_20x"),
+            "Claude Max 20x"
+        );
     }
 
     #[test]

--- a/rust/src/providers/devin/mod.rs
+++ b/rust/src/providers/devin/mod.rs
@@ -3,8 +3,8 @@ use reqwest::{Client, Url};
 use serde_json::Value;
 
 use crate::core::{
-    FetchContext, Provider, ProviderError, ProviderFetchResult, ProviderId, ProviderMetadata,
-    RateWindow, SourceMode, UsageSnapshot,
+    CostSnapshot, FetchContext, Provider, ProviderError, ProviderFetchResult, ProviderId,
+    ProviderMetadata, RateWindow, SourceMode, UsageSnapshot,
 };
 
 const CREDENTIAL_TARGET: &str = "codexbar-devin";
@@ -95,10 +95,7 @@ impl Provider for DevinProvider {
                 let value: Value = response.json().await.map_err(|e| {
                     ProviderError::Parse(format!("Failed to parse Devin quota: {e}"))
                 })?;
-                Ok(ProviderFetchResult::new(
-                    snapshot_from_quota(&value, &org),
-                    "api",
-                ))
+                Ok(fetch_result_from_quota(&value, &org))
             }
             SourceMode::Web | SourceMode::Cli => {
                 Err(ProviderError::UnsupportedSource(ctx.source_mode))
@@ -138,10 +135,18 @@ fn snapshot_from_quota(value: &Value, org: &str) -> UsageSnapshot {
     snapshot
 }
 
+fn fetch_result_from_quota(value: &Value, org: &str) -> ProviderFetchResult {
+    let mut result = ProviderFetchResult::new(snapshot_from_quota(value, org), "api");
+    if let Some(balance) = extra_usage_balance(value) {
+        result = result.with_cost(CostSnapshot::new(balance, "USD", "Extra usage balance"));
+    }
+    result
+}
+
 fn percent(value: &Value, keys: &[&str]) -> Option<f64> {
     for key in keys {
         if let Some(v) = value.get(*key).and_then(Value::as_f64) {
-            return Some(if v <= 1.0 { v * 100.0 } else { v });
+            return Some(if v < 1.0 { v * 100.0 } else { v });
         }
     }
     let used = ["used", "usage", "used_count", "usedCount", "consumed"]
@@ -156,6 +161,25 @@ fn percent(value: &Value, keys: &[&str]) -> Option<f64> {
     }
 }
 
+fn extra_usage_balance(value: &Value) -> Option<f64> {
+    let dollars = [
+        "overage_balance",
+        "overageBalance",
+        "extra_usage_balance",
+        "extraUsageBalance",
+    ]
+    .iter()
+    .find_map(|key| value.get(*key).and_then(Value::as_f64))
+    .filter(|value| value.is_finite() && *value >= 0.0);
+    dollars.or_else(|| {
+        ["overage_balance_cents", "overageBalanceCents"]
+            .iter()
+            .find_map(|key| value.get(*key).and_then(Value::as_f64))
+            .filter(|value| value.is_finite() && *value >= 0.0)
+            .map(|cents| cents / 100.0)
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -165,5 +189,34 @@ mod tests {
         let snapshot =
             snapshot_from_quota(&serde_json::json!({"daily_percentage":0.25}), "org/demo");
         assert_eq!(snapshot.primary.used_percent, 25.0);
+    }
+
+    #[test]
+    fn parses_exact_one_as_one_percent() {
+        let snapshot =
+            snapshot_from_quota(&serde_json::json!({"daily_percentage":1.0}), "org/demo");
+        assert_eq!(snapshot.primary.used_percent, 1.0);
+    }
+
+    #[test]
+    fn parses_extra_usage_balance() {
+        let result = fetch_result_from_quota(
+            &serde_json::json!({"daily_percentage": 0.2, "overage_balance": 12.34}),
+            "org/demo",
+        );
+
+        let cost = result.cost.unwrap();
+        assert_eq!(cost.used, 12.34);
+        assert_eq!(cost.period, "Extra usage balance");
+    }
+
+    #[test]
+    fn parses_extra_usage_balance_cents() {
+        let result = fetch_result_from_quota(
+            &serde_json::json!({"daily_percentage": 0.2, "overage_balance_cents": 7087}),
+            "org/demo",
+        );
+
+        assert_eq!(result.cost.unwrap().used, 70.87);
     }
 }

--- a/rust/src/providers/kimi/mod.rs
+++ b/rust/src/providers/kimi/mod.rs
@@ -6,7 +6,7 @@
 
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
-use reqwest::Url;
+use reqwest::{Client, Url};
 use serde::Deserialize;
 
 use crate::browser::cookies::get_cookie_header;
@@ -15,8 +15,11 @@ use crate::core::{
     RateWindow, SourceMode, UsageSnapshot,
 };
 
-const KIMI_API_BASE: &str = "https://kimi.moonshot.cn";
-const KIMI_COOKIE_DOMAIN: &str = "kimi.moonshot.cn";
+const KIMI_WEB_USAGE_URL: &str =
+    "https://www.kimi.com/apiv2/kimi.gateway.billing.v1.BillingService/GetUsages";
+const KIMI_SUBSCRIPTION_STATS_URL: &str =
+    "https://www.kimi.com/apiv2/kimi.gateway.membership.v2.MembershipService/GetSubscriptionStats";
+const KIMI_COOKIE_DOMAINS: [&str; 2] = ["www.kimi.com", "kimi.moonshot.cn"];
 const KIMI_CODE_API_BASE: &str = "https://api.kimi.com";
 const KIMI_CODE_API_KEY_ENV: &str = "KIMI_CODE_API_KEY";
 const KIMI_CODE_BASE_URL_ENV: &str = "KIMI_CODE_BASE_URL";
@@ -26,6 +29,41 @@ struct KimiCodeApiUsageResponse {
     usage: KimiUsageDetail,
     #[serde(default)]
     limits: Option<Vec<KimiRateLimit>>,
+}
+
+#[derive(Debug, Deserialize)]
+struct KimiWebUsageResponse {
+    usages: Vec<KimiUsage>,
+}
+
+#[derive(Debug, Deserialize)]
+struct KimiUsage {
+    scope: String,
+    detail: KimiUsageDetail,
+    #[serde(default)]
+    limits: Option<Vec<KimiRateLimit>>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct KimiSubscriptionStatsResponse {
+    subscription_balance: Option<KimiSubscriptionBalance>,
+    ratelimit_code7d: Option<KimiSubscriptionRateLimit>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct KimiSubscriptionBalance {
+    amount_used_ratio: Option<serde_json::Value>,
+    expire_time: Option<serde_json::Value>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct KimiSubscriptionRateLimit {
+    ratio: Option<serde_json::Value>,
+    enabled: Option<bool>,
+    reset_time: Option<serde_json::Value>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -84,37 +122,29 @@ impl KimiProvider {
 
     /// Extract JWT token from kimi-auth cookie
     fn get_auth_token(&self) -> Result<String, ProviderError> {
-        // Try to get cookies from browser
-        let cookies = get_cookie_header(KIMI_COOKIE_DOMAIN)
-            .map_err(|e| ProviderError::Other(format!("Failed to get cookies: {}", e)))?;
-
+        let mut cookies = String::new();
+        let mut last_error = None;
+        for domain in KIMI_COOKIE_DOMAINS {
+            match get_cookie_header(domain) {
+                Ok(header) if !header.is_empty() => {
+                    cookies = header;
+                    break;
+                }
+                Ok(_) => {}
+                Err(e) => last_error = Some(e),
+            }
+        }
         if cookies.is_empty() {
+            if let Some(e) = last_error {
+                return Err(ProviderError::Other(format!(
+                    "Failed to get cookies: {}",
+                    e
+                )));
+            }
             return Err(ProviderError::AuthRequired);
         }
 
-        // Look for the kimi-auth or authorization cookie
-        for cookie in cookies.split(';') {
-            let cookie = cookie.trim();
-            if cookie.starts_with("kimi-auth=") || cookie.starts_with("authorization=") {
-                let token = cookie.split('=').nth(1).unwrap_or("");
-                if !token.is_empty() {
-                    return Ok(token.to_string());
-                }
-            }
-        }
-
-        // Also check for access_token cookie
-        for cookie in cookies.split(';') {
-            let cookie = cookie.trim();
-            if cookie.starts_with("access_token=") {
-                let token = cookie.split('=').nth(1).unwrap_or("");
-                if !token.is_empty() {
-                    return Ok(token.to_string());
-                }
-            }
-        }
-
-        Err(ProviderError::AuthRequired)
+        Self::auth_token_from_cookie_header(&cookies)
     }
 
     fn auth_token_from_cookie_header(cookie_header: &str) -> Result<String, ProviderError> {
@@ -150,18 +180,13 @@ impl KimiProvider {
             .build()
             .map_err(|e| ProviderError::Other(e.to_string()))?;
 
-        // Fetch user profile/quota info
-        let resp = client
-            .get(format!("{}/api/user", KIMI_API_BASE))
-            .header("Authorization", format!("Bearer {}", token))
-            .header("Cookie", format!("kimi-auth={}", token))
-            .header("Accept", "application/json")
-            .header(
-                "User-Agent",
-                "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36",
-            )
-            .send()
-            .await?;
+        let resp = kimi_web_post(
+            &client,
+            KIMI_WEB_USAGE_URL,
+            &token,
+            serde_json::json!({ "scope": ["FEATURE_CODING"] }),
+        )
+        .await?;
 
         if !resp.status().is_success() {
             let status = resp.status();
@@ -171,12 +196,24 @@ impl KimiProvider {
             return Err(ProviderError::Other(format!("API error: {}", status)));
         }
 
-        let json: serde_json::Value = resp
+        let usage: KimiWebUsageResponse = resp
             .json()
             .await
             .map_err(|e| ProviderError::Parse(e.to_string()))?;
 
-        self.parse_usage_response(&json)
+        let subscription = match kimi_web_post(
+            &client,
+            KIMI_SUBSCRIPTION_STATS_URL,
+            &token,
+            serde_json::json!({}),
+        )
+        .await
+        {
+            Ok(response) if response.status().is_success() => response.json().await.ok(),
+            _ => None,
+        };
+
+        Self::snapshot_from_web_usage_response(usage, subscription)
     }
 
     async fn fetch_via_code_api(
@@ -258,6 +295,61 @@ impl KimiProvider {
             let window_minutes = limit.window.as_ref().and_then(kimi_window_minutes);
             let rate_limit = Self::rate_window_from_usage_detail(&limit.detail, window_minutes)?;
             usage = usage.with_secondary(rate_limit);
+        }
+
+        Ok(usage)
+    }
+
+    fn snapshot_from_web_usage_response(
+        response: KimiWebUsageResponse,
+        subscription: Option<KimiSubscriptionStatsResponse>,
+    ) -> Result<UsageSnapshot, ProviderError> {
+        let coding = response
+            .usages
+            .into_iter()
+            .find(|usage| usage.scope == "FEATURE_CODING")
+            .ok_or_else(|| ProviderError::Parse("Kimi FEATURE_CODING usage missing".into()))?;
+        let primary = Self::rate_window_from_usage_detail(&coding.detail, Some(10080))?;
+        let mut usage = UsageSnapshot::new(primary).with_login_method("Kimi");
+
+        if let Some(limit) = coding.limits.unwrap_or_default().into_iter().next() {
+            let window_minutes = limit.window.as_ref().and_then(kimi_window_minutes);
+            let rate_limit = Self::rate_window_from_usage_detail(&limit.detail, window_minutes)?;
+            usage = usage.with_secondary(rate_limit);
+        }
+
+        if let Some(subscription) = subscription {
+            if let Some(balance) = subscription.subscription_balance
+                && let Some(ratio) =
+                    value_as_f64(balance.amount_used_ratio.as_ref()).filter(|v| v.is_finite())
+            {
+                usage = usage.with_extra_rate_window(
+                    "kimi-monthly",
+                    "Monthly",
+                    RateWindow::with_details(
+                        ratio * 100.0,
+                        None,
+                        balance.expire_time.as_ref().and_then(parse_kimi_timestamp),
+                        None,
+                    ),
+                );
+            }
+
+            if let Some(limit) = subscription.ratelimit_code7d
+                && limit.enabled.unwrap_or(true)
+                && let Some(ratio) = value_as_f64(limit.ratio.as_ref()).filter(|v| v.is_finite())
+            {
+                usage = usage.with_extra_rate_window(
+                    "kimi-code-7d",
+                    "Code 7-day",
+                    RateWindow::with_details(
+                        ratio * 100.0,
+                        Some(10080),
+                        limit.reset_time.as_ref().and_then(parse_kimi_timestamp),
+                        None,
+                    ),
+                );
+            }
         }
 
         Ok(usage)
@@ -481,6 +573,28 @@ fn kimi_window_minutes(window: &KimiWindow) -> Option<u32> {
     }
 }
 
+async fn kimi_web_post(
+    client: &Client,
+    url: &str,
+    token: &str,
+    body: serde_json::Value,
+) -> Result<reqwest::Response, ProviderError> {
+    client
+        .post(url)
+        .bearer_auth(token)
+        .header("Cookie", format!("kimi-auth={token}"))
+        .header("Accept", "application/json")
+        .header("Content-Type", "application/json")
+        .header(
+            "User-Agent",
+            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36",
+        )
+        .json(&body)
+        .send()
+        .await
+        .map_err(ProviderError::from)
+}
+
 fn value_as_f64(value: Option<&serde_json::Value>) -> Option<f64> {
     match value? {
         serde_json::Value::Number(number) => number.as_f64(),
@@ -597,5 +711,56 @@ mod tests {
         let snapshot = KimiProvider::snapshot_from_code_api_response(response).unwrap();
         assert!((snapshot.primary.used_percent - 12.5).abs() < f64::EPSILON);
         assert!(snapshot.secondary.is_none());
+    }
+
+    #[test]
+    fn parses_web_usage_with_subscription_windows() {
+        let usage: KimiWebUsageResponse = serde_json::from_value(json!({
+            "usages": [{
+                "scope": "FEATURE_CODING",
+                "detail": { "limit": "2048", "used": "375", "resetTime": "2026-01-09T15:23:13Z" },
+                "limits": [{
+                    "window": { "duration": 300, "timeUnit": "TIME_UNIT_MINUTE" },
+                    "detail": { "limit": "100", "used": "25" }
+                }]
+            }]
+        }))
+        .unwrap();
+        let subscription: KimiSubscriptionStatsResponse = serde_json::from_value(json!({
+            "subscriptionBalance": {
+                "amountUsedRatio": 0.7716,
+                "expireTime": "2026-07-23T00:00:00Z"
+            },
+            "ratelimitCode7d": {
+                "ratio": 0.0946,
+                "enabled": true,
+                "resetTime": "2026-07-13T15:28:00Z"
+            }
+        }))
+        .unwrap();
+
+        let snapshot =
+            KimiProvider::snapshot_from_web_usage_response(usage, Some(subscription)).unwrap();
+
+        assert!((snapshot.primary.used_percent - 18.310546875).abs() < f64::EPSILON);
+        assert_eq!(
+            snapshot.secondary.as_ref().unwrap().window_minutes,
+            Some(300)
+        );
+        let monthly = snapshot
+            .extra_rate_windows
+            .iter()
+            .find(|window| window.id == "kimi-monthly")
+            .unwrap();
+        assert_eq!(monthly.title, "Monthly");
+        assert!((monthly.window.used_percent - 77.16).abs() < 0.0001);
+        let code_7d = snapshot
+            .extra_rate_windows
+            .iter()
+            .find(|window| window.id == "kimi-code-7d")
+            .unwrap();
+        assert_eq!(code_7d.title, "Code 7-day");
+        assert_eq!(code_7d.window.window_minutes, Some(10080));
+        assert!((code_7d.window.used_percent - 9.46).abs() < 0.0001);
     }
 }

--- a/rust/src/providers/kimi/mod.rs
+++ b/rust/src/providers/kimi/mod.rs
@@ -122,29 +122,40 @@ impl KimiProvider {
 
     /// Extract JWT token from kimi-auth cookie
     fn get_auth_token(&self) -> Result<String, ProviderError> {
-        let mut cookies = String::new();
+        let mut saw_cookie_header = false;
         let mut last_error = None;
         for domain in KIMI_COOKIE_DOMAINS {
             match get_cookie_header(domain) {
                 Ok(header) if !header.is_empty() => {
-                    cookies = header;
-                    break;
+                    saw_cookie_header = true;
+                    if let Ok(token) = Self::auth_token_from_cookie_header(&header) {
+                        return Ok(token);
+                    }
                 }
                 Ok(_) => {}
                 Err(e) => last_error = Some(e),
             }
         }
-        if cookies.is_empty() {
-            if let Some(e) = last_error {
-                return Err(ProviderError::Other(format!(
-                    "Failed to get cookies: {}",
-                    e
-                )));
-            }
-            return Err(ProviderError::AuthRequired);
+
+        if !saw_cookie_header && let Some(e) = last_error {
+            return Err(ProviderError::Other(format!(
+                "Failed to get cookies: {}",
+                e
+            )));
         }
 
-        Self::auth_token_from_cookie_header(&cookies)
+        Err(ProviderError::AuthRequired)
+    }
+
+    fn auth_token_from_cookie_headers(
+        headers: impl IntoIterator<Item = impl AsRef<str>>,
+    ) -> Result<String, ProviderError> {
+        for header in headers {
+            if let Ok(token) = Self::auth_token_from_cookie_header(header.as_ref()) {
+                return Ok(token);
+            }
+        }
+        Err(ProviderError::AuthRequired)
     }
 
     fn auth_token_from_cookie_header(cookie_header: &str) -> Result<String, ProviderError> {
@@ -667,6 +678,17 @@ mod tests {
                 .as_str(),
             "https://proxy.example/kimi/coding/v1/usages"
         );
+    }
+
+    #[test]
+    fn auth_token_search_skips_unrelated_cookie_headers() {
+        let token = KimiProvider::auth_token_from_cookie_headers([
+            "locale=en-US; device_id=abc",
+            "kimi-auth=valid-token",
+        ])
+        .unwrap();
+
+        assert_eq!(token, "valid-token");
     }
 
     #[test]

--- a/rust/src/providers/kimik2/mod.rs
+++ b/rust/src/providers/kimik2/mod.rs
@@ -164,21 +164,21 @@ impl KimiK2Provider {
         let available_balance = data
             .get("available_balance")
             .or_else(|| data.get("balance"))
-            .and_then(|v| v.as_f64())
+            .and_then(finite_json_f64)
             .unwrap_or(0.0);
 
         // Total credits (used + available)
         let total_credits = data
             .get("total_balance")
             .or_else(|| data.get("total"))
-            .and_then(|v| v.as_f64())
+            .and_then(finite_json_f64)
             .unwrap_or(available_balance.max(0.0));
 
         // Used credits
         let used_credits = data
             .get("used_balance")
             .or_else(|| data.get("used"))
-            .and_then(|v| v.as_f64())
+            .and_then(finite_json_f64)
             .unwrap_or(total_credits - available_balance);
 
         // Calculate percentage used
@@ -189,8 +189,8 @@ impl KimiK2Provider {
         };
 
         // Cash balance (if any)
-        let voucher_balance = data.get("voucher_balance").and_then(|v| v.as_f64());
-        let cash_balance = data.get("cash_balance").and_then(|v| v.as_f64());
+        let voucher_balance = data.get("voucher_balance").and_then(finite_json_f64);
+        let cash_balance = data.get("cash_balance").and_then(finite_json_f64);
 
         // Create primary rate window (credits used)
         let mut primary = RateWindow::new(used_percent);
@@ -201,6 +201,15 @@ impl KimiK2Provider {
             && cash < 0.0
         {
             login_method.push_str(&format!(" · ${:.2} in deficit", cash.abs()));
+        }
+
+        fn finite_json_f64(value: &serde_json::Value) -> Option<f64> {
+            match value {
+                serde_json::Value::Number(number) => number.as_f64(),
+                serde_json::Value::String(text) => text.trim().replace(',', "").parse().ok(),
+                _ => None,
+            }
+            .filter(|value: &f64| value.is_finite())
         }
 
         let mut usage = UsageSnapshot::new(primary).with_login_method(login_method);
@@ -300,5 +309,28 @@ mod tests {
             KimiK2Provider::api_bases_from_region(Some("china")),
             &[super::KIMIK2_API_BASE_CHINA]
         );
+    }
+
+    #[test]
+    fn parses_string_balances_and_ignores_non_finite_values() {
+        let usage = KimiK2Provider::new()
+            .parse_usage_response(&serde_json::json!({
+                "data": {
+                    "available_balance": "12.50",
+                    "total_balance": "50",
+                    "used_balance": "37.50",
+                    "voucher_balance": "Infinity",
+                    "cash_balance": "-5"
+                }
+            }))
+            .unwrap();
+
+        assert_eq!(
+            usage.primary.reset_description.as_deref(),
+            Some("Balance $12.50")
+        );
+        assert!((usage.primary.used_percent - 75.0).abs() < f64::EPSILON);
+        assert_eq!(usage.extra_rate_windows.len(), 1);
+        assert_eq!(usage.extra_rate_windows[0].id, "cash");
     }
 }

--- a/rust/src/providers/mistral/mod.rs
+++ b/rust/src/providers/mistral/mod.rs
@@ -281,6 +281,9 @@ impl MistralProvider {
                 let metric = price.billing_metric?;
                 let group = price.billing_group?;
                 let value = price.price?.parse::<f64>().ok()?;
+                if !value.is_finite() {
+                    return None;
+                }
                 Some((format!("{metric}::{group}"), value))
             })
             .collect()
@@ -311,7 +314,11 @@ impl MistralProvider {
             let paid = entry.value_paid.or(entry.value).unwrap_or(0);
             tokens += paid;
             if let (Some(metric), Some(group)) = (&entry.billing_metric, &entry.billing_group) {
-                cost += (paid as f64) * prices.get(&format!("{metric}::{group}")).unwrap_or(&0.0);
+                let entry_cost =
+                    (paid as f64) * prices.get(&format!("{metric}::{group}")).unwrap_or(&0.0);
+                if entry_cost.is_finite() {
+                    cost += entry_cost;
+                }
             }
         }
         (tokens, cost)
@@ -434,5 +441,28 @@ mod tests {
             MistralProvider::csrf_from_cookie_header("foo=bar; csrftoken=abc123; ory_session=x"),
             Some("abc123")
         );
+    }
+
+    #[test]
+    fn ignores_non_finite_prices() {
+        let billing: BillingResponse = serde_json::from_value(serde_json::json!({
+            "prices": [
+                { "billing_metric": "mistral-large", "billing_group": "input", "price": "1e309" }
+            ],
+            "completion": {
+                "models": {
+                    "mistral-large": {
+                        "input": [
+                            { "billing_metric": "mistral-large", "billing_group": "input", "value": 1000 }
+                        ]
+                    }
+                }
+            }
+        }))
+        .unwrap();
+
+        let summary = MistralProvider::summarize_billing(billing);
+
+        assert_eq!(summary.total_cost, 0.0);
     }
 }

--- a/rust/src/providers/ollama/mod.rs
+++ b/rust/src/providers/ollama/mod.rs
@@ -158,7 +158,7 @@ impl OllamaProvider {
         match status {
             reqwest::StatusCode::OK => Self::parse_api_tags(&bytes),
             reqwest::StatusCode::UNAUTHORIZED | reqwest::StatusCode::FORBIDDEN => {
-                Err(ProviderError::AuthRequired)
+                Err(ollama_api_key_error())
             }
             _ => Err(ProviderError::Other(format!(
                 "Ollama API returned status {status}"
@@ -495,6 +495,10 @@ fn is_ollama_login_url(url: &Url) -> bool {
     path.contains("/login") || path.contains("/signin")
 }
 
+fn ollama_api_key_error() -> ProviderError {
+    ProviderError::Other("Ollama API key is invalid or revoked.".to_string())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -565,6 +569,14 @@ mod tests {
             Some("2 cloud models available")
         );
         assert_eq!(snapshot.login_method.as_deref(), Some("API key"));
+    }
+
+    #[test]
+    fn api_auth_error_names_invalid_or_revoked_key() {
+        assert_eq!(
+            ollama_api_key_error().to_string(),
+            "Ollama API key is invalid or revoked."
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Ported the scoped Windows/Rust-relevant pieces from upstream CodexBar v0.39.0-v0.41.0.
- Added `usage --brief` compact usage output and sub-1% percent formatting.
- Added shared finite percent/cost guards and minute-preserving reset countdowns.
- Updated focused provider behavior: Kimi web usage/subscription endpoints and windows, Kimi cookie fallback, KimiK2 finite/string balances, Mistral non-finite price guard, Devin exact 1% plus overage balance/cents, Ollama invalid/revoked API key wording, Amp usage URL, and Claude Max 5x/20x labels.

## Skipped / deferred
- macOS/site/workflow-only upstream changes.
- Broad UI/account/cache rewrites.
- Codex reset-credit inventory/cache/project-rollup parity that needs a larger data model.
- Claude multi-account/swap/history quarantine work.

## Validation
- `cargo fmt --all -- --check`
- `git --no-pager diff --check`
- `cargo test --manifest-path rust\Cargo.toml --lib --quiet` — 510 passed, 0 failed
- `cargo clippy --manifest-path rust\Cargo.toml --all-targets --quiet -- -D warnings`
- `cargo test --manifest-path apps\desktop-tauri\src-tauri\Cargo.toml --quiet` — 284 passed, 0 failed