### PR TITLE
Drop regional suffix from Traditional Chinese label

### DIFF
--- a/apps/desktop-tauri/src-tauri/src/commands/locale_cmd.rs
+++ b/apps/desktop-tauri/src-tauri/src/commands/locale_cmd.rs
@@ -183,14 +183,7 @@ mod locale_tests {
         );
         assert_eq!(
             displays,
-            vec![
-                "English",
-                "中文",
-                "繁體中文（臺灣）",
-                "日本語",
-                "한국어",
-                "Español"
-            ]
+            vec!["English", "中文", "繁體中文", "日本語", "한국어", "Español"]
         );
     }
 

--- a/apps/desktop-tauri/src/surfaces/settings/tabs/GeneralTab.test.tsx
+++ b/apps/desktop-tauri/src/surfaces/settings/tabs/GeneralTab.test.tsx
@@ -10,7 +10,7 @@ vi.mock("@tauri-apps/api/core", () => ({
   invoke: vi.fn().mockResolvedValue([
     { value: "english", display: "English" },
     { value: "chinese", display: "中文" },
-    { value: "chinesetraditional", display: "繁體中文（臺灣）" },
+    { value: "chinesetraditional", display: "繁體中文" },
     { value: "japanese", display: "日本語" },
     { value: "korean", display: "한국어" },
     { value: "spanish", display: "Español" },
@@ -99,7 +99,7 @@ describe("GeneralTab language picker", () => {
   it("includes Traditional Chinese as a selectable option", () => {
     render(<GeneralTab settings={settings} set={vi.fn()} saving={false} />);
 
-    expect(screen.getByText("繁體中文（臺灣）")).toBeInTheDocument();
+    expect(screen.getByText("繁體中文")).toBeInTheDocument();
   });
 
   it("updates the predictive pace warning preference", () => {

--- a/apps/desktop-tauri/src/surfaces/settings/tabs/GeneralTab.tsx
+++ b/apps/desktop-tauri/src/surfaces/settings/tabs/GeneralTab.tsx
@@ -9,7 +9,7 @@ import type { TabProps } from "../../Settings";
 const FALLBACK_LANGUAGE_OPTIONS: LanguageOption[] = [
   { value: "english", display: "English" },
   { value: "chinese", display: "中文" },
-  { value: "chinesetraditional", display: "繁體中文（臺灣）" },
+  { value: "chinesetraditional", display: "繁體中文" },
   { value: "japanese", display: "日本語" },
   { value: "korean", display: "한국어" },
   { value: "spanish", display: "Español" },

--- a/rust/src/settings/tests.rs
+++ b/rust/src/settings/tests.rs
@@ -536,10 +536,7 @@ fn test_language_all_variants_available() {
 fn test_language_display_names() {
     assert_eq!(Language::English.display_name(), "English");
     assert_eq!(Language::Chinese.display_name(), "中文");
-    assert_eq!(
-        Language::ChineseTraditional.display_name(),
-        "繁體中文（臺灣）"
-    );
+    assert_eq!(Language::ChineseTraditional.display_name(), "繁體中文");
     assert_eq!(Language::Japanese.display_name(), "日本語");
 }
 

--- a/rust/src/settings/types.rs
+++ b/rust/src/settings/types.rs
@@ -80,7 +80,7 @@ impl Language {
         match self {
             Language::English => "English",
             Language::Chinese => "中文",
-            Language::ChineseTraditional => "繁體中文（臺灣）",
+            Language::ChineseTraditional => "繁體中文",
             Language::Japanese => "日本語",
             Language::Korean => "한국어",
             Language::Spanish => "Español",


### PR DESCRIPTION
## Summary
The Traditional Chinese option in the language picker was labeled `繁體中文（臺灣）`. This drops the `（臺灣）` regional suffix so the label reads simply `繁體中文`.

## Why
Traditional Chinese is not specific to Taiwan. It is the standard written script in **Hong Kong** and **Macau** as well, and `zh-Hant` (the BCP-47 tag this language maps to) is script-based rather than region-based. Tying the label to a single region is misleading for users in HK/Macau. The bare `繁體中文` matches how most cross-region Chinese software labels this option (e.g. macOS, iOS, Google products).

## What changed
- \`rust/src/settings/types.rs\`: \`display_name()\` returns \`"繁體中文"\`.
- \`GeneralTab.tsx\`: fallback \`LanguageOption\` display updated to match.
- Matching test assertions in \`settings/tests.rs\`, \`locale_cmd.rs\`, and \`GeneralTab.test.tsx\`.

The \`value\` (\`"chinesetraditional"\`), the \`zh-tw\`/\`zh-hant\` aliases in \`parse_locale_language\`, and the \`.ftl\` filename are all unchanged — only the user-facing label.

## Verification
\`\`\`
cargo test --manifest-path rust/Cargo.toml settings::tests
pnpm --dir apps/desktop-tauri test
cargo fmt --all
\`\`\`