### PR TITLE
Fix Cursor dashboard link to use /dashboard/usage

### DIFF
--- a/rust/src/providers/cursor/mod.rs
+++ b/rust/src/providers/cursor/mod.rs
@@ -31,7 +31,7 @@ impl CursorProvider {
                 supports_credits: true,
                 default_enabled: true,
                 is_primary: false,
-                dashboard_url: Some("https://cursor.com/settings/usage"),
+                dashboard_url: Some("https://cursor.com/dashboard/usage"),
                 status_page_url: None,
             },
             api: CursorApi::new(),


### PR DESCRIPTION
## Summary

Updates the Cursor provider `dashboard_url` from `https://cursor.com/settings/usage` to `https://cursor.com/dashboard/usage`. Cursor's usage page now lives under `/dashboard/usage`; the old `/settings/usage` path is incorrect.

## Related issue

None

## Affected areas

Check every area this PR changes or could affect:

- [ ] Tray panel
- [ ] Settings UI
- [ ] Config file / settings persistence
- [ ] CLI
- [x] Provider-specific behavior
- [ ] Installer / release packaging
- [ ] Startup / background behavior
- [ ] Documentation
- [ ] Other:

## Validation

There is no hosted CI right now. Run the relevant local checks and list the exact commands/results. If a check is not relevant, say why.

- [ ] `powershell.exe -ExecutionPolicy Bypass -NoProfile -File scripts\local-check.ps1` — not run; one-line provider metadata URL change only.
- [ ] For full pre-release validation: `powershell.exe -ExecutionPolicy Bypass -NoProfile -File scripts\local-check.ps1 -All -Version <version>` — not applicable.
- [ ] For installer/release changes: `powershell.exe -File scripts\windows-release-build.ps1 -Ref <ref> -SmokeInstall` — not applicable.
- [ ] Thermo-nuclear code quality review completed before submitting: https://github.com/cursor/plugins/blob/main/cursor-team-kit/skills/thermo-nuclear-code-quality-review/SKILL.md — not applicable for this trivial URL fix.
- [x] Other: change is a single static URL string in `rust/src/providers/cursor/mod.rs`; no logic changes.

## UI / tray proof

For UI, tray, settings, or visual behavior changes, use CUA Driver for visual proof. If CUA Driver cannot be used, explain why and attach equivalent manual proof.

- [x] Not applicable
- [ ] CUA Driver visual proof attached
- [ ] CUA Driver could not be used; equivalent manual proof and explanation attached

## Notes for reviewers

Upstream Interaction guard workflow failed due to a billing lock on the `Finesssee` account (job never started); not related to this change. Socket Security checks passed.