### PR TITLE
Make global shortcut toggle the tray flyout

### DIFF
--- a/apps/desktop-tauri/src-tauri/src/shortcut_bridge.rs
+++ b/apps/desktop-tauri/src-tauri/src/shortcut_bridge.rs
@@ -1,8 +1,8 @@
-//! Global keyboard shortcut registration for opening the primary window.
+//! Global keyboard shortcut registration for toggling the tray flyout.
 //!
 //! Reads the persisted `global_shortcut` setting (e.g. `"Ctrl+Shift+U"`)
 //! and registers it through the Tauri global-shortcut plugin. The shortcut
-//! opens/focuses the native PopOut dashboard via the surface state machine.
+//! toggles the dedicated tray flyout, matching a left-click on the tray icon.
 
 use tauri::AppHandle;
 use tauri_plugin_global_shortcut::{Code, GlobalShortcutExt, Modifiers, Shortcut, ShortcutState};
@@ -104,17 +104,12 @@ fn parse_key(token: &str) -> Option<Code> {
         .find_map(|(alias, code)| (*alias == normalized).then_some(*code))
 }
 
-/// Build the Tauri global-shortcut plugin with the primary-window handler.
+/// Build the Tauri global-shortcut plugin with the tray-flyout handler.
 pub fn plugin() -> tauri::plugin::TauriPlugin<tauri::Wry> {
     tauri_plugin_global_shortcut::Builder::new()
         .with_handler(|app, _shortcut, event| {
             if event.state == ShortcutState::Pressed {
-                let _ = shell::reopen_to_target(
-                    app,
-                    crate::surface::SurfaceMode::PopOut,
-                    crate::surface_target::SurfaceTarget::Dashboard,
-                    None,
-                );
+                shell::flyout_window::toggle_with_blur_consume(app, None);
             }
         })
         .build()


### PR DESCRIPTION
## Summary

Change the global shortcut so it performs the same action as a left-click on the tray icon: toggle the dedicated tray flyout instead of reopening the full PopOut dashboard.

This keeps the full window available through **Show Window** while making the shortcut behavior consistent with the tray-first workflow.

Fixes #184

## Affected areas

- [x] Tray panel
- [ ] Settings UI
- [ ] Config file / settings persistence
- [ ] CLI
- [ ] Provider-specific behavior
- [ ] Installer / release packaging
- [x] Startup / background behavior
- [ ] Documentation
- [ ] Other: Global shortcut handler

## Validation

- [ ] `powershell.exe -ExecutionPolicy Bypass -NoProfile -File scripts\local-check.ps1`
- [ ] Thermo-nuclear code quality review completed before submitting
- [x] Diff reviewed: the shortcut handler now calls the same `toggle_with_blur_consume` path as the tray-icon left-click.

Local Windows runtime validation was not available in this environment.

## UI / tray proof

- [ ] Not applicable
- [ ] CUA Driver visual proof attached
- [x] CUA Driver could not be used; manual validation is required on Windows.

## Notes for reviewers

The change is limited to `shortcut_bridge.rs`: it updates the handler and its comments. Please verify first press opens the flyout, second press closes it, click-outside dismissal remains unchanged, and **Show Window** still opens the full dashboard.