### PR TITLE
Add repository interaction guard

### DIFF
--- a/.github/scripts/interaction-guard.mjs
+++ b/.github/scripts/interaction-guard.mjs
@@ -1,0 +1,112 @@
+const accountAgeDays = 30;
+const windowDays = 7;
+const limits = {
+  issue: { count: 10, label: "issues" },
+  pull_request: { count: 4, label: "pull requests" },
+};
+
+export function evaluateInteraction({ kind, userCreatedAt, now, recentCount }) {
+  const created = Date.parse(userCreatedAt);
+  const current = Date.parse(now);
+  if (!Number.isFinite(created) || !Number.isFinite(current)) {
+    return { allowed: false, reason: "Unable to verify account age." };
+  }
+
+  const ageDays = Math.floor((current - created) / 86_400_000);
+  if (ageDays < accountAgeDays) {
+    return {
+      allowed: false,
+      reason: `Your GitHub account must be at least ${accountAgeDays} days old to open issues or pull requests in this repository.`,
+    };
+  }
+
+  const limit = limits[kind];
+  if (!limit) {
+    return { allowed: true };
+  }
+
+  if (recentCount > limit.count) {
+    return {
+      allowed: false,
+      reason: `This repository allows each user to open at most ${limit.count} ${limit.label} per ${windowDays} days.`,
+    };
+  }
+
+  return { allowed: true };
+}
+
+function eventTarget(payload) {
+  if (payload.pull_request) {
+    return {
+      kind: "pull_request",
+      number: payload.pull_request.number,
+      author: payload.pull_request.user.login,
+    };
+  }
+  if (payload.issue && !payload.issue.pull_request) {
+    return {
+      kind: "issue",
+      number: payload.issue.number,
+      author: payload.issue.user.login,
+    };
+  }
+  return null;
+}
+
+function sinceDate(now) {
+  const since = new Date(now);
+  since.setUTCDate(since.getUTCDate() - windowDays);
+  return since.toISOString().slice(0, 10);
+}
+
+async function github(path, options = {}) {
+  const response = await fetch(`https://api.github.com${path}`, {
+    ...options,
+    headers: {
+      accept: "application/vnd.github+json",
+      authorization: `Bearer ${process.env.GITHUB_TOKEN}`,
+      "x-github-api-version": "2022-11-28",
+      ...options.headers,
+    },
+  });
+  if (!response.ok) {
+    throw new Error(`${options.method ?? "GET"} ${path} failed: ${response.status} ${await response.text()}`);
+  }
+  return response.status === 204 ? null : response.json();
+}
+
+async function main() {
+  const fs = await import("node:fs/promises");
+  const payload = JSON.parse(await fs.readFile(process.env.GITHUB_EVENT_PATH, "utf8"));
+  const target = eventTarget(payload);
+  if (!target) return;
+
+  const repo = process.env.GITHUB_REPOSITORY;
+  const now = new Date().toISOString();
+  const user = await github(`/users/${target.author}`);
+  const type = target.kind === "pull_request" ? "pr" : "issue";
+  const query = encodeURIComponent(`repo:${repo} author:${target.author} type:${type} created:>=${sinceDate(now)}`);
+  const recent = await github(`/search/issues?q=${query}&per_page=1`);
+  const result = evaluateInteraction({
+    kind: target.kind,
+    userCreatedAt: user.created_at,
+    now,
+    recentCount: recent.total_count,
+  });
+
+  if (result.allowed) return;
+
+  const body = `${result.reason}\n\nClosing this automatically.`;
+  await github(`/repos/${repo}/issues/${target.number}/comments`, {
+    method: "POST",
+    body: JSON.stringify({ body }),
+  });
+  await github(`/repos/${repo}/issues/${target.number}`, {
+    method: "PATCH",
+    body: JSON.stringify({ state: "closed", state_reason: "not_planned" }),
+  });
+}
+
+if (import.meta.url === `file://${process.argv[1].replaceAll("\\", "/")}`) {
+  await main();
+}

--- a/.github/scripts/interaction-guard.test.mjs
+++ b/.github/scripts/interaction-guard.test.mjs
@@ -1,0 +1,57 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { evaluateInteraction } from "./interaction-guard.mjs";
+
+const now = "2026-07-08T00:00:00.000Z";
+
+test("blocks accounts younger than 30 days", () => {
+  const result = evaluateInteraction({
+    kind: "issue",
+    author: "new-user",
+    userCreatedAt: "2026-06-20T00:00:00.000Z",
+    now,
+    recentCount: 1,
+  });
+
+  assert.equal(result.allowed, false);
+  assert.match(result.reason, /at least 30 days old/);
+});
+
+test("allows old accounts under the weekly issue limit", () => {
+  const result = evaluateInteraction({
+    kind: "issue",
+    author: "steady-user",
+    userCreatedAt: "2026-05-01T00:00:00.000Z",
+    now,
+    recentCount: 10,
+  });
+
+  assert.equal(result.allowed, true);
+});
+
+test("blocks the 11th issue in 7 days", () => {
+  const result = evaluateInteraction({
+    kind: "issue",
+    author: "spammy-user",
+    userCreatedAt: "2026-05-01T00:00:00.000Z",
+    now,
+    recentCount: 11,
+  });
+
+  assert.equal(result.allowed, false);
+  assert.match(result.reason, /10 issues per 7 days/);
+});
+
+test("blocks the 5th pull request in 7 days", () => {
+  const result = evaluateInteraction({
+    kind: "pull_request",
+    author: "spammy-user",
+    userCreatedAt: "2026-05-01T00:00:00.000Z",
+    now,
+    recentCount: 5,
+  });
+
+  assert.equal(result.allowed, false);
+  assert.match(result.reason, /4 pull requests per 7 days/);
+});

--- a/.github/workflows/interaction-guard.yml
+++ b/.github/workflows/interaction-guard.yml
@@ -1,0 +1,21 @@
+name: Interaction guard
+
+on:
+  issues:
+    types: [opened, reopened]
+  pull_request_target:
+    types: [opened, reopened]
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  guard:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: node .github/scripts/interaction-guard.mjs
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Add a GitHub Actions guard for opened/reopened issues and PRs.
- Close interactions from accounts younger than 30 days.
- Close interactions exceeding 10 issues or 4 PRs per user in 7 days.

## Checks
- node --test .github\\scripts\\interaction-guard.test.mjs
- node --check .github\\scripts\\interaction-guard.mjs
- git diff --check