### PR TITLE
Add masonry tray card layout

### DIFF
--- a/apps/desktop-tauri/src/styles.css
+++ b/apps/desktop-tauri/src/styles.css
@@ -1097,28 +1097,26 @@ body:has(.tray-panel-reveal) {
 }
 
 /* Side-by-side provider cards once the user has widened the flyout enough to
-   fit two columns — mirrors the PopOut window's `.menu-surface--popout
-   .menu-stack` row layout (styles.css ~3223), but scoped to the tray's
-   usersized state only so the auto-fit (content-hugging) path never sees it.
-   Unlike PopOut, tray cards KEEP their visual chrome (background/border on
-   `.menu-stack__item--selected`, card padding, etc.) — only the separators
-   between stacked cards are hidden, since they read as noise once cards sit
-   side by side instead of one on top of the other. */
+   fit two columns. The columns are independent so a tall card in one column
+   doesn't force empty space under the shorter card beside it. */
 @media (min-width: 640px) {
   .tray-panel-reveal--usersized .menu-surface--tray .menu-stack {
     display: flex;
     flex-direction: row;
-    flex-wrap: wrap;
     align-content: flex-start;
     align-items: flex-start;
     gap: 12px 16px;
     width: 100%;
   }
-  .tray-panel-reveal--usersized .menu-surface--tray .menu-stack__item {
+
+  .tray-panel-reveal--usersized .menu-surface--tray .menu-stack__column {
     flex: 1 1 0;
     min-width: min(300px, 100%);
-    width: auto;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
   }
+
   .tray-panel-reveal--usersized .menu-surface--tray .menu-stack__sep {
     display: none;
   }

--- a/apps/desktop-tauri/src/surfaces/TrayPanel.test.tsx
+++ b/apps/desktop-tauri/src/surfaces/TrayPanel.test.tsx
@@ -1,5 +1,5 @@
 import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const tauriMocks = vi.hoisted(() => ({
   getCachedProviders: vi.fn(),
@@ -181,6 +181,7 @@ describe("TrayPanel provider grid", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     eventMocks.listeners.clear();
+    tauriMocks.flyoutStoredSize.mockResolvedValue(null);
     tauriMocks.refreshProviders.mockResolvedValue(undefined);
     tauriMocks.refreshProvidersIfStale.mockResolvedValue(undefined);
     tauriMocks.dismissTrayPanel.mockResolvedValue(undefined);
@@ -237,6 +238,9 @@ describe("TrayPanel provider grid", () => {
         return Promise.resolve(() => {});
       },
     );
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
   });
 
   it("reveals regardless of the shared surface-mode snapshot (TrayPanel now runs in its own dedicated window)", async () => {
@@ -484,6 +488,37 @@ describe("TrayPanel provider grid", () => {
         (node) => node.textContent,
       ),
     ).toEqual(["Codex", "Claude", "Cursor", "Factory", "Gemini"]);
+  });
+
+  it("uses independent columns for a wide user-sized overview", async () => {
+    vi.spyOn(window, "innerWidth", "get").mockReturnValue(700);
+    tauriMocks.flyoutStoredSize.mockResolvedValue([700, 700]);
+    const providers = [
+      provider("codex", "Codex"),
+      provider("claude", "Claude"),
+      provider("antigravity", "Antigravity"),
+      provider("copilot", "GitHub Copilot"),
+    ];
+
+    const { container } = renderTrayPanel(providers, {
+      enabledProviders: providers.map((snapshot) => snapshot.providerId),
+    });
+
+    await waitFor(() => {
+      expect(container.querySelector(".tray-panel-reveal--usersized")).not.toBeNull();
+    });
+
+    expect(
+      Array.from(container.querySelectorAll(".menu-stack__column")).map((column) =>
+        Array.from(column.querySelectorAll(".menu-stack__item")).map(
+          (item) => item.id,
+        ),
+      ),
+    ).toEqual([
+      ["card-codex", "card-antigravity"],
+      ["card-claude", "card-copilot"],
+    ]);
+    expect(container.querySelector(".menu-stack__sep")).toBeNull();
   });
 
   it("collapses and expands the full provider catalog in the dense tray grid", async () => {

--- a/apps/desktop-tauri/src/surfaces/TrayPanel.test.tsx
+++ b/apps/desktop-tauri/src/surfaces/TrayPanel.test.tsx
@@ -491,7 +491,6 @@ describe("TrayPanel provider grid", () => {
   });
 
   it("uses independent columns for a wide user-sized overview", async () => {
-    vi.spyOn(window, "innerWidth", "get").mockReturnValue(700);
     tauriMocks.flyoutStoredSize.mockResolvedValue([700, 700]);
     const providers = [
       provider("codex", "Codex"),
@@ -519,6 +518,28 @@ describe("TrayPanel provider grid", () => {
       ["card-claude", "card-copilot"],
     ]);
     expect(container.querySelector(".menu-stack__sep")).toBeNull();
+  });
+
+  it("keeps the stacked layout when the saved flyout width is narrow", async () => {
+    vi.spyOn(window, "innerWidth", "get").mockReturnValue(700);
+    tauriMocks.flyoutStoredSize.mockResolvedValue([500, 700]);
+    const providers = [
+      provider("codex", "Codex"),
+      provider("claude", "Claude"),
+      provider("antigravity", "Antigravity"),
+      provider("copilot", "GitHub Copilot"),
+    ];
+
+    const { container } = renderTrayPanel(providers, {
+      enabledProviders: providers.map((snapshot) => snapshot.providerId),
+    });
+
+    await waitFor(() => {
+      expect(container.querySelector(".tray-panel-reveal--usersized")).not.toBeNull();
+    });
+
+    expect(container.querySelector(".menu-stack__column")).toBeNull();
+    expect(container.querySelectorAll(".menu-stack__sep")).toHaveLength(3);
   });
 
   it("collapses and expands the full provider catalog in the dense tray grid", async () => {

--- a/apps/desktop-tauri/src/surfaces/TrayPanel.tsx
+++ b/apps/desktop-tauri/src/surfaces/TrayPanel.tsx
@@ -309,6 +309,21 @@ export default function TrayPanel({ state }: { state: BootstrapState }) {
   // reveal itself. Hardcoded true: being mounted IS "the flyout is open".
   const isFlyoutOpen = true;
   const fixedFlyoutSize = Array.isArray(flyoutSize) ? flyoutSize : null;
+  const [viewportWidth, setViewportWidth] = useState(() => window.innerWidth);
+  useEffect(() => {
+    const updateViewportWidth = () => setViewportWidth(window.innerWidth);
+    window.addEventListener("resize", updateViewportWidth);
+    return () => window.removeEventListener("resize", updateViewportWidth);
+  }, []);
+  const useWideColumns =
+    selectedProviderId === null && fixedFlyoutSize !== null && viewportWidth >= 640;
+  const wideColumns = useMemo(() => {
+    const columns: ProviderUsageSnapshot[][] = [[], []];
+    visibleProviders.forEach((provider, index) => {
+      columns[index % 2].push(provider);
+    });
+    return columns;
+  }, [visibleProviders]);
   const { layoutReady, requestLayout } = useTrayPanelLayout({
     canMeasure: hasLoadedCache || sorted.length > 0,
     denseOverview: expectsDenseOverview,
@@ -408,6 +423,26 @@ export default function TrayPanel({ state }: { state: BootstrapState }) {
     />
   );
   const revealClassName = `tray-panel-reveal${layoutReady ? " tray-panel-reveal--ready" : ""}${expectsDenseOverview ? " tray-panel-reveal--dense" : ""}${fixedFlyoutSize ? " tray-panel-reveal--usersized" : ""}`;
+  const renderProviderCard = (p: ProviderUsageSnapshot) => {
+    const isSelected =
+      selectedProviderId !== null && p.providerId === selectedProviderId;
+    return (
+      <div
+        className={`menu-stack__item${isSelected ? " menu-stack__item--selected" : ""}`}
+        id={`card-${p.providerId}`}
+        key={p.providerId}
+      >
+        <MenuCard
+          provider={p}
+          hideEmail={settings.hidePersonalInfo}
+          resetTimeRelative={settings.resetTimeRelative}
+          showAsUsed={settings.showAsUsed}
+          compactMetrics={selectedProviderId === null}
+          onLayoutChange={requestLayout}
+        />
+      </div>
+    );
+  };
 
   if (sorted.length === 0) {
     return (
@@ -458,28 +493,18 @@ export default function TrayPanel({ state }: { state: BootstrapState }) {
         />
         <div className="provider-grid__divider" />
         <div className="menu-stack">
-          {visibleProviders.map((p, idx) => {
-            const isSelected =
-              selectedProviderId !== null && p.providerId === selectedProviderId;
-            return (
-              <Fragment key={p.providerId}>
-                {idx > 0 && <div className="menu-stack__sep" />}
-                <div
-                  className={`menu-stack__item${isSelected ? " menu-stack__item--selected" : ""}`}
-                  id={`card-${p.providerId}`}
-                >
-                  <MenuCard
-                    provider={p}
-                    hideEmail={settings.hidePersonalInfo}
-                    resetTimeRelative={settings.resetTimeRelative}
-                    showAsUsed={settings.showAsUsed}
-                    compactMetrics={selectedProviderId === null}
-                    onLayoutChange={requestLayout}
-                  />
+          {useWideColumns
+            ? wideColumns.map((column, index) => (
+                <div className="menu-stack__column" key={index}>
+                  {column.map(renderProviderCard)}
                 </div>
-              </Fragment>
-            );
-          })}
+              ))
+            : visibleProviders.map((p, idx) => (
+                <Fragment key={p.providerId}>
+                  {idx > 0 && <div className="menu-stack__sep" />}
+                  {renderProviderCard(p)}
+                </Fragment>
+              ))}
         </div>
         {/* Context actions — detail mode only, matches macOS actionsSection */}
         {selectedProviderId && (HAS_DASHBOARD.has(selectedProviderId) || HAS_STATUS_PAGE.has(selectedProviderId)) && (

--- a/apps/desktop-tauri/src/surfaces/TrayPanel.tsx
+++ b/apps/desktop-tauri/src/surfaces/TrayPanel.tsx
@@ -309,14 +309,10 @@ export default function TrayPanel({ state }: { state: BootstrapState }) {
   // reveal itself. Hardcoded true: being mounted IS "the flyout is open".
   const isFlyoutOpen = true;
   const fixedFlyoutSize = Array.isArray(flyoutSize) ? flyoutSize : null;
-  const [viewportWidth, setViewportWidth] = useState(() => window.innerWidth);
-  useEffect(() => {
-    const updateViewportWidth = () => setViewportWidth(window.innerWidth);
-    window.addEventListener("resize", updateViewportWidth);
-    return () => window.removeEventListener("resize", updateViewportWidth);
-  }, []);
   const useWideColumns =
-    selectedProviderId === null && fixedFlyoutSize !== null && viewportWidth >= 640;
+    selectedProviderId === null &&
+    fixedFlyoutSize !== null &&
+    fixedFlyoutSize[0] >= 640;
   const wideColumns = useMemo(() => {
     const columns: ProviderUsageSnapshot[][] = [[], []];
     visibleProviders.forEach((provider, index) => {


### PR DESCRIPTION
﻿Closes #144

Summary:
- Split wide user-sized tray overview cards into two independent columns, preserving provider order by alternating cards between columns.
- Keep the default narrow/auto-fit tray layout unchanged.
- Add a focused TrayPanel test for the wide user-sized column layout.

Verification:
- `pnpm.cmd exec vitest run src\surfaces\TrayPanel.test.tsx -t "uses independent columns"`
- `pnpm.cmd run test`
- `pnpm.cmd run build`
