### PR TITLE
Test TypeScript 7 upgrade

### DIFF
--- a/apps/desktop-tauri/package.json
+++ b/apps/desktop-tauri/package.json
@@ -28,9 +28,10 @@
     "@testing-library/react": "16.1.0",
     "@types/react": "18.3.12",
     "@types/react-dom": "18.3.1",
+    "@typescript/typescript-win32-x64": "7.0.2",
     "@vitejs/plugin-react": "4.7.0",
     "jsdom": "25.0.1",
-    "typescript": "5.6.3",
+    "typescript": "7.0.2",
     "vite": "6.4.2",
     "vitest": "3.2.4"
   }

--- a/apps/desktop-tauri/pnpm-lock.yaml
+++ b/apps/desktop-tauri/pnpm-lock.yaml
@@ -33,6 +33,9 @@ importers:
       '@types/react-dom':
         specifier: 18.3.1
         version: 18.3.1
+      '@typescript/typescript-win32-x64':
+        specifier: 7.0.2
+        version: 7.0.2
       '@vitejs/plugin-react':
         specifier: 4.7.0
         version: 4.7.0(vite@6.4.2)
@@ -40,8 +43,8 @@ importers:
         specifier: 25.0.1
         version: 25.0.1
       typescript:
-        specifier: 5.6.3
-        version: 5.6.3
+        specifier: 7.0.2
+        version: 7.0.2
       vite:
         specifier: 6.4.2
         version: 6.4.2
@@ -620,6 +623,12 @@ packages:
   '@types/react@18.3.12':
     resolution: {integrity: sha512-D2wOSq/d6Agt28q7rSI3jhU7G6aiuzljDGZ2hTZHIkrTLUI+AF3WMeKkEZ9nN2fkBAlcktT6vcZjDFiIhMYEQw==}
 
+  '@typescript/typescript-win32-x64@7.0.2':
+    resolution: {integrity: sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [win32]
+
   '@vitejs/plugin-react@4.7.0':
     resolution: {integrity: sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==}
     engines: {node: ^14.18.0 || >=16.0.0}
@@ -1110,9 +1119,9 @@ packages:
     resolution: {integrity: sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==}
     engines: {node: '>=18'}
 
-  typescript@5.6.3:
-    resolution: {integrity: sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==}
-    engines: {node: '>=14.17'}
+  typescript@7.0.2:
+    resolution: {integrity: sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==}
+    engines: {node: '>=16.20.0'}
     hasBin: true
 
   update-browserslist-db@1.2.3:
@@ -1685,6 +1694,8 @@ snapshots:
       '@types/prop-types': 15.7.15
       csstype: 3.2.3
 
+  '@typescript/typescript-win32-x64@7.0.2': {}
+
   '@vitejs/plugin-react@4.7.0(vite@6.4.2)':
     dependencies:
       '@babel/core': 7.29.0
@@ -2191,7 +2202,9 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
-  typescript@5.6.3: {}
+  typescript@7.0.2:
+    optionalDependencies:
+      '@typescript/typescript-win32-x64': 7.0.2
 
   update-browserslist-db@1.2.3(browserslist@4.28.2):
     dependencies:


### PR DESCRIPTION
## Summary
- Upgrade the desktop frontend TypeScript package to 7.0.2.
- Add TypeScript 7's Windows x64 binary package required for `tsc` to run under pnpm on Windows.
- Update the desktop pnpm lockfile only.

## Checks
- `pnpm.cmd exec tsc --noEmit` — passed
- `pnpm.cmd test` — passed: 29 files, 135 tests
- `pnpm.cmd run check-locale` — passed: 553 locale keys match