### PR TITLE
Fix side taskbar popup alignment

### DIFF
--- a/apps/desktop-tauri/src-tauri/src/shell/flyout_window.rs
+++ b/apps/desktop-tauri/src-tauri/src/shell/flyout_window.rs
@@ -298,6 +298,12 @@ pub fn reanchor(app: &AppHandle) -> Result<(), String> {
         width: monitor.work_area().size.width,
         height: monitor.work_area().size.height,
     };
+    let monitor_bounds = Rect {
+        x: monitor.position().x,
+        y: monitor.position().y,
+        width: monitor.size().width,
+        height: monitor.size().height,
+    };
 
     let (x, y) = {
         let st = app.try_state::<Mutex<AppState>>();
@@ -310,6 +316,7 @@ pub fn reanchor(app: &AppHandle) -> Result<(), String> {
                     width: a.width,
                     height: a.height,
                 },
+                &monitor_bounds,
                 &work_area,
                 &panel_size,
                 scale,

--- a/apps/desktop-tauri/src-tauri/src/shell/flyout_window.rs
+++ b/apps/desktop-tauri/src-tauri/src/shell/flyout_window.rs
@@ -71,6 +71,8 @@ pub fn open_or_focus(app: &AppHandle, position: Option<(i32, i32)>) -> Result<()
     if let Some(window) = app.get_webview_window(FLYOUT_LABEL) {
         if let Some((x, y)) = position {
             let _ = window.set_position(PhysicalPosition::new(x, y));
+        } else {
+            reanchor(app)?;
         }
         window.show().map_err(|e| e.to_string())?;
         window.set_focus().map_err(|e| e.to_string())?;
@@ -285,19 +287,18 @@ pub fn reanchor(app: &AppHandle) -> Result<(), String> {
         height: (outer.height as f64 / scale).round() as u32,
     };
 
-    let monitor = window
-        .primary_monitor()
-        .ok()
-        .flatten()
+    let anchor = app
+        .try_state::<Mutex<AppState>>()
+        .and_then(|state| state.lock().ok()?.tray_anchor);
+    let monitors = window.available_monitors().unwrap_or_default();
+    let monitor = anchor
+        .and_then(|anchor| crate::shell::geometry::monitor_for_anchor(&monitors, anchor))
+        .cloned()
         .or_else(|| window.current_monitor().ok().flatten())
+        .or_else(|| window.primary_monitor().ok().flatten())
         .ok_or_else(|| "no monitor".to_string())?;
 
-    let work_area = Rect {
-        x: monitor.work_area().position.x,
-        y: monitor.work_area().position.y,
-        width: monitor.work_area().size.width,
-        height: monitor.work_area().size.height,
-    };
+    let work_area = crate::shell::geometry::monitor_work_area_rect(&monitor);
     let monitor_bounds = Rect {
         x: monitor.position().x,
         y: monitor.position().y,
@@ -306,8 +307,6 @@ pub fn reanchor(app: &AppHandle) -> Result<(), String> {
     };
 
     let (x, y) = {
-        let st = app.try_state::<Mutex<AppState>>();
-        let anchor = st.and_then(|s| s.lock().ok()?.tray_anchor);
         if let Some(a) = anchor {
             crate::window_positioner::calculate_panel_position(
                 &Rect {

--- a/apps/desktop-tauri/src-tauri/src/shell/geometry.rs
+++ b/apps/desktop-tauri/src-tauri/src/shell/geometry.rs
@@ -25,6 +25,24 @@ pub(super) fn tray_panel_size() -> PanelSize {
 }
 
 pub(super) fn monitor_work_area_rect(monitor: &tauri::Monitor) -> Rect {
+    let position = monitor.position();
+    let size = monitor.size();
+    if let Some(area) = codexbar::host::session::primary_work_area_pixels()
+        && area.width > 0
+        && area.height > 0
+        && area.x >= position.x
+        && area.y >= position.y
+        && area.x + area.width <= position.x + size.width as i32
+        && area.y + area.height <= position.y + size.height as i32
+    {
+        return Rect {
+            x: area.x,
+            y: area.y,
+            width: area.width as u32,
+            height: area.height as u32,
+        };
+    }
+
     let work_area = monitor.work_area();
     Rect {
         x: work_area.position.x,

--- a/apps/desktop-tauri/src-tauri/src/shell/geometry.rs
+++ b/apps/desktop-tauri/src-tauri/src/shell/geometry.rs
@@ -122,6 +122,7 @@ pub(super) fn inferred_tray_panel_position_for_monitor_size(
 ) -> (i32, i32) {
     window_positioner::calculate_panel_position(
         &inferred_tray_anchor_rect(monitor),
+        &monitor.bounds,
         &monitor.work_area,
         panel_size,
         monitor.scale_factor,

--- a/apps/desktop-tauri/src-tauri/src/shell/position.rs
+++ b/apps/desktop-tauri/src-tauri/src/shell/position.rs
@@ -279,13 +279,14 @@ pub fn tray_panel_position(app: &AppHandle) -> Option<(i32, i32)> {
     let monitors = window.available_monitors().ok()?;
 
     let monitor = monitor_for_anchor(&monitors, anchor)?;
-    let scale = monitor.scale_factor();
+    let placement = monitor_placement(monitor);
 
     Some(window_positioner::calculate_panel_position(
         &tray_anchor_rect(anchor),
-        &monitor_work_area_rect(monitor),
+        &placement.bounds,
+        &placement.work_area,
         &tray_panel_size(),
-        scale,
+        placement.scale_factor,
     ))
 }
 

--- a/apps/desktop-tauri/src-tauri/src/shell/tests.rs
+++ b/apps/desktop-tauri/src-tauri/src/shell/tests.rs
@@ -1,7 +1,7 @@
 use super::ShellTransitionRequest;
 use super::geometry::{
     MonitorPlacement, inferred_tray_anchor_rect, inferred_tray_panel_position_for_monitor,
-    inferred_tray_panel_position_for_monitor_size, surface_panel_size, tray_anchor_rect,
+    surface_panel_size, tray_anchor_rect,
 };
 use super::position::{
     remembered_panel_size, remembered_surface_position_with_monitors,
@@ -21,7 +21,7 @@ use super::window::{
 use crate::state::AppState;
 use crate::surface::{SurfaceMode, SurfaceTransition};
 use crate::surface_target::SurfaceTarget;
-use crate::window_positioner::{self, PanelSize, Rect};
+use crate::window_positioner::{self, Rect};
 
 #[test]
 fn hide_to_tray_resets_hidden_target_to_summary() {
@@ -744,60 +744,6 @@ fn inferred_tray_panel_position_uses_tray_style_corner_fallback() {
             monitor.scale_factor,
         )
     );
-}
-
-#[test]
-fn inferred_tray_panel_position_supports_left_taskbar_layouts() {
-    let monitor = MonitorPlacement {
-        bounds: Rect {
-            x: 0,
-            y: 0,
-            width: 1920,
-            height: 1080,
-        },
-        work_area: Rect {
-            x: 40,
-            y: 0,
-            width: 1880,
-            height: 1080,
-        },
-        scale_factor: 1.0,
-    };
-
-    let panel_size = PanelSize {
-        width: 420,
-        height: 560,
-    };
-    let position = inferred_tray_panel_position_for_monitor_size(&monitor, &panel_size);
-
-    assert_eq!(position.1, 1080 - 560 - 8);
-}
-
-#[test]
-fn inferred_tray_panel_position_bottom_aligns_for_high_dpi_right_taskbar() {
-    let monitor = MonitorPlacement {
-        bounds: Rect {
-            x: 0,
-            y: 0,
-            width: 3840,
-            height: 2160,
-        },
-        work_area: Rect {
-            x: 0,
-            y: 0,
-            width: 3760,
-            height: 2160,
-        },
-        scale_factor: 2.0,
-    };
-
-    let panel_size = PanelSize {
-        width: 420,
-        height: 560,
-    };
-    let position = inferred_tray_panel_position_for_monitor_size(&monitor, &panel_size);
-
-    assert_eq!(position.1, 2160 - (560 * 2) - 8);
 }
 
 #[test]

--- a/apps/desktop-tauri/src-tauri/src/shell/tests.rs
+++ b/apps/desktop-tauri/src-tauri/src/shell/tests.rs
@@ -1,7 +1,7 @@
 use super::ShellTransitionRequest;
 use super::geometry::{
     MonitorPlacement, inferred_tray_anchor_rect, inferred_tray_panel_position_for_monitor,
-    surface_panel_size, tray_anchor_rect,
+    inferred_tray_panel_position_for_monitor_size, surface_panel_size, tray_anchor_rect,
 };
 use super::position::{
     remembered_panel_size, remembered_surface_position_with_monitors,
@@ -21,7 +21,7 @@ use super::window::{
 use crate::state::AppState;
 use crate::surface::{SurfaceMode, SurfaceTransition};
 use crate::surface_target::SurfaceTarget;
-use crate::window_positioner::{self, Rect};
+use crate::window_positioner::{self, PanelSize, Rect};
 
 #[test]
 fn hide_to_tray_resets_hidden_target_to_summary() {
@@ -738,6 +738,7 @@ fn inferred_tray_panel_position_uses_tray_style_corner_fallback() {
                 width: 24,
                 height: 24,
             },
+            &monitor.bounds,
             &monitor.work_area,
             &super::geometry::tray_panel_size(),
             monitor.scale_factor,
@@ -763,22 +764,40 @@ fn inferred_tray_panel_position_supports_left_taskbar_layouts() {
         scale_factor: 1.0,
     };
 
-    let position = inferred_tray_panel_position_for_monitor(&monitor);
+    let panel_size = PanelSize {
+        width: 420,
+        height: 560,
+    };
+    let position = inferred_tray_panel_position_for_monitor_size(&monitor, &panel_size);
 
-    assert_eq!(
-        position,
-        window_positioner::calculate_panel_position(
-            &Rect {
-                x: 8,
-                y: 1048,
-                width: 24,
-                height: 24,
-            },
-            &monitor.work_area,
-            &super::geometry::tray_panel_size(),
-            monitor.scale_factor,
-        )
-    );
+    assert_eq!(position.1, 1080 - 560 - 8);
+}
+
+#[test]
+fn inferred_tray_panel_position_bottom_aligns_for_high_dpi_right_taskbar() {
+    let monitor = MonitorPlacement {
+        bounds: Rect {
+            x: 0,
+            y: 0,
+            width: 3840,
+            height: 2160,
+        },
+        work_area: Rect {
+            x: 0,
+            y: 0,
+            width: 3760,
+            height: 2160,
+        },
+        scale_factor: 2.0,
+    };
+
+    let panel_size = PanelSize {
+        width: 420,
+        height: 560,
+    };
+    let position = inferred_tray_panel_position_for_monitor_size(&monitor, &panel_size);
+
+    assert_eq!(position.1, 2160 - (560 * 2) - 8);
 }
 
 #[test]

--- a/apps/desktop-tauri/src-tauri/src/window_positioner.rs
+++ b/apps/desktop-tauri/src-tauri/src/window_positioner.rs
@@ -83,16 +83,18 @@ pub fn clamp_position_to_work_area(
 ///
 /// Placement rules:
 /// - Horizontally centered on the icon, clamped to the monitor work area.
+/// - Left/right taskbars bottom-align the panel to the work area.
 /// - If the icon is in the bottom half of the monitor (bottom taskbar), the
 ///   panel opens *above* the icon. Otherwise it opens *below*.
 pub fn calculate_panel_position(
     icon_rect: &Rect,
-    monitor_rect: &Rect,
+    monitor_bounds: &Rect,
+    work_area: &Rect,
     panel_size: &PanelSize,
     scale_factor: f64,
 ) -> (i32, i32) {
-    let my = monitor_rect.y;
-    let mh = monitor_rect.height as i32;
+    let my = work_area.y;
+    let mh = work_area.height as i32;
 
     let icon_cy = icon_rect.y + (icon_rect.height as i32) / 2;
     let monitor_cy = my + mh / 2;
@@ -104,14 +106,26 @@ pub fn calculate_panel_position(
         icon_rect.y + icon_rect.height as i32
     };
 
-    calculate_anchored_position(
+    let position = calculate_anchored_position(
         icon_rect,
-        monitor_rect,
+        work_area,
         panel_size,
         scale_factor,
         anchor_y,
         open_above,
-    )
+    );
+    let bounds_right = monitor_bounds.x + monitor_bounds.width as i32;
+    let work_right = work_area.x + work_area.width as i32;
+
+    if work_area.x > monitor_bounds.x || work_right < bounds_right {
+        let (_, ph) = physical_panel_size(panel_size, scale_factor);
+        (
+            position.0,
+            work_area.y + work_area.height as i32 - ph - MARGIN,
+        )
+    } else {
+        position
+    }
 }
 
 /// Position for shortcut-triggered opening: 22 % from left, vertically centred.
@@ -222,7 +236,8 @@ mod tests {
             width: 24,
             height: 24,
         };
-        let (_, y) = calculate_panel_position(&icon, &hd_monitor(), &panel(), 1.0);
+        let monitor = hd_monitor();
+        let (_, y) = calculate_panel_position(&icon, &monitor, &monitor, &panel(), 1.0);
         assert!(y < icon.y, "panel should sit above the icon");
     }
 
@@ -234,7 +249,8 @@ mod tests {
             width: 24,
             height: 24,
         };
-        let (_, y) = calculate_panel_position(&icon, &hd_monitor(), &panel(), 1.0);
+        let monitor = hd_monitor();
+        let (_, y) = calculate_panel_position(&icon, &monitor, &monitor, &panel(), 1.0);
         assert!(
             y >= icon.y + icon.height as i32,
             "panel should sit below the icon"
@@ -249,7 +265,8 @@ mod tests {
             width: 24,
             height: 24,
         };
-        let (x, _) = calculate_panel_position(&icon, &hd_monitor(), &panel(), 1.0);
+        let monitor = hd_monitor();
+        let (x, _) = calculate_panel_position(&icon, &monitor, &monitor, &panel(), 1.0);
         let icon_cx = icon.x + 12;
         let panel_cx = x + 210;
         assert!(
@@ -267,7 +284,8 @@ mod tests {
             width: 24,
             height: 24,
         };
-        let (x, _) = calculate_panel_position(&icon, &hd_monitor(), &panel(), 1.0);
+        let monitor = hd_monitor();
+        let (x, _) = calculate_panel_position(&icon, &monitor, &monitor, &panel(), 1.0);
         assert!(x >= MARGIN, "panel must not exceed left margin");
     }
 
@@ -279,7 +297,8 @@ mod tests {
             width: 24,
             height: 24,
         };
-        let (x, _) = calculate_panel_position(&icon, &hd_monitor(), &panel(), 1.0);
+        let monitor = hd_monitor();
+        let (x, _) = calculate_panel_position(&icon, &monitor, &monitor, &panel(), 1.0);
         assert!(
             x + panel().width as i32 + MARGIN <= 1920,
             "panel must not exceed right margin"
@@ -294,7 +313,8 @@ mod tests {
             width: 24,
             height: 24,
         };
-        let (_, y) = calculate_panel_position(&icon, &hd_monitor(), &panel(), 1.0);
+        let monitor = hd_monitor();
+        let (_, y) = calculate_panel_position(&icon, &monitor, &monitor, &panel(), 1.0);
         assert!(y >= MARGIN, "panel must not exceed top margin");
     }
 
@@ -312,7 +332,8 @@ mod tests {
             width: 24,
             height: 24,
         };
-        let (_, y) = calculate_panel_position(&icon, &work_area, &panel(), 1.0);
+        let monitor = hd_monitor();
+        let (_, y) = calculate_panel_position(&icon, &monitor, &work_area, &panel(), 1.0);
         assert_eq!(y, work_area.y + MARGIN);
     }
 
@@ -330,7 +351,7 @@ mod tests {
             width: 24,
             height: 24,
         };
-        let (x, _) = calculate_panel_position(&icon, &monitor, &panel(), 1.0);
+        let (x, _) = calculate_panel_position(&icon, &monitor, &monitor, &panel(), 1.0);
         assert!(x >= monitor.x + MARGIN);
         assert!(x + panel().width as i32 + MARGIN <= monitor.x + monitor.width as i32);
     }
@@ -343,8 +364,9 @@ mod tests {
             width: 24,
             height: 24,
         };
-        let (x1, y1) = calculate_panel_position(&icon, &hd_monitor(), &panel(), 1.0);
-        let (x2, y2) = calculate_panel_position(&icon, &hd_monitor(), &panel(), 2.0);
+        let monitor = hd_monitor();
+        let (x1, y1) = calculate_panel_position(&icon, &monitor, &monitor, &panel(), 1.0);
+        let (x2, y2) = calculate_panel_position(&icon, &monitor, &monitor, &panel(), 2.0);
         assert!(
             x2 < x1,
             "higher scale should shift the panel left to fit its physical width"
@@ -410,7 +432,8 @@ mod tests {
             height: 24,
         };
 
-        let (panel_x, _) = calculate_panel_position(&icon, &standard_monitor(), &panel(), 1.0);
+        let monitor = standard_monitor();
+        let (panel_x, _) = calculate_panel_position(&icon, &monitor, &monitor, &panel(), 1.0);
         let (popout_x, _) =
             calculate_popout_position(Some(&icon), &standard_monitor(), &panel(), 1.0);
 

--- a/apps/desktop-tauri/src-tauri/src/window_positioner.rs
+++ b/apps/desktop-tauri/src-tauri/src/window_positioner.rs
@@ -338,6 +338,53 @@ mod tests {
     }
 
     #[test]
+    fn left_taskbar_bottom_aligns_panel() {
+        let monitor = hd_monitor();
+        let work_area = Rect {
+            x: 40,
+            y: 0,
+            width: 1880,
+            height: 1080,
+        };
+        let icon = Rect {
+            x: 8,
+            y: 1048,
+            width: 24,
+            height: 24,
+        };
+
+        let (_, y) = calculate_panel_position(&icon, &monitor, &work_area, &panel(), 1.0);
+
+        assert_eq!(y, 1080 - 560 - MARGIN);
+    }
+
+    #[test]
+    fn high_dpi_right_taskbar_bottom_aligns_panel() {
+        let monitor = Rect {
+            x: 0,
+            y: 0,
+            width: 3840,
+            height: 2160,
+        };
+        let work_area = Rect {
+            x: 0,
+            y: 0,
+            width: 3760,
+            height: 2160,
+        };
+        let icon = Rect {
+            x: 3808,
+            y: 2128,
+            width: 24,
+            height: 24,
+        };
+
+        let (_, y) = calculate_panel_position(&icon, &monitor, &work_area, &panel(), 2.0);
+
+        assert_eq!(y, 2160 - (560 * 2) - MARGIN);
+    }
+
+    #[test]
     fn multi_monitor_offset() {
         let monitor = Rect {
             x: 1920,


### PR DESCRIPTION
## Summary
- detect left/right taskbars from monitor bounds versus work area in the shared panel positioner
- reuse the existing Windows-native work-area probe when Tauri reports full monitor bounds
- bottom-align side-taskbar panels using the existing 8px work-area margin
- reanchor an existing flyout before showing it, preserving tray-anchor monitor selection
- preserve icon-relative positioning for top and bottom taskbars
- cover left-taskbar and high-DPI right-taskbar layouts

Fixes #158

## Validation
- `cargo test --manifest-path apps\desktop-tauri\src-tauri\Cargo.toml inferred_tray_panel_position` (3 passed)
- `cargo test --manifest-path apps\desktop-tauri\src-tauri\Cargo.toml --quiet` (299 passed)
- `cargo fmt --all -- --check`
- `git diff --check`
- `pnpm run tauri:build:debug`
- CUA Driver CLI on a live 1920x1080 Windows desktop with a left taskbar and work area `{ x: 124, y: 0, width: 1796, height: 1080 }`: popup measured `{ x: 1464, y: 392, width: 420, height: 680 }`; expected y is `1080 - 680 - 8 = 392`
- CUA screenshot captured as `issue-158-cua-final.png`
- `cargo clippy --manifest-path apps\desktop-tauri\src-tauri\Cargo.toml --all-targets -- -D warnings` remains blocked by pre-existing unused `tray_menu::build_tray_menu`