### PR TITLE
Add Antigravity agy alias

### DIFF
--- a/rust/src/cli/usage.rs
+++ b/rust/src/cli/usage.rs
@@ -9,7 +9,7 @@ use crate::core::{
 };
 use crate::status::{ProviderStatus as StatusInfo, StatusLevel, fetch_provider_status};
 
-pub const PROVIDER_ARG_HELP: &str = "Provider to query (for example: codex, claude, gemini, nanogpt, deepseek, codebuff, windsurf, all, both)";
+pub const PROVIDER_ARG_HELP: &str = "Provider to query (for example: codex, claude, gemini, antigravity/agy, nanogpt, deepseek, codebuff, windsurf, all, both)";
 
 /// Arguments for the usage command
 #[derive(Args, Debug, Default)]

--- a/rust/src/core/provider.rs
+++ b/rust/src/core/provider.rs
@@ -331,7 +331,7 @@ impl ProviderId {
             "cursor" => Some(ProviderId::Cursor),
             "factory" | "droid" => Some(ProviderId::Factory),
             "gemini" | "google" => Some(ProviderId::Gemini),
-            "antigravity" => Some(ProviderId::Antigravity),
+            "antigravity" | "agy" => Some(ProviderId::Antigravity),
             "copilot" | "github" => Some(ProviderId::Copilot),
             "zai" | "z.ai" => Some(ProviderId::Zai),
             "minimax" => Some(ProviderId::MiniMax),
@@ -568,6 +568,7 @@ pub fn cli_name_map() -> HashMap<&'static str, ProviderId> {
     map.insert("ds", ProviderId::DeepSeek);
     map.insert("codeium", ProviderId::Windsurf);
     map.insert("google", ProviderId::Gemini);
+    map.insert("agy", ProviderId::Antigravity);
     map.insert("github", ProviderId::Copilot);
     map.insert("aws", ProviderId::Kiro);
     map.insert("vertex", ProviderId::VertexAI);
@@ -690,6 +691,10 @@ mod tests {
             ProviderId::from_cli_name("factory"),
             Some(ProviderId::Factory)
         );
+        assert_eq!(
+            ProviderId::from_cli_name("agy"),
+            Some(ProviderId::Antigravity)
+        );
         assert_eq!(ProviderId::from_cli_name("zed"), Some(ProviderId::Zed));
         assert_eq!(ProviderId::from_cli_name("unknown"), None);
     }
@@ -740,6 +745,7 @@ mod tests {
         assert_eq!(map.get("anthropic"), Some(&ProviderId::Claude));
         assert_eq!(map.get("codex"), Some(&ProviderId::Codex));
         assert_eq!(map.get("openai"), Some(&ProviderId::Codex));
+        assert_eq!(map.get("agy"), Some(&ProviderId::Antigravity));
     }
 
     #[test]

--- a/rust/src/providers/antigravity/mod.rs
+++ b/rust/src/providers/antigravity/mod.rs
@@ -16,6 +16,9 @@ use crate::core::{
     RateWindow, SourceMode, UsageSnapshot,
 };
 
+const NOT_RUNNING_MESSAGE: &str =
+    "Antigravity language server not running. Start Google Antigravity and sign in, then retry.";
+
 /// Antigravity provider
 pub struct AntigravityProvider {
     metadata: ProviderMetadata,
@@ -113,9 +116,7 @@ impl AntigravityProvider {
             }
         }
 
-        Err(ProviderError::NotInstalled(
-            "Antigravity language server not running".to_string(),
-        ))
+        Err(ProviderError::NotInstalled(NOT_RUNNING_MESSAGE.to_string()))
     }
 
     /// Find the actual API port by probing the language server's candidate ports.
@@ -776,5 +777,12 @@ mod tests {
                 .iter()
                 .any(|window| window.title == "Gemini 2.5 Flash Image")
         );
+    }
+
+    #[test]
+    fn not_running_error_tells_user_how_to_start() {
+        let error = ProviderError::NotInstalled(NOT_RUNNING_MESSAGE.to_string()).to_string();
+
+        assert!(error.contains("Start Google Antigravity and sign in"));
     }
 }


### PR DESCRIPTION
Fixes #141.

## Summary
- Add `agy` as an Antigravity provider alias in the shared provider parser and CLI alias map.
- Clarify the Antigravity not-running message with setup guidance to start Google Antigravity and sign in.
- Add Antigravity/agy to the usage provider help examples.

## Verification
- `cargo fmt --manifest-path rust\Cargo.toml --all`
- `cargo test --manifest-path rust\Cargo.toml` (518 lib tests, 1 bin test, doc tests passed)
- `cargo run --manifest-path rust\Cargo.toml -- usage -p agy --json` (accepted alias and returned Antigravity setup guidance)
- `cargo clippy --manifest-path rust\Cargo.toml --all-targets -- -D warnings`

## Note
- `cargo test --manifest-path apps\desktop-tauri\src-tauri\Cargo.toml` did not complete because local MSVC `link.exe` failed with exit code `0xc0000142` while compiling dependencies before project tests ran.