### PR TITLE
Add agy alias for Antigravity provider

### DIFF
--- a/rust/src/core/provider.rs
+++ b/rust/src/core/provider.rs
@@ -331,7 +331,7 @@ impl ProviderId {
             "cursor" => Some(ProviderId::Cursor),
             "factory" | "droid" => Some(ProviderId::Factory),
             "gemini" | "google" => Some(ProviderId::Gemini),
-            "antigravity" => Some(ProviderId::Antigravity),
+            "antigravity" | "agy" => Some(ProviderId::Antigravity),
             "copilot" | "github" => Some(ProviderId::Copilot),
             "zai" | "z.ai" => Some(ProviderId::Zai),
             "minimax" => Some(ProviderId::MiniMax),
@@ -568,6 +568,7 @@ pub fn cli_name_map() -> HashMap<&'static str, ProviderId> {
     map.insert("ds", ProviderId::DeepSeek);
     map.insert("codeium", ProviderId::Windsurf);
     map.insert("google", ProviderId::Gemini);
+    map.insert("agy", ProviderId::Antigravity);
     map.insert("github", ProviderId::Copilot);
     map.insert("aws", ProviderId::Kiro);
     map.insert("vertex", ProviderId::VertexAI);
@@ -687,6 +688,10 @@ mod tests {
         assert_eq!(ProviderId::from_cli_name("codex"), Some(ProviderId::Codex));
         assert_eq!(ProviderId::from_cli_name("openai"), Some(ProviderId::Codex));
         assert_eq!(
+            ProviderId::from_cli_name("agy"),
+            Some(ProviderId::Antigravity)
+        );
+        assert_eq!(
             ProviderId::from_cli_name("factory"),
             Some(ProviderId::Factory)
         );
@@ -740,6 +745,7 @@ mod tests {
         assert_eq!(map.get("anthropic"), Some(&ProviderId::Claude));
         assert_eq!(map.get("codex"), Some(&ProviderId::Codex));
         assert_eq!(map.get("openai"), Some(&ProviderId::Codex));
+        assert_eq!(map.get("agy"), Some(&ProviderId::Antigravity));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Adds `agy` as a CLI alias for the existing Antigravity provider.

This lets commands such as the following resolve to `ProviderId::Antigravity`:

```bash
codexbar-cli usage -p agy
codexbar-cli config enable agy
```

## Related issue

Refs #141

## Affected areas

- [ ] Tray panel
- [ ] Settings UI
- [ ] Config file / settings persistence
- [x] CLI
- [x] Provider-specific behavior
- [ ] Installer / release packaging
- [ ] Startup / background behavior
- [ ] Documentation
- [ ] Other:

## Validation

- [ ] `powershell.exe -ExecutionPolicy Bypass -NoProfile -File scripts\local-check.ps1` - not run; this PR is limited to provider alias parsing and targeted Rust tests were used instead.
- [ ] For full pre-release validation: `powershell.exe -ExecutionPolicy Bypass -NoProfile -File scripts\local-check.ps1 -All -Version <version>` - not applicable.
- [ ] For installer/release changes: `powershell.exe -File scripts\windows-release-build.ps1 -Ref <ref> -SmokeInstall` - not applicable.
- [ ] Thermo-nuclear code quality review completed before submitting: https://github.com/cursor/plugins/blob/main/cursor-team-kit/skills/thermo-nuclear-code-quality-review/SKILL.md - not run; single-file alias change.
- [x] Other:

```powershell
cargo test --manifest-path rust/Cargo.toml test_provider_id_from_cli_name
cargo test --manifest-path rust/Cargo.toml test_cli_name_map
cargo fmt --manifest-path rust/Cargo.toml --check
```

## UI / tray proof

- [x] Not applicable
- [ ] CUA Driver visual proof attached
- [ ] CUA Driver could not be used; equivalent manual proof and explanation attached

## Notes for reviewers

This intentionally covers only the `agy` alias portion of #141. Setup guidance/error wording can be handled separately if desired.